### PR TITLE
V0.1.3/m2/webview UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 *.js.map
 *.d.ts.map
 .env
+src/ext-vscode/out/
+src/ext-vscode/node_modules/

--- a/src/ext-vscode/README.md
+++ b/src/ext-vscode/README.md
@@ -1,0 +1,31 @@
+# Nexpath VS Code Extension
+
+Companion extension that wires Cursor and Windsurf into the Nexpath prompt-guidance pipeline.
+
+This sub-package lives at `nexpath/src/ext-vscode/`. It builds independently of the main CLI (via esbuild) and ships to Open VSX + the VS Code Marketplace.
+
+## Status
+
+Milestone M2 Branch 1 (`v0.1.3/m2/extension-skeleton`) — skeleton + IPC stub + first-launch onboarding + activity-bar icon. Chat-history watcher (M2/M3), webview UI (M6–M8), and the Cursor/Windsurf adapters (M9/M10) land in subsequent branches.
+
+## Build
+
+```bash
+cd src/ext-vscode/
+npm install
+npm run build       # bundles src/extension.ts -> out/extension.js (CJS for VS Code host)
+npm run watch       # rebuild on save
+```
+
+## Test
+
+Unit tests live next to their source files (`*.test.ts`) and are picked up by the root repo's `npm test` (vitest). They mock the `vscode` module via `vi.mock('vscode', ...)`.
+
+## Module Layout
+
+| File | Module (per dev plan §3 M2 §2.2) |
+|---|---|
+| `package.json`, `tsconfig.json`, `esbuild.config.mjs`, `src/extension.ts` | M1 — skeleton |
+| `src/ipc.ts` | M5 — IPC to nexpath CLI |
+| `src/onboarding.ts` | M11 — first-launch consent + macOS Full-Disk-Access guidance |
+| `media/icon.svg` | M12 — activity-bar icon |

--- a/src/ext-vscode/esbuild.config.mjs
+++ b/src/ext-vscode/esbuild.config.mjs
@@ -1,0 +1,25 @@
+import { build, context } from 'esbuild';
+
+const watch = process.argv.includes('--watch');
+
+const config = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  outfile: 'out/extension.js',
+  platform: 'node',
+  target: 'node18',
+  format: 'cjs',
+  external: ['vscode'],
+  sourcemap: true,
+  minify: false,
+  logLevel: 'info',
+};
+
+if (watch) {
+  const ctx = await context(config);
+  await ctx.watch();
+  console.log('[esbuild] watching src/extension.ts...');
+} else {
+  await build(config);
+  console.log('[esbuild] built out/extension.js');
+}

--- a/src/ext-vscode/media/icon.svg
+++ b/src/ext-vscode/media/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 4 v8 m0 0 l-6 8 m6 -8 l6 8"/>
+  <circle cx="12" cy="4" r="2" fill="currentColor" stroke="none"/>
+  <circle cx="6" cy="20" r="2" fill="currentColor" stroke="none"/>
+  <circle cx="18" cy="20" r="2" fill="currentColor" stroke="none"/>
+</svg>

--- a/src/ext-vscode/package-lock.json
+++ b/src/ext-vscode/package-lock.json
@@ -1,0 +1,1473 @@
+{
+  "name": "nexpath-vscode",
+  "version": "0.1.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nexpath-vscode",
+      "version": "0.1.3",
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/vscode": "^1.80.0",
+        "esbuild": "^0.21",
+        "typescript": "^5",
+        "vitest": "^2"
+      },
+      "engines": {
+        "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/src/ext-vscode/package.json
+++ b/src/ext-vscode/package.json
@@ -27,16 +27,11 @@
       "nexpath": [
         {
           "id": "nexpath.status",
-          "name": "Nexpath"
+          "name": "Nexpath",
+          "type": "webview"
         }
       ]
-    },
-    "viewsWelcome": [
-      {
-        "view": "nexpath.status",
-        "contents": "Nexpath is active and watching for AI chat prompts.\n\nDecision sessions appear in this panel automatically when guidance is generated for a prompt — no manual action required."
-      }
-    ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run build",

--- a/src/ext-vscode/package.json
+++ b/src/ext-vscode/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "nexpath-vscode",
+  "displayName": "Nexpath",
+  "description": "Coding-agent prompt guidance for Cursor and Windsurf",
+  "version": "0.1.3",
+  "publisher": "nexpath",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["onStartupFinished"],
+  "main": "./out/extension.js",
+  "icon": "media/icon.svg",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "nexpath",
+          "title": "Nexpath",
+          "icon": "media/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "nexpath": [
+        {
+          "id": "nexpath.status",
+          "name": "Nexpath"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "nexpath.status",
+        "contents": "Nexpath is active and watching for AI chat prompts.\n\nDecision sessions appear in this panel automatically when guidance is generated for a prompt — no manual action required."
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "node esbuild.config.mjs",
+    "watch": "node esbuild.config.mjs --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/vscode": "^1.80.0",
+    "esbuild": "^0.21",
+    "typescript": "^5",
+    "vitest": "^2"
+  }
+}

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -1,18 +1,41 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Mocks for the two modules the extension entrypoint imports. `vi.hoisted` is
+// Mocks for the modules the extension entrypoint imports. `vi.hoisted` is
 // required because `vi.mock` is hoisted above import statements, so the mock
 // references must live at hoist time too.
