### PR TITLE
V0.1.3/m1/foundation scaffold

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,4 @@
+// Adapter registrations live here as side-effect imports.
+// Branch 2 (`v0.1.3/m1/claude-code-refactor`) will add:
+//   import './adapters/claude-code.js';
+// Subsequent milestones add Cursor, Windsurf, CLI-wrap, browser adapters.

--- a/src/agents/registry.test.ts
+++ b/src/agents/registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { AgentAdapter, InstallContext } from './types.js';
+
+/**
+ * Unit tests for the adapter registry.
+ *
+ * The registry stores adapters in a module-local mutable array, so tests would
+ * leak state into each other if we re-used the same module instance. Each test
+ * calls `vi.resetModules()` and re-imports `./registry.js` so it gets a fresh,
+ * empty registry.
+ */
+describe('agents/registry', () => {
+  let registerAdapter: typeof import('./registry.js')['registerAdapter'];
+  let detectAll: typeof import('./registry.js')['detectAll'];
+  let getAdapter: typeof import('./registry.js')['getAdapter'];
+
+  const dummyCtx: InstallContext = {
+    home: '/fake/home',
+    cwd: '/fake/cwd',
+    yes: true,
+    dbPath: ':memory:',
+  };
+
+  const makeAdapter = (id: string, detectResult: boolean): AgentAdapter => ({
+    id,
+    label: `Label-${id}`,
+    category: 'hook',
+    detect: () => detectResult,
+    install: async () => ({ status: 'installed' }),
+    uninstall: async () => {},
+  });
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const reg = await import('./registry.js');
+    registerAdapter = reg.registerAdapter;
+    detectAll = reg.detectAll;
+    getAdapter = reg.getAdapter;
+  });
+
+  describe('registerAdapter + getAdapter', () => {
+    it('registers an adapter and retrieves it by id', () => {
+      const a = makeAdapter('cursor', true);
+      registerAdapter(a);
+      expect(getAdapter('cursor')).toBe(a);
+    });
+
+    it('returns undefined for an unknown id', () => {
+      registerAdapter(makeAdapter('cursor', true));
+      expect(getAdapter('nonexistent')).toBeUndefined();
+    });
+
+    it('returns undefined when no adapters are registered', () => {
+      expect(getAdapter('any')).toBeUndefined();
+    });
+
+    it('supports multiple registrations and finds each by its id', () => {
+      const a = makeAdapter('a', true);
+      const b = makeAdapter('b', true);
+      registerAdapter(a);
+      registerAdapter(b);
+      expect(getAdapter('a')).toBe(a);
+      expect(getAdapter('b')).toBe(b);
+    });
+  });
+
+  describe('detectAll', () => {
+    it('returns an empty list when no adapters are registered', async () => {
+      const result = await detectAll(dummyCtx);
+      expect(result).toEqual([]);
+    });
+
+    it('returns only adapters whose detect() returns true', async () => {
+      const yes = makeAdapter('yes', true);
+      const no = makeAdapter('no', false);
+      registerAdapter(yes);
+      registerAdapter(no);
+      const result = await detectAll(dummyCtx);
+      expect(result).toEqual([yes]);
+    });
+
+    it('supports async detect() returning a Promise', async () => {
+      const yesAsync: AgentAdapter = {
+        ...makeAdapter('async-yes', true),
+        detect: async () => true,
+      };
+      const noAsync: AgentAdapter = {
+        ...makeAdapter('async-no', false),
+        detect: async () => false,
+      };
+      registerAdapter(yesAsync);
+      registerAdapter(noAsync);
+      const result = await detectAll(dummyCtx);
+      expect(result.map((x) => x.id)).toEqual(['async-yes']);
+    });
+
+    it('preserves insertion order across multiple detected adapters', async () => {
+      registerAdapter(makeAdapter('a', true));
+      registerAdapter(makeAdapter('b', true));
+      registerAdapter(makeAdapter('c', true));
+      const result = await detectAll(dummyCtx);
+      expect(result.map((x) => x.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('passes the InstallContext through to each adapter.detect()', async () => {
+      const detectSpy = vi.fn(() => true);
+      const adapter: AgentAdapter = {
+        ...makeAdapter('spy', true),
+        detect: detectSpy,
+      };
+      registerAdapter(adapter);
+      await detectAll(dummyCtx);
+      expect(detectSpy).toHaveBeenCalledWith(dummyCtx);
+      expect(detectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips false-detecting adapters while keeping true-detecting ones, regardless of registration order', async () => {
+      registerAdapter(makeAdapter('first-no', false));
+      registerAdapter(makeAdapter('second-yes', true));
+      registerAdapter(makeAdapter('third-no', false));
+      registerAdapter(makeAdapter('fourth-yes', true));
+      const result = await detectAll(dummyCtx);
+      expect(result.map((x) => x.id)).toEqual(['second-yes', 'fourth-yes']);
+    });
+  });
+});

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,0 +1,24 @@
+import type { AgentAdapter, InstallContext } from './types.js';
+
+/**
+ * Module-local mutable list. Adapters register themselves at module import time
+ * via side-effect imports in ./index.ts. This file does not import any adapter
+ * directly — that keeps the registry decoupled from individual adapter modules.
+ */
+const adapters: AgentAdapter[] = [];
+
+export function registerAdapter(a: AgentAdapter): void {
+  adapters.push(a);
+}
+
+export async function detectAll(ctx: InstallContext): Promise<AgentAdapter[]> {
+  const present: AgentAdapter[] = [];
+  for (const a of adapters) {
+    if (await a.detect(ctx)) present.push(a);
+  }
+  return present;
+}
+
+export function getAdapter(id: string): AgentAdapter | undefined {
+  return adapters.find((a) => a.id === id);
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Adapter interface contract for the coding-agent hooking module (Layer B of the
+ * three-layer architecture). Every coding agent surface (Claude Code, Cursor,
+ * Windsurf, Codex CLI, Aider, Replit, Bolt.new, Lovable, ChatGPT) is wired into
+ * nexpath through one of these four adapter categories.
+ *
+ * See: lib/share/submodule/reviewduel-submodule/docs/architecture/coding-agent-hooks-architecture.md
+ */
+
+export type AdapterCategory =
+  | 'hook'
+  | 'vscode-extension'
+  | 'cli-wrap'
+  | 'browser-extension';
+
+export interface InstallContext {
+  home: string;
+  cwd: string;
+  /** Skip confirmation prompts. */
+  yes: boolean;
+  /** Path to ~/.nexpath/prompt-store.db (or ':memory:' for tests). */
+  dbPath: string;
+}
+
+export interface InstallResult {
+  status: 'installed' | 'already-installed' | 'skipped' | 'failed';
+  notes?: string;
+}
+
+export interface AgentAdapter {
+  /** Stable identifier, e.g. 'claude-code', 'cursor', 'replit'. */
+  id: string;
+  label: string;
+  category: AdapterCategory;
+
+  /** Returns true if this agent appears to be present on the current system. */
+  detect(ctx: InstallContext): Promise<boolean> | boolean;
+
+  /** Wire up the binding — write config, install extension, register shell alias, etc. */
+  install(ctx: InstallContext): Promise<InstallResult>;
+
+  /** Reverse of install. */
+  uninstall(ctx: InstallContext): Promise<void>;
+}
+
+/** Adapters that wire into agents with native lifecycle hooks (e.g. Claude Code). */
+export interface HookAdapter extends AgentAdapter {
+  category: 'hook';
+  /** Path to the agent's settings file that hosts hook entries. */
+  settingsPath(ctx: InstallContext): string;
+  /** Build the hook entries to merge into the agent's settings file. */
+  buildHooks(ctx: InstallContext): Record<string, Array<{ type: string; command: string }>>;
+}
+
+/** Adapters that ship a companion VS Code-format extension (e.g. Cursor, Windsurf). */
+export interface VSCodeExtensionAdapter extends AgentAdapter {
+  category: 'vscode-extension';
+  /** Marketplace identifiers. */
+  marketplace: { openVsx: string; vsCode?: string };
+  /** Per-OS chat-history paths the extension's file-watcher subscribes to. */
+  chatHistoryPaths(ctx: InstallContext): string[];
+  /** Schema-extractor — reads new rows out of the watched file. */
+  extractPrompt(rowKey: string, rowValue: unknown): { prompt: string; sessionId: string } | null;
+}
+
+/** Adapters that wrap a CLI binary (e.g. Codex CLI, Aider). */
+export interface CLIWrapAdapter extends AgentAdapter {
+  category: 'cli-wrap';
+  /** The original binary name, e.g. 'codex', 'aider'. */
+  realBinary: string;
+  /** Strategy: 'shell-alias' or 'node-proxy'. */
+  strategy: 'shell-alias' | 'node-proxy';
+  /** For node-proxy: heuristic that detects an agent response boundary in stdout. */
+  detectResponseEnd?(stdoutChunk: string): boolean;
+}
+
+/** Adapters that ship a browser extension content script (Replit, Bolt.new, Lovable, ChatGPT). */
+export interface BrowserExtensionAdapter extends AgentAdapter {
+  category: 'browser-extension';
+  /** Origins this content script runs against (Manifest V3 match patterns). */
+  origins: string[];
+  /** Capture strategy in priority order. */
+  capture: Array<'fetch' | 'websocket' | 'dom-events' | 'mutation-observer'>;
+  /** Inline content-script source to be bundled into the extension build. */
+  contentScriptModule: string;
+}

--- a/src/cli/commands/__snapshots__/install.snapshot.test.ts.snap
+++ b/src/cli/commands/__snapshots__/install.snapshot.test.ts.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`installAction snapshot (M1 zero-diff safety net) > writes the same settings.json bytes and stdout as the pre-refactor baseline 1`] = `
+{
+  "settingsContent": "{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "_nexpath_hook": true,
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \\"/fixture/nexpath/dist/cli/index.js\\" auto --db \\"$HOME/.nexpath/prompt-store.db\\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "_nexpath_hook": true,
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \\"/fixture/nexpath/dist/cli/index.js\\" stop --db \\"$HOME/.nexpath/prompt-store.db\\""
+          }
+        ]
+      }
+    ]
+  }
+}
+",
+  "stdout": "
+Before installing nexpath, a few things to know:
+  1. An OpenAI API key is required (OPENAI_API_KEY) for advisory generation
+  2. Prompts are stored locally at $HOME/.nexpath/prompt-store.db — nothing leaves your machine
+  3. To opt out at any time: press Ctrl+X during an advisory, or run nexpath uninstall
+
+Detected: Claude Code
+✓ Claude Code  — advisory hook written to $HOME/.claude/settings.json
+
+Restart your agents to activate nexpath-prompt-store.
+Note: advisory pipeline (nexpath auto) auto-wired for Claude Code only.
+Run: nexpath status  to verify connections.",
+}
+`;

--- a/src/cli/commands/install.snapshot.test.ts
+++ b/src/cli/commands/install.snapshot.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { installAction, resolveAgentPaths, type AgentPaths } from './install.js';
+
+/**
+ * Real $HOME captured at module load — DEFAULT_DB_PATH (resolved when store/db.ts
+ * was imported) bakes this in, so we normalise it out of the snapshot to keep
+ * the snapshot portable across machines.
+ */
+const REAL_HOME = homedir();
+
+/**
+ * Snapshot test — captures the current behaviour of installAction before any
+ * refactor begins. This is the safety net for Milestone M1 Branch 2's zero-diff
+ * guarantee: after the refactor merges, this snapshot MUST remain byte-identical.
+ *
+ * See dev plan §1.5 and §1.6 in the reviewduel-submodule docs.
+ */
+describe('installAction snapshot (M1 zero-diff safety net)', () => {
+  let tmpHome: string;
+  let originalArgv1: string;
+  let originalPlatform: NodeJS.Platform;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'nexpath-snapshot-'));
+    vi.stubEnv('HOME', tmpHome);
+
+    // Pin process.argv[1] so the hook command's resolved CLI path is deterministic.
+    originalArgv1 = process.argv[1];
+    process.argv[1] = '/fixture/nexpath/dist/cli/index.js';
+
+    // Pin process.platform to 'linux' so the disclosure modifier-key ("Ctrl+X"
+    // vs "Cmd+X" on macOS) is stable regardless of where the test runs.
+    originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv[1] = originalArgv1;
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    vi.unstubAllEnvs();
+    logSpy.mockRestore();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('writes the same settings.json bytes and stdout as the pre-refactor baseline', async () => {
+    // Controlled paths — no real user dirs touched, snapshot is fully portable.
+    const paths: AgentPaths = resolveAgentPaths(
+      tmpHome,
+      join(tmpHome, 'AppData', 'Roaming'),
+      join(tmpHome, 'cwd'),
+      'linux',
+    );
+
+    await installAction(
+      { yes: true },
+      {
+        isWin: false,
+        paths,
+        dbPath: ':memory:',
+        skipClipboardCheck: true,
+      },
+    );
+
+    const settingsPath = join(tmpHome, '.claude', 'settings.json');
+    const settingsContent = existsSync(settingsPath)
+      ? readFileSync(settingsPath, 'utf8')
+      : null;
+
+    const stdout = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+
+    // Normalise both the test-tmp home (resolved at install-time) and the real
+    // home (which DEFAULT_DB_PATH captured at module-import-time).
+    const normalise = (s: string | null): string | null =>
+      s === null
+        ? null
+        : s.replaceAll(tmpHome, '$HOME').replaceAll(REAL_HOME, '$HOME');
+
+    expect({
+      settingsContent: normalise(settingsContent),
+      stdout: normalise(stdout),
+    }).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Adds src/agents/: 4 adapter interfaces (HookAdapter, VSCodeExtensionAdapter, CLIWrapAdapter, BrowserExtensionAdapter), in-process registry (registerAdapter,
detectAll, getAdapter), unit tests, and empty index.ts placeholder.
Adds install.snapshot.test.ts + generated baseline snapshot — captures current installAction output (settings.json bytes + stdout). M1 Branch 2 must keep this snapshot
byte-identical.
No existing source code is modified. Zero-diff verified.