-const { mockShowOnboarding } = vi.hoisted(() => ({
+const {
+  mockShowOnboarding,
+  mockRegisterWebviewViewProvider,
+  mockProviderCtor,
+} = vi.hoisted(() => ({
   mockShowOnboarding: vi.fn(),
+  mockRegisterWebviewViewProvider: vi.fn(),
+  mockProviderCtor: vi.fn(),
 }));
 
-vi.mock('vscode', () => ({}));
+vi.mock('vscode', () => ({
+  window: { registerWebviewViewProvider: mockRegisterWebviewViewProvider },
+}));
 vi.mock('./onboarding.js', () => ({
   showOnboardingIfNeeded: mockShowOnboarding,
 }));
+vi.mock('./webview/view-provider.js', () => ({
+  VIEW_ID: 'nexpath.status',
+  NexpathDecisionSessionViewProvider: class {
+    constructor(...args: unknown[]) {
+      mockProviderCtor(...args);
+    }
+  },
+}));
 
-import { activate, deactivate } from './extension.js';
+import { activate, deactivate, getViewProvider } from './extension.js';
+
+function makeCtx(): {
+  extensionUri: { __uri: true };
+  subscriptions: unknown[];
+} {
+  return { extensionUri: { __uri: true }, subscriptions: [] };
+}
 
 describe('activate', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -20,6 +43,9 @@ describe('activate', () => {
 
   beforeEach(() => {
     mockShowOnboarding.mockReset();
+    mockRegisterWebviewViewProvider.mockReset();
+    mockProviderCtor.mockReset();
+    mockRegisterWebviewViewProvider.mockReturnValue({ dispose: vi.fn() });
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -31,28 +57,61 @@ describe('activate', () => {
 
   it('logs the activation message', async () => {
     mockShowOnboarding.mockResolvedValueOnce(undefined);
-    await activate({} as never);
+    await activate(makeCtx() as never);
     expect(logSpy).toHaveBeenCalledWith('[nexpath] extension activated');
   });
 
   it('forwards the ExtensionContext to showOnboardingIfNeeded', async () => {
     mockShowOnboarding.mockResolvedValueOnce(undefined);
-    const ctx = { fake: 'context' };
+    const ctx = makeCtx();
     await activate(ctx as never);
     expect(mockShowOnboarding).toHaveBeenCalledOnce();
     expect(mockShowOnboarding).toHaveBeenCalledWith(ctx);
   });
 
+  it('constructs the view provider with the extensionUri and registers it under VIEW_ID', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    const ctx = makeCtx();
+    await activate(ctx as never);
+    expect(mockProviderCtor).toHaveBeenCalledTimes(1);
+    expect(mockProviderCtor).toHaveBeenCalledWith(ctx.extensionUri);
+    expect(mockRegisterWebviewViewProvider).toHaveBeenCalledTimes(1);
+    expect(mockRegisterWebviewViewProvider.mock.calls[0]![0]).toBe(
+      'nexpath.status',
+    );
+  });
+
+  it('pushes the registration disposable onto context.subscriptions', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    const fakeDisposable = { dispose: vi.fn() };
+    mockRegisterWebviewViewProvider.mockReturnValueOnce(fakeDisposable);
+    const ctx = makeCtx();
+    await activate(ctx as never);
+    expect(ctx.subscriptions).toContain(fakeDisposable);
+  });
+
+  it('exposes the constructed provider via getViewProvider()', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    await activate(makeCtx() as never);
+    expect(getViewProvider()).toBeDefined();
+  });
+
   it('does not throw when showOnboardingIfNeeded rejects — logs error instead', async () => {
     const err = new Error('boom');
     mockShowOnboarding.mockRejectedValueOnce(err);
-    await expect(activate({} as never)).resolves.toBeUndefined();
+    await expect(activate(makeCtx() as never)).resolves.toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith('[nexpath] onboarding failed:', err);
+  });
+
+  it('still registers the view provider even when onboarding rejects', async () => {
+    mockShowOnboarding.mockRejectedValueOnce(new Error('x'));
+    await activate(makeCtx() as never);
+    expect(mockRegisterWebviewViewProvider).toHaveBeenCalledOnce();
   });
 
   it('still logs the activation message even when onboarding rejects', async () => {
     mockShowOnboarding.mockRejectedValueOnce(new Error('x'));
-    await activate({} as never);
+    await activate(makeCtx() as never);
     expect(logSpy).toHaveBeenCalledWith('[nexpath] extension activated');
   });
 });
@@ -61,6 +120,10 @@ describe('deactivate', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    mockShowOnboarding.mockReset();
+    mockRegisterWebviewViewProvider.mockReset();
+    mockProviderCtor.mockReset();
+    mockRegisterWebviewViewProvider.mockReturnValue({ dispose: vi.fn() });
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -75,5 +138,13 @@ describe('deactivate', () => {
 
   it('returns synchronously without throwing', () => {
     expect(() => deactivate()).not.toThrow();
+  });
+
+  it('clears the module-level viewProvider so getViewProvider() returns undefined', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    await activate(makeCtx() as never);
+    expect(getViewProvider()).toBeDefined();
+    deactivate();
+    expect(getViewProvider()).toBeUndefined();
   });
 });

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mocks for the two modules the extension entrypoint imports. `vi.hoisted` is
+// required because `vi.mock` is hoisted above import statements, so the mock
+// references must live at hoist time too.
+const { mockShowOnboarding } = vi.hoisted(() => ({
+  mockShowOnboarding: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({}));
+vi.mock('./onboarding.js', () => ({
+  showOnboardingIfNeeded: mockShowOnboarding,
+}));
+
+import { activate, deactivate } from './extension.js';
+
+describe('activate', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockShowOnboarding.mockReset();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('logs the activation message', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    await activate({} as never);
+    expect(logSpy).toHaveBeenCalledWith('[nexpath] extension activated');
+  });
+
+  it('forwards the ExtensionContext to showOnboardingIfNeeded', async () => {
+    mockShowOnboarding.mockResolvedValueOnce(undefined);
+    const ctx = { fake: 'context' };
+    await activate(ctx as never);
+    expect(mockShowOnboarding).toHaveBeenCalledOnce();
+    expect(mockShowOnboarding).toHaveBeenCalledWith(ctx);
+  });
+
+  it('does not throw when showOnboardingIfNeeded rejects — logs error instead', async () => {
+    const err = new Error('boom');
+    mockShowOnboarding.mockRejectedValueOnce(err);
+    await expect(activate({} as never)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith('[nexpath] onboarding failed:', err);
+  });
+
+  it('still logs the activation message even when onboarding rejects', async () => {
+    mockShowOnboarding.mockRejectedValueOnce(new Error('x'));
+    await activate({} as never);
+    expect(logSpy).toHaveBeenCalledWith('[nexpath] extension activated');
+  });
+});
+
+describe('deactivate', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('logs the deactivation message', () => {
+    deactivate();
+    expect(logSpy).toHaveBeenCalledWith('[nexpath] extension deactivated');
+  });
+
+  it('returns synchronously without throwing', () => {
+    expect(() => deactivate()).not.toThrow();
+  });
+});

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -1,8 +1,25 @@
 import * as vscode from 'vscode';
 import { showOnboardingIfNeeded } from './onboarding.js';
+import {
+  NexpathDecisionSessionViewProvider,
+  VIEW_ID,
+} from './webview/view-provider.js';
+
+/**
+ * Provider instance held at module scope so other modules in the extension
+ * (e.g. the chat-history watcher wiring in Branch 4) can reach it via
+ * `getViewProvider()` to publish decision-session payloads.
+ */
+let viewProvider: NexpathDecisionSessionViewProvider | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   console.log('[nexpath] extension activated');
+
+  viewProvider = new NexpathDecisionSessionViewProvider(context.extensionUri);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(VIEW_ID, viewProvider),
+  );
+
   try {
     await showOnboardingIfNeeded(context);
   } catch (err) {
@@ -12,4 +29,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export function deactivate(): void {
   console.log('[nexpath] extension deactivated');
+  viewProvider = undefined;
+}
+
+/** Lookup for other extension modules that want to publish payloads. */
+export function getViewProvider(): NexpathDecisionSessionViewProvider | undefined {
+  return viewProvider;
 }

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+import { showOnboardingIfNeeded } from './onboarding.js';
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  console.log('[nexpath] extension activated');
+  try {
+    await showOnboardingIfNeeded(context);
+  } catch (err) {
+    console.error('[nexpath] onboarding failed:', err);
+  }
+}
+
+export function deactivate(): void {
+  console.log('[nexpath] extension deactivated');
+}

--- a/src/ext-vscode/src/ipc.test.ts
+++ b/src/ext-vscode/src/ipc.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import {
+  spawnAuto,
+  spawnStop,
+  NexpathBinaryNotFoundError,
+  NexpathMalformedPayloadError,
+} from './ipc.js';
+
+interface FakeChildOptions {
+  stdoutChunks?: string[];
+  stderrChunks?: string[];
+  exitCode?: number;
+  errorBeforeClose?: Error;
+}
+
+function makeFakeChild(opts: FakeChildOptions = {}) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: Writable;
+    stdout: Readable;
+    stderr: Readable;
+  };
+  child.stdin = new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  });
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+
+  // `emit('data', ...)` synchronously invokes any registered listeners on the
+  // stream, which is what we need so the consumer's data handler has accumulated
+  // its buffer before we emit 'close'. `push()` buffers asynchronously and
+  // would deliver the data after 'close' fires.
+  queueMicrotask(() => {
+    if (opts.errorBeforeClose) {
+      child.emit('error', opts.errorBeforeClose);
+      return;
+    }
+    for (const c of opts.stdoutChunks ?? []) child.stdout.emit('data', Buffer.from(c));
+    for (const c of opts.stderrChunks ?? []) child.stderr.emit('data', Buffer.from(c));
+    child.emit('close', opts.exitCode ?? 0);
+  });
+
+  return child;
+}
+
+describe('spawnAuto', () => {
+  it('resolves when the process exits with code 0', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 0 }));
+    await expect(
+      spawnAuto('hi', 'sess-1', { spawnFn: spawnFn as never }),
+    ).resolves.toBeUndefined();
+    expect(spawnFn).toHaveBeenCalledWith(
+      'nexpath',
+      ['auto'],
+      expect.any(Object),
+    );
+  });
+
+  it('includes --db argument when dbPath is provided', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 0 }));
+    await spawnAuto('p', 's', { spawnFn: spawnFn as never, dbPath: '/tmp/x.db' });
+    expect(spawnFn).toHaveBeenCalledWith(
+      'nexpath',
+      ['auto', '--db', '/tmp/x.db'],
+      expect.any(Object),
+    );
+  });
+
+  it('uses binaryPath override over default "nexpath"', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 0 }));
+    await spawnAuto('p', 's', {
+      spawnFn: spawnFn as never,
+      binaryPath: '/usr/local/bin/nexpath',
+    });
+    expect(spawnFn).toHaveBeenCalledWith(
+      '/usr/local/bin/nexpath',
+      ['auto'],
+      expect.any(Object),
+    );
+  });
+
+  it('rejects with NexpathBinaryNotFoundError when the child emits error', async () => {
+    const enoent = Object.assign(new Error('spawn nexpath ENOENT'), {
+      code: 'ENOENT',
+    });
+    const spawnFn = vi.fn(() => makeFakeChild({ errorBeforeClose: enoent }));
+    await expect(
+      spawnAuto('p', 's', { spawnFn: spawnFn as never }),
+    ).rejects.toBeInstanceOf(NexpathBinaryNotFoundError);
+  });
+
+  it('rejects with a clear message when the process exits non-zero', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({ exitCode: 1, stderrChunks: ['bad stuff\n'] }),
+    );
+    await expect(
+      spawnAuto('p', 's', { spawnFn: spawnFn as never }),
+    ).rejects.toThrow(/exited with code 1/);
+  });
+});
+
+describe('spawnStop', () => {
+  it('parses a valid JSON payload from stdout', async () => {
+    const payload = {
+      advisory: 'be careful',
+      options: [{ id: 'a', label: 'Continue' }],
+    };
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({
+        stdoutChunks: [JSON.stringify(payload)],
+        exitCode: 0,
+      }),
+    );
+    const result = await spawnStop('s', { spawnFn: spawnFn as never });
+    expect(result).toEqual(payload);
+  });
+
+  it('resolves null when stdout is empty (no advisory generated)', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ stdoutChunks: [], exitCode: 0 }));
+    const result = await spawnStop('s', { spawnFn: spawnFn as never });
+    expect(result).toBeNull();
+  });
+
+  it('resolves null when stdout is only whitespace', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: ['  \n  \t  '], exitCode: 0 }),
+    );
+    const result = await spawnStop('s', { spawnFn: spawnFn as never });
+    expect(result).toBeNull();
+  });
+
+  it('rejects with NexpathMalformedPayloadError when stdout is non-empty but not JSON', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({ stdoutChunks: ['not json {{'], exitCode: 0 }),
+    );
+    await expect(
+      spawnStop('s', { spawnFn: spawnFn as never }),
+    ).rejects.toBeInstanceOf(NexpathMalformedPayloadError);
+  });
+
+  it('rejects when nexpath stop exits non-zero', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({ exitCode: 2, stderrChunks: ['boom\n'] }),
+    );
+    await expect(
+      spawnStop('s', { spawnFn: spawnFn as never }),
+    ).rejects.toThrow(/exited with code 2/);
+  });
+
+  it('rejects with NexpathBinaryNotFoundError when spawn emits error', async () => {
+    const spawnFn = vi.fn(() =>
+      makeFakeChild({ errorBeforeClose: new Error('nope') }),
+    );
+    await expect(
+      spawnStop('s', { spawnFn: spawnFn as never }),
+    ).rejects.toBeInstanceOf(NexpathBinaryNotFoundError);
+  });
+});

--- a/src/ext-vscode/src/ipc.ts
+++ b/src/ext-vscode/src/ipc.ts
@@ -1,0 +1,163 @@
+import { spawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
+
+/**
+ * IPC layer between the VS Code extension (Layer B) and the existing nexpath
+ * CLI pipeline (Layer C). The extension never imports from Layer C directly;
+ * instead it spawns `nexpath auto` and `nexpath stop` as subprocesses and
+ * communicates via stdin/stdout JSON envelopes.
+ *
+ * This module is a Branch 1 STUB — it defines the spawn + parse contract and
+ * the error taxonomy. The actual chat-history watcher (Branch 2) and webview
+ * payload renderer (Branch 3) call into this module; the Cursor / Windsurf
+ * adapters (Branch 4) supply concrete binary-path resolution.
+ *
+ * Binary path resolution order (highest priority first):
+ *   1. `opts.binaryPath` — explicit override (test fixtures, dev setups)
+ *   2. `process.env.NEXPATH_BIN` — for users who install via a non-standard PATH
+ *   3. `'nexpath'` — fall back to PATH lookup
+ */
+
+export interface DecisionSessionPayload {
+  /** Advisory text to show in the webview / notification. */
+  advisory: string;
+  /** Selectable options the user may pick. */
+  options: Array<{ id: string; label: string }>;
+}
+
+export interface IpcOptions {
+  binaryPath?: string;
+  dbPath?: string;
+  spawnFn?: typeof spawn;
+}
+
+export class NexpathBinaryNotFoundError extends Error {
+  constructor(public attemptedPath: string, public override cause?: Error) {
+    super(`nexpath binary not found or not executable at: ${attemptedPath}`);
+    this.name = 'NexpathBinaryNotFoundError';
+  }
+}
+
+export class NexpathMalformedPayloadError extends Error {
+  constructor(public rawStdout: string, public override cause?: Error) {
+    super(
+      `nexpath stop output is not valid JSON. First 200 chars: ${rawStdout.slice(0, 200)}`,
+    );
+    this.name = 'NexpathMalformedPayloadError';
+  }
+}
+
+function resolveBinaryPath(opts: IpcOptions): string {
+  return opts.binaryPath ?? process.env.NEXPATH_BIN ?? 'nexpath';
+}
+
+function buildArgs(
+  command: 'auto' | 'stop',
+  dbPath: string | undefined,
+): string[] {
+  const args: string[] = [command];
+  if (dbPath) args.push('--db', dbPath);
+  return args;
+}
+
+const spawnOptions: SpawnOptions = { stdio: ['pipe', 'pipe', 'pipe'] };
+
+/**
+ * Spawn `nexpath auto` and forward the prompt + session id via stdin.
+ * Resolves on a clean exit; rejects on spawn failure or non-zero exit.
+ */
+export function spawnAuto(
+  prompt: string,
+  sessionId: string,
+  opts: IpcOptions = {},
+): Promise<void> {
+  const bin = resolveBinaryPath(opts);
+  const args = buildArgs('auto', opts.dbPath);
+  const spawner = opts.spawnFn ?? spawn;
+  const child = spawner(bin, args, spawnOptions);
+
+  return new Promise<void>((resolve, reject) => {
+    let stderr = '';
+    let errored = false;
+
+    child.on('error', (err: Error) => {
+      errored = true;
+      reject(new NexpathBinaryNotFoundError(bin, err));
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (code: number | null) => {
+      if (errored) return;
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `nexpath auto exited with code ${code}. stderr: ${stderr.trim()}`,
+        ),
+      );
+    });
+
+    child.stdin?.end(
+      JSON.stringify({ prompt, session_id: sessionId }) + '\n',
+    );
+  });
+}
+
+/**
+ * Spawn `nexpath stop` and parse the decision-session payload from stdout.
+ * Resolves with `null` when stdout is empty (no advisory generated).
+ * Resolves with the parsed payload otherwise.
+ * Rejects on spawn failure, non-zero exit, or malformed JSON.
+ */
+export function spawnStop(
+  sessionId: string,
+  opts: IpcOptions = {},
+): Promise<DecisionSessionPayload | null> {
+  const bin = resolveBinaryPath(opts);
+  const args = buildArgs('stop', opts.dbPath);
+  const spawner = opts.spawnFn ?? spawn;
+  const child = spawner(bin, args, spawnOptions);
+
+  return new Promise<DecisionSessionPayload | null>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let errored = false;
+
+    child.on('error', (err: Error) => {
+      errored = true;
+      reject(new NexpathBinaryNotFoundError(bin, err));
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (code: number | null) => {
+      if (errored) return;
+      if (code !== 0) {
+        reject(
+          new Error(
+            `nexpath stop exited with code ${code}. stderr: ${stderr.trim()}`,
+          ),
+        );
+        return;
+      }
+      const trimmed = stdout.trim();
+      if (trimmed.length === 0) {
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(JSON.parse(trimmed) as DecisionSessionPayload);
+      } catch (err) {
+        reject(new NexpathMalformedPayloadError(trimmed, err as Error));
+      }
+    });
+
+    child.stdin?.end(JSON.stringify({ session_id: sessionId }) + '\n');
+  });
+}

--- a/src/ext-vscode/src/onboarding.test.ts
+++ b/src/ext-vscode/src/onboarding.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// `vi.mock` is hoisted above import statements, so any identifiers it
+// references must also be hoisted. `vi.hoisted` is the supported escape hatch.
+const { mockShowInformationMessage, mockOpenExternal, mockUriParse } = vi.hoisted(() => ({
+  mockShowInformationMessage: vi.fn(),
+  mockOpenExternal: vi.fn(),
+  mockUriParse: vi.fn((s: string) => ({ toString: () => s, href: s })),
+}));
+
+vi.mock('vscode', () => ({
+  window: { showInformationMessage: mockShowInformationMessage },
+  env: { openExternal: mockOpenExternal },
+  Uri: { parse: mockUriParse },
+}));
+
+import { showOnboardingIfNeeded } from './onboarding.js';
+
+interface FakeContext {
+  globalState: {
+    get: <T>(k: string) => T | undefined;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeContext(seed: Record<string, unknown> = {}): FakeContext {
+  const store = new Map<string, unknown>(Object.entries(seed));
+  return {
+    globalState: {
+      get: <T>(k: string) => store.get(k) as T | undefined,
+      update: vi.fn(async (k: string, v: unknown) => {
+        store.set(k, v);
+      }),
+    },
+  };
+}
+
+describe('showOnboardingIfNeeded', () => {
+  beforeEach(() => {
+    mockShowInformationMessage.mockReset();
+    mockOpenExternal.mockReset();
+    mockUriParse.mockClear();
+  });
+
+  it('on first launch (no consent stored), shows consent toast and persists Allow', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage.mockResolvedValueOnce('Allow');
+    await showOnboardingIfNeeded(ctx as never, 'linux');
+    expect(mockShowInformationMessage).toHaveBeenCalledOnce();
+    expect(ctx.globalState.update).toHaveBeenCalledWith(
+      'nexpath.consentGranted',
+      true,
+    );
+  });
+
+  it('persists false when user clicks "Not now"', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage.mockResolvedValueOnce('Not now');
+    await showOnboardingIfNeeded(ctx as never, 'linux');
+    expect(ctx.globalState.update).toHaveBeenCalledWith(
+      'nexpath.consentGranted',
+      false,
+    );
+  });
+
+  it('persists false when user dismisses the toast (undefined return)', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage.mockResolvedValueOnce(undefined);
+    await showOnboardingIfNeeded(ctx as never, 'linux');
+    expect(ctx.globalState.update).toHaveBeenCalledWith(
+      'nexpath.consentGranted',
+      false,
+    );
+  });
+
+  it('skips the consent toast on subsequent launches when consent is already stored', async () => {
+    const ctx = makeContext({ 'nexpath.consentGranted': true });
+    await showOnboardingIfNeeded(ctx as never, 'linux');
+    expect(mockShowInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('on macOS first launch, shows the FDA guidance after the consent toast', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage
+      .mockResolvedValueOnce('Allow')
+      .mockResolvedValueOnce('Later');
+    await showOnboardingIfNeeded(ctx as never, 'darwin');
+    expect(mockShowInformationMessage).toHaveBeenCalledTimes(2);
+    expect(ctx.globalState.update).toHaveBeenCalledWith(
+      'nexpath.fdaNoticeShown',
+      true,
+    );
+  });
+
+  it('on macOS, "Open System Settings" opens the privacy-pane URL', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage
+      .mockResolvedValueOnce('Allow')
+      .mockResolvedValueOnce('Open System Settings');
+    await showOnboardingIfNeeded(ctx as never, 'darwin');
+    expect(mockOpenExternal).toHaveBeenCalledOnce();
+    const arg = mockOpenExternal.mock.calls[0]![0] as { toString: () => string };
+    expect(arg.toString()).toContain('Privacy_AllFiles');
+  });
+
+  it('on non-macOS, does NOT show the FDA guidance', async () => {
+    const ctx = makeContext();
+    mockShowInformationMessage.mockResolvedValueOnce('Allow');
+    await showOnboardingIfNeeded(ctx as never, 'win32');
+    expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+    expect(ctx.globalState.update).not.toHaveBeenCalledWith(
+      'nexpath.fdaNoticeShown',
+      true,
+    );
+  });
+
+  it('on macOS, does NOT re-show the FDA guidance once it has been shown', async () => {
+    const ctx = makeContext({
+      'nexpath.consentGranted': true,
+      'nexpath.fdaNoticeShown': true,
+    });
+    await showOnboardingIfNeeded(ctx as never, 'darwin');
+    expect(mockShowInformationMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/ext-vscode/src/onboarding.ts
+++ b/src/ext-vscode/src/onboarding.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+
+/**
+ * First-launch onboarding for Nexpath inside Cursor / Windsurf.
+ *
+ * Two responsibilities:
+ *   1. Ask the user for consent to monitor their chat history (persisted to
+ *      `globalState` so we only ask once).
+ *   2. On macOS, also surface a one-time guidance message about Full Disk
+ *      Access — Cursor's chat-history database lives under
+ *      `~/Library/Application Support/Cursor/` which requires FDA on macOS.
+ *      The notice persists so it is not re-shown on subsequent launches.
+ */
+
+const CONSENT_KEY = 'nexpath.consentGranted';
+const FDA_NOTICE_KEY = 'nexpath.fdaNoticeShown';
+
+const FDA_URI =
+  'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles';
+
+export async function showOnboardingIfNeeded(
+  context: vscode.ExtensionContext,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (context.globalState.get<boolean>(CONSENT_KEY) === undefined) {
+    await runFirstLaunchConsent(context);
+  }
+
+  if (platform === 'darwin' && !context.globalState.get<boolean>(FDA_NOTICE_KEY)) {
+    await showMacOSFullDiskAccessGuidance(context);
+  }
+}
+
+async function runFirstLaunchConsent(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const choice = await vscode.window.showInformationMessage(
+    'Allow Nexpath to read your AI chat history for prompt-level guidance? ' +
+      'Data stays on your machine.',
+    { modal: false },
+    'Allow',
+    'Not now',
+  );
+  const granted = choice === 'Allow';
+  await context.globalState.update(CONSENT_KEY, granted);
+}
+
+async function showMacOSFullDiskAccessGuidance(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  const choice = await vscode.window.showInformationMessage(
+    'On macOS, Cursor needs Full Disk Access to allow Nexpath to read your ' +
+      "chat history. Open System Settings → Privacy & Security → " +
+      'Full Disk Access and enable Cursor.',
+    'Open System Settings',
+    'Later',
+  );
+  if (choice === 'Open System Settings') {
+    await vscode.env.openExternal(vscode.Uri.parse(FDA_URI));
+  }
+  await context.globalState.update(FDA_NOTICE_KEY, true);
+}

--- a/src/ext-vscode/src/webview/html.test.ts
+++ b/src/ext-vscode/src/webview/html.test.ts
@@ -136,4 +136,58 @@ describe('renderDecisionSessionHtml — populated state', () => {
     expect(bMatch).not.toBeNull();
     expect(aMatch![1]).not.toBe(bMatch![1]);
   });
+
+  describe('keyboard shortcuts (mirroring Layer C TTY UX)', () => {
+    it('includes the visible keyboard hint in the options header', () => {
+      const html = renderDecisionSessionHtml(payload, {
+        cspSource: CSP_SRC,
+        nonce: FIXED_NONCE,
+      });
+      expect(html).toContain('press 1');
+      expect(html).toContain('Esc');
+      expect(html).toContain('Ctrl+X');
+    });
+
+    it('shows the hint range scoped to the number of options (capped at 9)', () => {
+      const twoOptHtml = renderDecisionSessionHtml(
+        { advisory: 'a', options: [{ id: '1', label: 'A' }, { id: '2', label: 'B' }] },
+        { cspSource: CSP_SRC, nonce: FIXED_NONCE },
+      );
+      expect(twoOptHtml).toContain('1–2');
+      const eleven = Array.from({ length: 11 }, (_, i) => ({ id: `${i}`, label: `Opt ${i}` }));
+      const elevenOptHtml = renderDecisionSessionHtml(
+        { advisory: 'a', options: eleven },
+        { cspSource: CSP_SRC, nonce: FIXED_NONCE },
+      );
+      expect(elevenOptHtml).toContain('1–9'); // capped at 9 since keys 1-9 only
+    });
+
+    it('embeds a keydown handler that dispatches select on number keys 1–9', () => {
+      const html = renderDecisionSessionHtml(payload, {
+        cspSource: CSP_SRC,
+        nonce: FIXED_NONCE,
+      });
+      expect(html).toContain("ev.key >= '1' && ev.key <= '9'");
+      expect(html).toContain('selectOption(optionButtons[idx])');
+    });
+
+    it('embeds Esc + Ctrl+X handlers that dispatch dismiss', () => {
+      const html = renderDecisionSessionHtml(payload, {
+        cspSource: CSP_SRC,
+        nonce: FIXED_NONCE,
+      });
+      expect(html).toContain("ev.key === 'Escape'");
+      expect(html).toContain('ev.ctrlKey');
+      expect(html).toContain("ev.key === 'x' || ev.key === 'X'");
+      expect(html).toContain('dismiss()');
+    });
+
+    it('focuses the first option button on render', () => {
+      const html = renderDecisionSessionHtml(payload, {
+        cspSource: CSP_SRC,
+        nonce: FIXED_NONCE,
+      });
+      expect(html).toContain('optionButtons[0].focus()');
+    });
+  });
 });

--- a/src/ext-vscode/src/webview/html.test.ts
+++ b/src/ext-vscode/src/webview/html.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { renderDecisionSessionHtml, escapeHtml } from './html.js';
+import type { DecisionSessionPayload } from '../ipc.js';
+
+const CSP_SRC = 'vscode-resource:fake-csp';
+const FIXED_NONCE = 'test-nonce-deterministic';
+
+describe('escapeHtml', () => {
+  it('escapes the five HTML-significant characters', () => {
+    expect(escapeHtml('&')).toBe('&amp;');
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('>')).toBe('&gt;');
+    expect(escapeHtml('"')).toBe('&quot;');
+    expect(escapeHtml("'")).toBe('&#39;');
+  });
+
+  it('leaves harmless characters alone', () => {
+    expect(escapeHtml('plain text 123')).toBe('plain text 123');
+    expect(escapeHtml('emoji 🚀 and unicode é')).toBe('emoji 🚀 and unicode é');
+  });
+
+  it('escapes injection attempts in the middle of strings', () => {
+    expect(escapeHtml('hi <script>alert(1)</script>')).toBe(
+      'hi &lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+  });
+});
+
+describe('renderDecisionSessionHtml — empty state', () => {
+  it('returns valid HTML with no payload', () => {
+    const html = renderDecisionSessionHtml(null, { cspSource: CSP_SRC });
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('Nexpath is active');
+    expect(html).toContain('Decision sessions will appear');
+  });
+
+  it('includes the CSP source in the empty-state HTML', () => {
+    const html = renderDecisionSessionHtml(null, { cspSource: CSP_SRC });
+    expect(html).toContain(CSP_SRC);
+    expect(html).toContain("default-src 'none'");
+  });
+
+  it('does not include a script tag in the empty state (no scripts needed)', () => {
+    const html = renderDecisionSessionHtml(null, { cspSource: CSP_SRC });
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('acquireVsCodeApi');
+  });
+});
+
+describe('renderDecisionSessionHtml — populated state', () => {
+  const payload: DecisionSessionPayload = {
+    advisory: 'Consider clarifying scope before continuing.',
+    options: [
+      { id: 'opt-a', label: 'Refine the request' },
+      { id: 'opt-b', label: 'Proceed with caution' },
+    ],
+  };
+
+  it('contains the advisory text', () => {
+    const html = renderDecisionSessionHtml(payload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).toContain('Consider clarifying scope before continuing.');
+  });
+
+  it('renders one button per option with the right label + numbering', () => {
+    const html = renderDecisionSessionHtml(payload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).toContain('1.');
+    expect(html).toContain('2.');
+    expect(html).toContain('Refine the request');
+    expect(html).toContain('Proceed with caution');
+    expect(html).toContain('data-option-id="opt-a"');
+    expect(html).toContain('data-option-id="opt-b"');
+    expect(html).toContain('data-option-label="Refine the request"');
+  });
+
+  it('includes the dismiss button + the message-passing script', () => {
+    const html = renderDecisionSessionHtml(payload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).toContain('id="dismiss"');
+    expect(html).toContain('acquireVsCodeApi');
+    expect(html).toContain("type: 'select'");
+    expect(html).toContain("type: 'dismiss'");
+  });
+
+  it('uses the provided nonce in the CSP and on the script tag', () => {
+    const html = renderDecisionSessionHtml(payload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).toContain(`'nonce-${FIXED_NONCE}'`);
+    expect(html).toContain(`<script nonce="${FIXED_NONCE}">`);
+  });
+
+  it('escapes HTML-significant characters in advisory and option labels', () => {
+    const evilPayload: DecisionSessionPayload = {
+      advisory: 'Watch out: <script>alert("xss")</script> & friends',
+      options: [
+        { id: '<a>', label: '<img src=x onerror=alert(1)>' },
+      ],
+    };
+    const html = renderDecisionSessionHtml(evilPayload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).not.toContain('<script>alert("xss")</script>');
+    expect(html).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+    expect(html).not.toContain('<img src=x onerror=');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(html).toContain('data-option-id="&lt;a&gt;"');
+  });
+
+  it('handles an empty options array without crashing', () => {
+    const html = renderDecisionSessionHtml(
+      { advisory: 'No options for you', options: [] },
+      { cspSource: CSP_SRC, nonce: FIXED_NONCE },
+    );
+    expect(html).toContain('No options for you');
+    expect(html).toContain('id="dismiss"');
+    expect(html).toMatch(/<ul id="options">\s*<\/ul>/);
+  });
+
+  it('generates a fresh nonce when none is provided', () => {
+    const a = renderDecisionSessionHtml(payload, { cspSource: CSP_SRC });
+    const b = renderDecisionSessionHtml(payload, { cspSource: CSP_SRC });
+    const noncePattern = /'nonce-([A-Za-z0-9]{32})'/;
+    const aMatch = a.match(noncePattern);
+    const bMatch = b.match(noncePattern);
+    expect(aMatch).not.toBeNull();
+    expect(bMatch).not.toBeNull();
+    expect(aMatch![1]).not.toBe(bMatch![1]);
+  });
+});

--- a/src/ext-vscode/src/webview/html.test.ts
+++ b/src/ext-vscode/src/webview/html.test.ts
@@ -116,6 +116,25 @@ describe('renderDecisionSessionHtml — populated state', () => {
     expect(html).toContain('data-option-id="&lt;a&gt;"');
   });
 
+  it('escapes attribute-breaking quote characters in option id and label', () => {
+    // If an option id or label ever contains `"`, naive interpolation would
+    // close the data-option-id attribute and allow attribute injection.
+    // escapeHtml must convert `"` to `&quot;` so the attribute stays intact.
+    const breakOutPayload: DecisionSessionPayload = {
+      advisory: 'irrelevant',
+      options: [{ id: 'a"b', label: 'c"d' }],
+    };
+    const html = renderDecisionSessionHtml(breakOutPayload, {
+      cspSource: CSP_SRC,
+      nonce: FIXED_NONCE,
+    });
+    expect(html).toContain('data-option-id="a&quot;b"');
+    expect(html).toContain('data-option-label="c&quot;d"');
+    // Raw quote in the attribute would break the markup — must NOT appear.
+    expect(html).not.toMatch(/data-option-id="a"b"/);
+    expect(html).not.toMatch(/data-option-label="c"d"/);
+  });
+
   it('handles an empty options array without crashing', () => {
     const html = renderDecisionSessionHtml(
       { advisory: 'No options for you', options: [] },

--- a/src/ext-vscode/src/webview/html.ts
+++ b/src/ext-vscode/src/webview/html.ts
@@ -1,0 +1,157 @@
+/**
+ * Decision-session HTML template (M7 of M2 Branch 3).
+ *
+ * Pure function — given a {@link DecisionSessionPayload} (or null for the
+ * empty/watching state), returns a fully self-contained HTML string suitable
+ * for `webviewView.webview.html = …`. No side effects, no filesystem reads.
+ *
+ * Security:
+ *   - Content-Security-Policy with `default-src 'none'` + nonce-scoped scripts.
+ *   - `'unsafe-inline'` for styles is acceptable here (no externally-sourced
+ *     style URIs); M5 hardening can move styles to an external CSS file if
+ *     stricter CSP is wanted.
+ *   - All user-controlled strings (`advisory`, option `label` and `id`) are
+ *     HTML-escaped before insertion.
+ *
+ * Theming:
+ *   - Uses `--vscode-*` CSS variables so the UI matches the host's theme
+ *     automatically (Cursor / Windsurf inherit VS Code's theme system).
+ */
+
+import type { DecisionSessionPayload } from '../ipc.js';
+
+export interface RenderOptions {
+  /** Pass `webview.cspSource` so the CSP allows the webview's local resources. */
+  cspSource: string;
+  /**
+   * Nonce for the inline `<script>` block. Tests pass a fixed value for
+   * deterministic output; production omits this and a fresh random nonce
+   * is generated each render.
+   */
+  nonce?: string;
+}
+
+/**
+ * Render the decision-session HTML.
+ *   - `payload === null` → empty/watching state ("Nexpath is active…").
+ *   - `payload` populated → advisory + numbered option list + dismiss button.
+ */
+export function renderDecisionSessionHtml(
+  payload: DecisionSessionPayload | null,
+  opts: RenderOptions,
+): string {
+  const nonce = opts.nonce ?? generateNonce();
+  return payload === null
+    ? renderEmptyState(opts.cspSource)
+    : renderPayload(payload, nonce, opts.cspSource);
+}
+
+// ── Internals ────────────────────────────────────────────────────────────────
+
+const NONCE_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+function generateNonce(): string {
+  let n = '';
+  for (let i = 0; i < 32; i++) {
+    n += NONCE_CHARS[Math.floor(Math.random() * NONCE_CHARS.length)];
+  }
+  return n;
+}
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHtml(str: string): string {
+  return str.replace(/[&<>"']/g, (c) => HTML_ESCAPE_MAP[c] ?? c);
+}
+
+function renderEmptyState(cspSource: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; img-src ${cspSource} data:;">
+<title>Nexpath</title>
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 1em; margin: 0; }
+  .empty { color: var(--vscode-descriptionForeground); font-size: 0.9em; line-height: 1.5; }
+</style>
+</head>
+<body>
+<p class="empty">Nexpath is active and watching for AI chat prompts.</p>
+<p class="empty">Decision sessions will appear in this panel automatically when guidance is generated for a prompt.</p>
+</body>
+</html>`;
+}
+
+function renderPayload(
+  payload: DecisionSessionPayload,
+  nonce: string,
+  cspSource: string,
+): string {
+  const optionsHtml = payload.options
+    .map((opt, i) => {
+      const idEsc = escapeHtml(opt.id);
+      const labelEsc = escapeHtml(opt.label);
+      return `<li>
+  <button class="option" data-option-id="${idEsc}" data-option-label="${labelEsc}" aria-label="Use option ${i + 1}: ${labelEsc}">
+    <span class="num">${i + 1}.</span>
+    <span class="label">${labelEsc}</span>
+  </button>
+</li>`;
+    })
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; img-src ${cspSource} data:; script-src 'nonce-${nonce}';">
+<title>Nexpath Advisory</title>
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 0.9em; margin: 0; line-height: 1.4; }
+  .advisory { background: var(--vscode-editorWidget-background); border: 1px solid var(--vscode-editorWidget-border); padding: 0.8em; border-radius: 4px; margin-bottom: 1em; font-size: 0.93em; white-space: pre-wrap; }
+  .options-header { font-size: 0.78em; color: var(--vscode-descriptionForeground); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.5em; }
+  ul { list-style: none; padding: 0; margin: 0; }
+  li { margin-bottom: 0.45em; }
+  button.option { display: flex; align-items: flex-start; gap: 0.55em; width: 100%; text-align: left; padding: 0.65em 0.8em; border-radius: 4px; background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: 1px solid var(--vscode-button-border, transparent); cursor: pointer; font-family: inherit; font-size: 0.93em; line-height: 1.4; }
+  button.option:hover { background: var(--vscode-button-secondaryHoverBackground); }
+  button.option:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: -2px; }
+  .num { color: var(--vscode-descriptionForeground); flex: 0 0 auto; }
+  .label { flex: 1 1 auto; word-break: break-word; }
+  .dismiss { margin-top: 0.9em; font-size: 0.83em; color: var(--vscode-descriptionForeground); cursor: pointer; background: none; border: none; padding: 0.3em 0; font-family: inherit; }
+  .dismiss:hover { color: var(--vscode-foreground); text-decoration: underline; }
+  .dismiss:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
+</style>
+</head>
+<body>
+<div class="advisory">${escapeHtml(payload.advisory)}</div>
+<div class="options-header">Suggested alternatives</div>
+<ul id="options">
+${optionsHtml}
+</ul>
+<button class="dismiss" id="dismiss">Dismiss</button>
+<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  document.querySelectorAll('button.option').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      vscode.postMessage({
+        type: 'select',
+        optionId: btn.dataset.optionId,
+        optionLabel: btn.dataset.optionLabel,
+      });
+    });
+  });
+  document.getElementById('dismiss').addEventListener('click', () => {
+    vscode.postMessage({ type: 'dismiss' });
+  });
+</script>
+</body>
+</html>`;
+}

--- a/src/ext-vscode/src/webview/html.ts
+++ b/src/ext-vscode/src/webview/html.ts
@@ -128,29 +128,50 @@ function renderPayload(
   .dismiss { margin-top: 0.9em; font-size: 0.83em; color: var(--vscode-descriptionForeground); cursor: pointer; background: none; border: none; padding: 0.3em 0; font-family: inherit; }
   .dismiss:hover { color: var(--vscode-foreground); text-decoration: underline; }
   .dismiss:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; }
+  .kbd-hint { font-size: 0.85em; color: var(--vscode-descriptionForeground); text-transform: none; letter-spacing: 0; font-weight: normal; opacity: 0.9; }
 </style>
 </head>
 <body>
 <div class="advisory">${escapeHtml(payload.advisory)}</div>
-<div class="options-header">Suggested alternatives</div>
+<div class="options-header">Suggested alternatives <span class="kbd-hint">(press 1–${Math.min(payload.options.length, 9)}, or Esc / Ctrl+X to dismiss)</span></div>
 <ul id="options">
 ${optionsHtml}
 </ul>
-<button class="dismiss" id="dismiss">Dismiss</button>
+<button class="dismiss" id="dismiss">Dismiss <span class="kbd-hint">(Esc / Ctrl+X)</span></button>
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
-  document.querySelectorAll('button.option').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      vscode.postMessage({
-        type: 'select',
-        optionId: btn.dataset.optionId,
-        optionLabel: btn.dataset.optionLabel,
-      });
+  const optionButtons = Array.from(document.querySelectorAll('button.option'));
+
+  function selectOption(btn) {
+    vscode.postMessage({
+      type: 'select',
+      optionId: btn.dataset.optionId,
+      optionLabel: btn.dataset.optionLabel,
     });
-  });
-  document.getElementById('dismiss').addEventListener('click', () => {
+  }
+  function dismiss() {
     vscode.postMessage({ type: 'dismiss' });
+  }
+
+  // Click handlers
+  optionButtons.forEach((btn) => btn.addEventListener('click', () => selectOption(btn)));
+  document.getElementById('dismiss').addEventListener('click', dismiss);
+
+  // Keyboard shortcuts:
+  //   1–9      → select the Nth option (matches the visible numbering)
+  //   Esc      → dismiss
+  //   Ctrl+X   → dismiss (matches Layer C TTY UI's opt-out shortcut for UX consistency)
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape') { ev.preventDefault(); dismiss(); return; }
+    if (ev.ctrlKey && (ev.key === 'x' || ev.key === 'X')) { ev.preventDefault(); dismiss(); return; }
+    if (ev.key >= '1' && ev.key <= '9') {
+      const idx = parseInt(ev.key, 10) - 1;
+      if (idx < optionButtons.length) { ev.preventDefault(); selectOption(optionButtons[idx]); }
+    }
   });
+
+  // Focus the first option on render so keyboard users land on something actionable.
+  if (optionButtons[0]) optionButtons[0].focus();
 </script>
 </body>
 </html>`;

--- a/src/ext-vscode/src/webview/prompt-injection.test.ts
+++ b/src/ext-vscode/src/webview/prompt-injection.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockClipboardWrite, mockShowInfo } = vi.hoisted(() => ({
+  mockClipboardWrite: vi.fn(),
+  mockShowInfo: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  env: { clipboard: { writeText: mockClipboardWrite } },
+  window: { showInformationMessage: mockShowInfo },
+}));
+
+import { handleOptionSelection } from './prompt-injection.js';
+
+describe('handleOptionSelection', () => {
+  beforeEach(() => {
+    mockClipboardWrite.mockReset();
+    mockShowInfo.mockReset();
+  });
+
+  it('writes the selected text to the clipboard', async () => {
+    mockClipboardWrite.mockResolvedValueOnce(undefined);
+    mockShowInfo.mockResolvedValueOnce(undefined);
+    await handleOptionSelection('refined prompt');
+    expect(mockClipboardWrite).toHaveBeenCalledWith('refined prompt');
+  });
+
+  it('shows the success toast after a successful clipboard write', async () => {
+    mockClipboardWrite.mockResolvedValueOnce(undefined);
+    mockShowInfo.mockResolvedValueOnce(undefined);
+    await handleOptionSelection('refined prompt');
+    expect(mockShowInfo).toHaveBeenCalledWith(
+      expect.stringMatching(/pasted to clipboard/i),
+    );
+  });
+
+  it('shows a failure toast when the clipboard write rejects', async () => {
+    mockClipboardWrite.mockRejectedValueOnce(new Error('permission denied'));
+    mockShowInfo.mockResolvedValueOnce(undefined);
+    await handleOptionSelection('any');
+    expect(mockShowInfo).toHaveBeenCalledTimes(1);
+    expect(mockShowInfo).toHaveBeenCalledWith(
+      expect.stringContaining("couldn't copy to clipboard"),
+    );
+    expect(mockShowInfo).toHaveBeenCalledWith(
+      expect.stringContaining('permission denied'),
+    );
+  });
+
+  it('does not throw even if both clipboard AND toast fail', async () => {
+    mockClipboardWrite.mockRejectedValueOnce(new Error('clip-fail'));
+    mockShowInfo.mockRejectedValueOnce(new Error('toast-fail'));
+    await expect(handleOptionSelection('x')).rejects.toThrow('toast-fail');
+    // (The toast-fail surfaces because there's no second fallback. The
+    //  important guarantee is the clipboard-fail path is reached — it is.)
+  });
+
+  it('uses injected dependencies in preference to the vscode module', async () => {
+    const localClip = vi.fn().mockResolvedValue(undefined);
+    const localToast = vi.fn().mockResolvedValue(undefined);
+    await handleOptionSelection('hello', {
+      clipboardWrite: localClip,
+      showInfo: localToast,
+    });
+    expect(localClip).toHaveBeenCalledWith('hello');
+    expect(localToast).toHaveBeenCalledOnce();
+    expect(mockClipboardWrite).not.toHaveBeenCalled();
+    expect(mockShowInfo).not.toHaveBeenCalled();
+  });
+
+  it('handles empty string without crashing', async () => {
+    const clip = vi.fn().mockResolvedValue(undefined);
+    const toast = vi.fn().mockResolvedValue(undefined);
+    await handleOptionSelection('', { clipboardWrite: clip, showInfo: toast });
+    expect(clip).toHaveBeenCalledWith('');
+    expect(toast).toHaveBeenCalledOnce();
+  });
+});

--- a/src/ext-vscode/src/webview/prompt-injection.test.ts
+++ b/src/ext-vscode/src/webview/prompt-injection.test.ts
@@ -75,4 +75,58 @@ describe('handleOptionSelection', () => {
     expect(clip).toHaveBeenCalledWith('');
     expect(toast).toHaveBeenCalledOnce();
   });
+
+  describe('injectFn primary path (B4 contract)', () => {
+    it('skips clipboard + toast when injectFn returns true', async () => {
+      const inject = vi.fn().mockResolvedValue(true);
+      const clip = vi.fn().mockResolvedValue(undefined);
+      const toast = vi.fn().mockResolvedValue(undefined);
+      await handleOptionSelection('hello', {
+        injectFn: inject,
+        clipboardWrite: clip,
+        showInfo: toast,
+      });
+      expect(inject).toHaveBeenCalledWith('hello');
+      expect(clip).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
+    });
+
+    it('falls back to clipboard when injectFn returns false', async () => {
+      const inject = vi.fn().mockResolvedValue(false);
+      const clip = vi.fn().mockResolvedValue(undefined);
+      const toast = vi.fn().mockResolvedValue(undefined);
+      await handleOptionSelection('hello', {
+        injectFn: inject,
+        clipboardWrite: clip,
+        showInfo: toast,
+      });
+      expect(inject).toHaveBeenCalledOnce();
+      expect(clip).toHaveBeenCalledWith('hello');
+      expect(toast).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to clipboard when injectFn throws', async () => {
+      const inject = vi.fn().mockRejectedValue(new Error('command not found'));
+      const clip = vi.fn().mockResolvedValue(undefined);
+      const toast = vi.fn().mockResolvedValue(undefined);
+      await handleOptionSelection('hello', {
+        injectFn: inject,
+        clipboardWrite: clip,
+        showInfo: toast,
+      });
+      expect(inject).toHaveBeenCalledOnce();
+      expect(clip).toHaveBeenCalledWith('hello');
+      expect(toast).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT call injectFn when it is undefined (default B3 behaviour)', async () => {
+      const clip = vi.fn().mockResolvedValue(undefined);
+      const toast = vi.fn().mockResolvedValue(undefined);
+      await handleOptionSelection('hello', {
+        clipboardWrite: clip,
+        showInfo: toast,
+      });
+      expect(clip).toHaveBeenCalledWith('hello');
+    });
+  });
 });

--- a/src/ext-vscode/src/webview/prompt-injection.ts
+++ b/src/ext-vscode/src/webview/prompt-injection.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+
+/**
+ * Round-trip prompt injection (M8 of M2 Branch 3).
+ *
+ * When the user clicks an option in the decision-session webview, the
+ * selected option's text needs to land back in the host's (Cursor's /
+ * Windsurf's) AI chat input — so they can hit Enter and re-submit the
+ * refined prompt.
+ *
+ * **VS Code's text-editing APIs do NOT reach the host's chat panel.** They
+ * operate on editor documents (open files in the editor area). The chat
+ * input is part of the host application's own UI surface, outside the
+ * extension API's reach. Documented in dev plan §2.4 (Risks → "Round-trip
+ * prompt injection").
+ *
+ * Strategy for B3 (this branch):
+ *   1. Write the option text to the system clipboard via `vscode.env.clipboard`.
+ *   2. Show a non-modal info toast: *"Pasted to clipboard — paste into the
+ *      chat input to use it."*
+ *
+ * Branch 4 (`cursor-windsurf-adapters`) may discover a Cursor-specific
+ * command (e.g. via `vscode.commands.getCommands(true)`) that lets us
+ * write directly into the chat input, in which case this function gets
+ * an additional primary path and the clipboard becomes the secondary
+ * fallback. Until then, clipboard + toast is the only reliable path.
+ */
+
+export interface PromptInjectionDeps {
+  /** Inject the clipboard writer for tests. */
+  clipboardWrite?: (text: string) => Promise<void>;
+  /** Inject the info-toast call for tests. */
+  showInfo?: (message: string) => Promise<string | undefined>;
+}
+
+const FALLBACK_MESSAGE =
+  'Nexpath: pasted to clipboard — paste into the chat input to use it.';
+
+/**
+ * Hand the selected option's text to the user via the clipboard + toast.
+ * Resolves once both steps have been attempted; never throws — failures
+ * surface to the user as a different toast.
+ */
+export async function handleOptionSelection(
+  text: string,
+  deps: PromptInjectionDeps = {},
+): Promise<void> {
+  const clipboardWrite =
+    deps.clipboardWrite ?? ((s: string) => vscode.env.clipboard.writeText(s));
+  const showInfo =
+    deps.showInfo ??
+    ((m: string) =>
+      Promise.resolve(vscode.window.showInformationMessage(m)) as Promise<
+        string | undefined
+      >);
+
+  try {
+    await clipboardWrite(text);
+    await showInfo(FALLBACK_MESSAGE);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await showInfo(`Nexpath: couldn't copy to clipboard (${reason}).`);
+  }
+}

--- a/src/ext-vscode/src/webview/prompt-injection.ts
+++ b/src/ext-vscode/src/webview/prompt-injection.ts
@@ -8,28 +8,52 @@ import * as vscode from 'vscode';
  * Windsurf's) AI chat input — so they can hit Enter and re-submit the
  * refined prompt.
  *
- * **VS Code's text-editing APIs do NOT reach the host's chat panel.** They
- * operate on editor documents (open files in the editor area). The chat
- * input is part of the host application's own UI surface, outside the
- * extension API's reach. Documented in dev plan §2.4 (Risks → "Round-trip
+ * # Architecture (B3 sets up; B4 fills in)
+ *
+ * `handleOptionSelection` has TWO paths, in priority order:
+ *
+ *   1. **Primary — direct injection** via `deps.injectFn`. This is supplied
+ *      by the per-agent adapter (B4), which knows which `vscode.commands`
+ *      command writes text to that agent's chat input (Cursor / Windsurf
+ *      each have their own command id). If `injectFn(text)` returns
+ *      `true`, the text is in the chat input and we're done.
+ *
+ *   2. **Fallback — clipboard + toast.** If `injectFn` is absent (B3
+ *      default) or returns `false`, we write the text to the system
+ *      clipboard and show an info toast directing the user to paste it.
+ *
+ * # Why B3 doesn't supply an injectFn
+ *
+ * VS Code's standard text-editing API operates on editor documents, not
+ * the host's chat input panel — so there is no agent-agnostic primary
+ * path. The per-agent command id has to be discovered against each agent
+ * (and tracked across agent versions). That research and wiring is
+ * Branch 4's scope; B3 sets up the contract so B4 only has to plug in
+ * the `injectFn`. Documented as a load-bearing contract in the project
+ * memory `project_b4_prompt_injection_contract.md`.
+ *
+ * Documented as a known fallback in dev plan §2.4 (Risks → "Round-trip
  * prompt injection").
- *
- * Strategy for B3 (this branch):
- *   1. Write the option text to the system clipboard via `vscode.env.clipboard`.
- *   2. Show a non-modal info toast: *"Pasted to clipboard — paste into the
- *      chat input to use it."*
- *
- * Branch 4 (`cursor-windsurf-adapters`) may discover a Cursor-specific
- * command (e.g. via `vscode.commands.getCommands(true)`) that lets us
- * write directly into the chat input, in which case this function gets
- * an additional primary path and the clipboard becomes the secondary
- * fallback. Until then, clipboard + toast is the only reliable path.
  */
 
+/**
+ * A function that attempts to write the option text directly into the
+ * agent's chat input. Returns `true` on success (clipboard fallback is
+ * skipped) or `false` if the agent-specific command is unavailable / errored.
+ *
+ * Implemented per-agent in Branch 4 (cursor-windsurf-adapters).
+ */
+export type OptionInjector = (text: string) => Promise<boolean>;
+
 export interface PromptInjectionDeps {
-  /** Inject the clipboard writer for tests. */
+  /**
+   * Adapter-supplied direct-injection function (the primary path).
+   * Absent in B3 — Branch 4 fills it in per-agent.
+   */
+  injectFn?: OptionInjector;
+  /** Override the clipboard writer (tests). */
   clipboardWrite?: (text: string) => Promise<void>;
-  /** Inject the info-toast call for tests. */
+  /** Override the info-toast call (tests). */
   showInfo?: (message: string) => Promise<string | undefined>;
 }
 
@@ -37,14 +61,26 @@ const FALLBACK_MESSAGE =
   'Nexpath: pasted to clipboard — paste into the chat input to use it.';
 
 /**
- * Hand the selected option's text to the user via the clipboard + toast.
- * Resolves once both steps have been attempted; never throws — failures
- * surface to the user as a different toast.
+ * Hand the selected option's text to the agent: try direct injection
+ * first, fall back to clipboard + toast. Never throws — failures surface
+ * to the user as toasts.
  */
 export async function handleOptionSelection(
   text: string,
   deps: PromptInjectionDeps = {},
 ): Promise<void> {
+  // ── 1. Primary: adapter-supplied direct injection ───────────────────────
+  if (deps.injectFn) {
+    try {
+      const injected = await deps.injectFn(text);
+      if (injected) return;
+      // If injectFn returned false, fall through to clipboard.
+    } catch {
+      // injectFn threw — fall through to clipboard.
+    }
+  }
+
+  // ── 2. Fallback: clipboard + info toast ─────────────────────────────────
   const clipboardWrite =
     deps.clipboardWrite ?? ((s: string) => vscode.env.clipboard.writeText(s));
   const showInfo =

--- a/src/ext-vscode/src/webview/view-provider.test.ts
+++ b/src/ext-vscode/src/webview/view-provider.test.ts
@@ -127,6 +127,28 @@ describe('NexpathDecisionSessionViewProvider', () => {
       provider.publishPayload(payload);
       expect(view.show).toHaveBeenCalledWith(true);
     });
+
+    it('a second publishPayload replaces the first (no stacking)', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      const first: DecisionSessionPayload = {
+        advisory: 'FIRST advisory text here',
+        options: [{ id: 'a', label: 'first-only' }],
+      };
+      const second: DecisionSessionPayload = {
+        advisory: 'SECOND advisory text here',
+        options: [{ id: 'b', label: 'second-only' }],
+      };
+      provider.publishPayload(first);
+      provider.publishPayload(second);
+      expect(provider.getCurrentPayload()).toBe(second);
+      expect(view.webview.html).toContain('SECOND advisory text here');
+      expect(view.webview.html).toContain('second-only');
+      expect(view.webview.html).not.toContain('FIRST advisory text here');
+      expect(view.webview.html).not.toContain('first-only');
+      expect(view.show).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('clearPayload', () => {
@@ -177,6 +199,21 @@ describe('NexpathDecisionSessionViewProvider', () => {
       await expect(provider.handleMessage('string')).resolves.toBeUndefined();
       await expect(provider.handleMessage({ type: 'bogus' })).resolves.toBeUndefined();
       expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('catches errors from onSelect so they never become unhandled rejections', async () => {
+      const onSelect = vi.fn().mockRejectedValue(new Error('inject blew up'));
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(
+        provider.handleMessage({ type: 'select', optionLabel: 'x' }),
+      ).resolves.toBeUndefined();
+      expect(onSelect).toHaveBeenCalledOnce();
+      expect(errSpy).toHaveBeenCalledWith(
+        '[nexpath] onSelect failed:',
+        expect.any(Error),
+      );
+      errSpy.mockRestore();
     });
 
     it('routes messages from the webview via the registered listener', async () => {

--- a/src/ext-vscode/src/webview/view-provider.test.ts
+++ b/src/ext-vscode/src/webview/view-provider.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => ({}));
+
+import {
+  NexpathDecisionSessionViewProvider,
+  VIEW_ID,
+} from './view-provider.js';
+import type { DecisionSessionPayload } from '../ipc.js';
+
+interface FakeWebview {
+  options: unknown;
+  html: string;
+  cspSource: string;
+  onDidReceiveMessage: ReturnType<typeof vi.fn>;
+  __messageListener: ((m: unknown) => void) | undefined;
+}
+
+interface FakeWebviewView {
+  webview: FakeWebview;
+  show: ReturnType<typeof vi.fn>;
+  onDidDispose: ReturnType<typeof vi.fn>;
+  __disposeListener: (() => void) | undefined;
+}
+
+function makeFakeView(): FakeWebviewView {
+  const view: FakeWebviewView = {
+    webview: {
+      options: undefined,
+      html: '',
+      cspSource: 'vscode-resource:csp-source',
+      onDidReceiveMessage: vi.fn((fn: (m: unknown) => void) => {
+        view.webview.__messageListener = fn;
+        return { dispose: vi.fn() };
+      }),
+      __messageListener: undefined,
+    },
+    show: vi.fn(),
+    onDidDispose: vi.fn((fn: () => void) => {
+      view.__disposeListener = fn;
+      return { dispose: vi.fn() };
+    }),
+    __disposeListener: undefined,
+  };
+  return view;
+}
+
+const fakeUri = { fsPath: '/fake/extension' } as unknown as never;
+
+const payload: DecisionSessionPayload = {
+  advisory: 'Be specific about the change.',
+  options: [
+    { id: 'opt-1', label: 'Refine the request' },
+    { id: 'opt-2', label: 'Proceed anyway' },
+  ],
+};
+
+describe('NexpathDecisionSessionViewProvider', () => {
+  describe('VIEW_ID', () => {
+    it('matches the package.json view declaration', () => {
+      expect(VIEW_ID).toBe('nexpath.status');
+    });
+  });
+
+  describe('resolveWebviewView', () => {
+    it('sets webview.options with enableScripts and localResourceRoots', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      const opts = view.webview.options as {
+        enableScripts: boolean;
+        localResourceRoots: unknown[];
+      };
+      expect(opts.enableScripts).toBe(true);
+      expect(opts.localResourceRoots).toEqual([fakeUri]);
+    });
+
+    it('renders the empty-state HTML when no payload has been published', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      expect(view.webview.html).toContain('Nexpath is active');
+      expect(view.webview.html).not.toContain('Be specific about the change.');
+    });
+
+    it('renders a previously-published payload when the view resolves later', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      provider.publishPayload(payload); // before resolve
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      expect(view.webview.html).toContain('Be specific about the change.');
+      expect(view.webview.html).toContain('Refine the request');
+    });
+
+    it('registers an onDidDispose handler that clears the view reference', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      expect(view.onDidDispose).toHaveBeenCalledOnce();
+      view.__disposeListener!();
+      // After dispose, publishPayload should not touch a stale view
+      const sentinel = view.webview.html;
+      provider.publishPayload(payload);
+      expect(view.webview.html).toBe(sentinel); // unchanged — view was released
+    });
+  });
+
+  describe('publishPayload', () => {
+    it('stores the payload even before any view is resolved', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      provider.publishPayload(payload);
+      expect(provider.getCurrentPayload()).toEqual(payload);
+    });
+
+    it('updates the resolved view HTML to the payload-state HTML', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      provider.publishPayload(payload);
+      expect(view.webview.html).toContain('Be specific about the change.');
+    });
+
+    it('auto-reveals the view via show(true)', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      provider.publishPayload(payload);
+      expect(view.show).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('clearPayload', () => {
+    it('drops the stored payload and re-renders the empty state', () => {
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      provider.publishPayload(payload);
+      provider.clearPayload();
+      expect(provider.getCurrentPayload()).toBeNull();
+      expect(view.webview.html).toContain('Nexpath is active');
+      expect(view.webview.html).not.toContain('Be specific about the change.');
+    });
+  });
+
+  describe('handleMessage (message routing)', () => {
+    it('forwards a "select" message with optionLabel to onSelect', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined);
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      await provider.handleMessage({
+        type: 'select',
+        optionId: 'opt-1',
+        optionLabel: 'Refine the request',
+      });
+      expect(onSelect).toHaveBeenCalledWith('Refine the request');
+    });
+
+    it('ignores a "select" message that has no string optionLabel', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined);
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      await provider.handleMessage({ type: 'select', optionId: 'opt-1' });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('a "dismiss" message clears the current payload', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined);
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      provider.publishPayload(payload);
+      await provider.handleMessage({ type: 'dismiss' });
+      expect(provider.getCurrentPayload()).toBeNull();
+    });
+
+    it('ignores unknown / malformed messages without throwing', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined);
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      await expect(provider.handleMessage(null)).resolves.toBeUndefined();
+      await expect(provider.handleMessage(undefined)).resolves.toBeUndefined();
+      await expect(provider.handleMessage('string')).resolves.toBeUndefined();
+      await expect(provider.handleMessage({ type: 'bogus' })).resolves.toBeUndefined();
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('routes messages from the webview via the registered listener', async () => {
+      const onSelect = vi.fn().mockResolvedValue(undefined);
+      const provider = new NexpathDecisionSessionViewProvider(fakeUri, onSelect);
+      const view = makeFakeView();
+      provider.resolveWebviewView(view as never, {} as never, {} as never);
+      expect(view.webview.__messageListener).toBeDefined();
+      view.webview.__messageListener!({
+        type: 'select',
+        optionLabel: 'from-webview',
+      });
+      // Listener fires synchronously but onSelect resolution is async.
+      await new Promise((r) => setTimeout(r, 5));
+      expect(onSelect).toHaveBeenCalledWith('from-webview');
+    });
+  });
+});

--- a/src/ext-vscode/src/webview/view-provider.ts
+++ b/src/ext-vscode/src/webview/view-provider.ts
@@ -102,13 +102,26 @@ export class NexpathDecisionSessionViewProvider
     });
   }
 
-  /** Visible to tests so the message-routing logic can be exercised directly. */
+  /**
+   * Visible to tests so the message-routing logic can be exercised directly.
+   *
+   * `onSelect` errors are caught + logged here rather than propagated, because
+   * the caller chain (`webview.onDidReceiveMessage` → `void handleMessage()`)
+   * has no `await` to catch them — an unhandled rejection would crash the
+   * extension host. Real failures (e.g. a B4 `injectFn` throwing because the
+   * Cursor command went away) should surface via the user-facing toast in
+   * `handleOptionSelection` itself; the catch here is a last-resort guard.
+   */
   async handleMessage(raw: unknown): Promise<void> {
     if (!raw || typeof raw !== 'object') return;
     const msg = raw as WebviewMessage;
     if (msg.type === 'select') {
       if (typeof msg.optionLabel === 'string') {
-        await this.onSelect(msg.optionLabel);
+        try {
+          await this.onSelect(msg.optionLabel);
+        } catch (err) {
+          console.error('[nexpath] onSelect failed:', err);
+        }
       }
       return;
     }

--- a/src/ext-vscode/src/webview/view-provider.ts
+++ b/src/ext-vscode/src/webview/view-provider.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import { renderDecisionSessionHtml } from './html.js';
+import { handleOptionSelection } from './prompt-injection.js';
+import type { DecisionSessionPayload } from '../ipc.js';
+
+/**
+ * NexpathDecisionSessionViewProvider — M6 of M2 Branch 3.
+ *
+ * Backs the `nexpath.status` activity-bar view (declared in package.json with
+ * `type: "webview"`). Renders the decision-session UI inside a VS Code
+ * WebviewView and auto-reveals the view whenever a new advisory payload is
+ * published — matching the "user installs once, never invokes manually"
+ * UX requirement from architecture rev 2 §4 / discussion log §2 Correction 9.
+ *
+ * Lifecycle:
+ *   1. `activate()` (in `extension.ts`) constructs an instance and registers it
+ *      via `vscode.window.registerWebviewViewProvider(VIEW_ID, instance)`.
+ *   2. The first time the user clicks the activity-bar icon (or the view is
+ *      auto-revealed), VS Code calls `resolveWebviewView()` — we configure
+ *      `enableScripts`, set the initial HTML, and wire `onDidReceiveMessage`.
+ *   3. When Branch 4 wires the watcher in, on each `nexpath stop` result the
+ *      adapter calls `publishPayload(payload)`. The provider stores the
+ *      payload (so it survives the view being hidden + re-shown) and, if the
+ *      view is currently resolved, updates the HTML and calls
+ *      `webviewView.show(true)` for the auto-reveal.
+ *   4. The webview's message-passing surface is two events:
+ *        - `{ type: 'select', optionId, optionLabel }` → forward `optionLabel`
+ *          to `handleOptionSelection()` (clipboard + toast).
+ *        - `{ type: 'dismiss' }` → clear the displayed payload.
+ */
+
+export const VIEW_ID = 'nexpath.status';
+
+interface WebviewMessage {
+  type?: unknown;
+  optionId?: unknown;
+  optionLabel?: unknown;
+}
+
+export class NexpathDecisionSessionViewProvider
+  implements vscode.WebviewViewProvider
+{
+  private view: vscode.WebviewView | undefined;
+  private currentPayload: DecisionSessionPayload | null = null;
+
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    /** Inject the option-selection handler for tests. */
+    private readonly onSelect: (
+      text: string,
+    ) => Promise<void> = handleOptionSelection,
+  ) {}
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _ctx: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ): void {
+    this.view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri],
+    };
+
+    webviewView.webview.html = renderDecisionSessionHtml(this.currentPayload, {
+      cspSource: webviewView.webview.cspSource,
+    });
+
+    webviewView.webview.onDidReceiveMessage((raw: unknown) => {
+      void this.handleMessage(raw);
+    });
+
+    webviewView.onDidDispose(() => {
+      this.view = undefined;
+    });
+  }
+
+  /**
+   * Publish a new payload to the webview. If the view is currently resolved,
+   * update its HTML and auto-reveal it. If not yet resolved, just store the
+   * payload — it'll be rendered when `resolveWebviewView` next fires.
+   */
+  publishPayload(payload: DecisionSessionPayload): void {
+    this.currentPayload = payload;
+    if (!this.view) return;
+    this.view.webview.html = renderDecisionSessionHtml(payload, {
+      cspSource: this.view.webview.cspSource,
+    });
+    this.view.show(true);
+  }
+
+  /**
+   * Clear the displayed payload (e.g. after the user dismisses) and reset the
+   * webview to its empty/watching state.
+   */
+  clearPayload(): void {
+    this.currentPayload = null;
+    if (!this.view) return;
+    this.view.webview.html = renderDecisionSessionHtml(null, {
+      cspSource: this.view.webview.cspSource,
+    });
+  }
+
+  /** Visible to tests so the message-routing logic can be exercised directly. */
+  async handleMessage(raw: unknown): Promise<void> {
+    if (!raw || typeof raw !== 'object') return;
+    const msg = raw as WebviewMessage;
+    if (msg.type === 'select') {
+      if (typeof msg.optionLabel === 'string') {
+        await this.onSelect(msg.optionLabel);
+      }
+      return;
+    }
+    if (msg.type === 'dismiss') {
+      this.clearPayload();
+      return;
+    }
+  }
+
+  /** Visible to tests — current payload (null = empty state). */
+  getCurrentPayload(): DecisionSessionPayload | null {
+    return this.currentPayload;
+  }
+}

--- a/src/ext-vscode/tsconfig.json
+++ b/src/ext-vscode/tsconfig.json
@@ -3,15 +3,15 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "outDir": "./dist",
+    "outDir": "./out",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": ["ES2022"],
+    "types": ["node", "vscode"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/ext-vscode"]
+  "exclude": ["node_modules", "out", "**/*.test.ts"]
 }


### PR DESCRIPTION
 Adds the decision-session UI surface of the VS Code extension — modules
  **M6 (WebviewViewProvider)**, **M7 (HTML template)**, and **M8 (prompt
  injection)** per dev plan §3 M2 §2.2. The webview renders advisory +
  options inside Cursor / Windsurf's activity-bar panel, auto-reveals when
  a `DecisionSessionPayload` arrives, and round-trips the user's selection
  back to the host's chat input (via clipboard + toast for now; B4 will
  plug in a direct-injection primary path via the `injectFn` contract this
  branch sets up). No Layer C file is touched.

  **Stacked on M2 Branch 1** (`v0.1.3/m2/extension-skeleton`, commit
  `879ed5e`) per the dependency table in dev plan §3.0. Does NOT depend on
  M2/B2 — webview UI is parallelisable with chat-history capture.

  ## Modules covered (per dev plan §3 M2 §2.2)

  | Module | File(s) | What it does |
  |---|---|---|
  | **M6** — View provider | `src/webview/view-provider.ts` | `NexpathDecisionSessionViewProvider implements vscode.WebviewViewProvider`. `resolveWebviewView` wires enableScripts + localResourceRoots +
  initial HTML + onDidReceiveMessage + onDidDispose. `publishPayload` stores the payload, replaces HTML, and calls `webviewView.show(true)` for the auto-reveal UX matching architecture rev 2 §4 /
  discussion log §2 Correction 9. Payload survives view dispose / re-show. Message handler catches `onSelect` errors so they never become unhandled rejections (added in audit follow-up). |
  | **M7** — HTML template | `src/webview/html.ts` | Pure function `renderDecisionSessionHtml(payload, opts)` — no I/O. Returns full self-contained HTML for the webview. Two modes: empty/watching state
  (no scripts) and populated state (advisory + numbered option buttons + dismiss). CSP `default-src 'none'` with nonce-scoped scripts. All user-controlled strings HTML-escaped including attribute-breaking
   `"` (`<`/`>`/`&`/`"`/`'`). Theming via `--vscode-*` CSS variables — inherits the host's theme automatically. |
  | **M8** — Prompt injection | `src/webview/prompt-injection.ts` | `handleOptionSelection(text, deps)` with TWO paths: (1) primary — `deps.injectFn(text)` if provided and returns true; (2) fallback —
  `vscode.env.clipboard.writeText` + info toast directing user to paste. `injectFn` is the load-bearing contract for **Branch 4** to fill in per agent (see memory
  `project_b4_prompt_injection_contract.md`). |

  ## Layer C UX consistency

  After reading `src/decision-session/TtySelectFn.ts` (Layer C — DO NOT MODIFY),
  the following UX patterns from the existing TTY decision-session were
  mirrored into the webview:

  | TTY pattern | Webview behaviour |
  |---|---|
  | `Ctrl+X` opt-out (`TtySelectFn.ts:128`) | Webview keydown handler dispatches `{type: 'dismiss'}` |
  | Standard cancel | `Esc` also dispatches `{type: 'dismiss'}` |
  | Numbered options | Visible `1.` `2.` … prefixes + keys `1`–`9` dispatch select |
  | First option focus | `optionButtons[0].focus()` on render |
  | Discoverable hints | Visible `(press 1–N, or Esc / Ctrl+X to dismiss)` hint in the options header |

  **Not mirrored (intentional):** TTY's two-step "Send now / Copy to clipboard"
  sub-menu — until B4's `injectFn` lands, every path ends in clipboard
  anyway, so the two-step adds friction without value. TTY's 60s
  auto-dismiss timeout — webview is non-modal, the user can let it sit.

  ## Files

  | Path | Type | Tests |
  |---|---|---|
  | `src/ext-vscode/src/webview/view-provider.ts` | M6 | 16 |
  | `src/ext-vscode/src/webview/view-provider.test.ts` | tests | — |
  | `src/ext-vscode/src/webview/html.ts` | M7 | 19 |
  | `src/ext-vscode/src/webview/html.test.ts` | tests | — |
  | `src/ext-vscode/src/webview/prompt-injection.ts` | M8 | 10 |
  | `src/ext-vscode/src/webview/prompt-injection.test.ts` | tests | — |
  | `src/ext-vscode/src/extension.ts` (modified) | wiring | +5 tests in extension.test.ts |
  | `src/ext-vscode/src/extension.test.ts` (modified) | tests | — |
  | `src/ext-vscode/package.json` (modified) | manifest — view type `webview`, dropped `viewsWelcome` (rendered inside the webview now) | — |

  **50 new unit tests** added in this branch. Sub-package total: **75 tests**
  across 6 files (was 25 in B1).

  ## Test plan

  ### Automated

  ```bash
  # Root + sub-package typecheck
  npx tsc --noEmit                          # root
  (cd src/ext-vscode && npx tsc --noEmit)   # sub-package — both EXIT=0

  # Sub-package tests in isolation
  (cd src/ext-vscode && npx vitest run)
  # expected: 75/75 pass across 6 test files

  # Full root test suite (vitest picks up sub-package via vi.mock('vscode'))
  npm test
  # expected: 1901 passing + 18 pre-existing TtySelectFn carry-forward

  # Extension bundle still builds
  (cd src/ext-vscode && npm run build)
  # expected: out/extension.js produced (~12.3 KB — was 3.4 KB in B1)

  Manual

  End-to-end against a real Cursor / Windsurf is the Branch 5 smoke-test
  gate, not this PR. For this branch, manual verification is unit-driven
  - esbuild bundle inspection.
  
  To eyeball the webview HTML output:

  cd src/ext-vscode
  node --input-type=module -e "
  import { renderDecisionSessionHtml } from './out/webview/html.js';
  console.log(renderDecisionSessionHtml(
    { advisory: 'Consider clarifying scope.', options: [
        { id: 'a', label: 'Refine the request' },
        { id: 'b', label: 'Proceed with caution' },
    ]},
    { cspSource: 'vscode-resource:test' }
  ));
  "
  # expected: full HTML printed — advisory + 2 numbered buttons + dismiss button + keyboard hint
