### PR TITLE
Telemetry install upgraded for nexpath install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,31 +132,65 @@ npm install
 npm run build
 npm link
 
-# Register with your coding agent and verify
-nexpath install --yes
+# Run the interactive installer
+nexpath install
+
+# Verify
 nexpath status
 ```
 
-### Environment Variables
+The installer walks through three steps:
 
-set it per project using a `.env` file:
+1. **OpenAI API Key** — Enter your key once. It is stored securely in your OS keychain
+   (macOS Keychain on macOS, Secret Service on Linux, Credential Manager on Windows) with an
+   encrypted-file fallback at `~/.nexpath/config.json` for systems without a keychain.
+
+2. **Telemetry consent** — Choose whether anonymous usage events leave your machine. Defaults
+   to enabled. You can change this anytime with `nexpath config set telemetry.enabled false`.
+
+3. **Agent registration** — Auto-registers the advisory hook with any detected AI coding
+   agents on your system.
+
+For non-interactive setups (CI, scripted installs):
 
 ```bash
-cd /path/to/your-project
-echo 'OPENAI_API_KEY=sk-your-key-here' > .env
-claude
+nexpath install --yes
 ```
 
-> This will directly start Claude Code using your project environment.
+`--yes` skips the API key and telemetry prompts (assumes "no API key change, telemetry on")
+and auto-confirms agent registration.
+
+### API Key Resolution Order
+
+Nexpath looks for your OpenAI API key in this order, using the first valid source:
+
+1. `process.env.OPENAI_API_KEY` — shell environment / CI
+2. Project `.env` file (`OPENAI_API_KEY=sk-...`)
+3. OS keychain (service `nexpath`, account `openai_api_key`)
+4. Fallback file at `~/.nexpath/config.json` (mode 0600)
 
 Without an API key, Nexpath still functions — it falls back to static pinch labels and skips
 LLM cross-confirmation. The local classifier and decision session UI work fully offline.
 
-To uninstall:
+### Managing Your API Key
+
+| Command | Purpose |
+|---|---|
+| `nexpath config set-api-key` | Prompt for a new key and store it in the keychain (or fallback file) |
+| `nexpath config rotate-api-key` | Replace the existing key (errors if none stored; asks confirmation before overwrite) |
+| `nexpath config show-key-source` | Print which layer is supplying the key: `env`, `dotenv`, `keychain`, `file`, or `none` |
+| `nexpath config remove-api-key` | Clear the stored key from the keychain and the fallback file |
+
+### Uninstalling
 
 ```bash
-nexpath uninstall
+nexpath uninstall          # interactive — prompts before removing the API key
+nexpath uninstall --yes    # auto-removes the API key without prompting
 ```
+
+Removes the MCP registration from all detected agents and offers to clear the stored API key.
+Local prompt history at `~/.nexpath/prompt-store.db` is retained — delete it explicitly with
+`nexpath store delete`.
 
 ---
 
@@ -193,8 +227,10 @@ detected stage).
 - **Automatic secret redaction** — API keys (`sk-*`, `ghp_*`, `ghu_*`), bearer tokens, and
   PEM blocks are automatically stripped from prompts before storage. If a prompt contains
   sensitive credentials, they never reach the database.
-- **First-run disclosure** — on the very first prompt capture, Nexpath prints a privacy banner
-  explaining exactly what it stores and how to opt out
+- **Install-time consent** — During `nexpath install`, telemetry is presented as a separate
+  consent step (defaults to enabled). Local prompt capture and remote telemetry are independent;
+  you can disable either at any time via `nexpath store disable` or
+  `nexpath config set telemetry.enabled false`.
 
 ### Opting Out and Data Control
 
@@ -208,6 +244,53 @@ nexpath store prune --older-than 30d
 # Delete all stored prompts permanently
 nexpath store delete -y
 ```
+
+---
+
+## Troubleshooting
+
+### Headless Linux (no keychain backend)
+
+If you run Nexpath on a Linux box without a desktop session (servers, containers, WSL without
+keyring), the OS keychain is unavailable. Nexpath transparently falls back to an
+encrypted-mode-0600 file at `~/.nexpath/config.json`. No manual setup needed.
+
+```bash
+nexpath config show-key-source   # → file (fallback active)
+```
+
+### Rotating Your API Key
+
+```bash
+nexpath config rotate-api-key
+```
+
+Requires a key to already be present. The command shows where the existing key lives, asks
+for an explicit confirmation, then prompts for the new key. Cancel either prompt to keep the
+existing key untouched.
+
+### Where Is My API Key Stored?
+
+| Platform | Default location | Inspect with |
+|---|---|---|
+| macOS | Keychain | Keychain Access.app → search "nexpath" |
+| Linux | Secret Service (libsecret) | `secret-tool lookup service nexpath account openai_api_key` |
+| Windows | Credential Manager | Control Panel → Credential Manager → Web Credentials |
+| Fallback (any OS) | `~/.nexpath/config.json` (mode 0600) | `cat ~/.nexpath/config.json` |
+
+Use `nexpath config show-key-source` to confirm which layer is currently active.
+
+### Diagnostic Logs
+
+Nexpath writes events to `~/.nexpath/nexpath.log`. Tail recent activity with:
+
+```bash
+nexpath log --tail 100
+nexpath log --level error
+```
+
+Telemetry events are written to `~/.nexpath/telemetry.jsonl`. Use
+`nexpath config set telemetry.enabled false` to disable.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "latest",
         "@xenova/transformers": "^2.17.2",
         "commander": "^12",
+        "cross-keychain": "^1.1.0",
         "dotenv": "^17.4.2",
         "natural": "^8.1.1",
         "openai": "^6.34.0",
@@ -549,6 +550,340 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -603,6 +938,241 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1349,6 +1919,30 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/apparatus": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
@@ -1629,6 +2223,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1644,6 +2244,15 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
@@ -1761,6 +2370,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-keychain": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cross-keychain/-/cross-keychain-1.1.0.tgz",
+      "integrity": "sha512-244DWNdGepLKD5vEn3reZqwzZFiE/LD4U+XV9IaXQbtIXKvQkf0VkRaOj/9vPYauPdR12PSGB3U0cE7jJi3WTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^7.8.6",
+        "meow": "^14.0.0"
+      },
+      "bin": {
+        "cross-keychain": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring": "^1.2.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1874,6 +2502,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2410,6 +3044,15 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2520,6 +3163,18 @@
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "license": "MIT"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -2688,6 +3343,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3600,6 +4264,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -3744,6 +4420,32 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4645,6 +5347,20 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4658,6 +5374,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@modelcontextprotocol/sdk": "latest",
     "@xenova/transformers": "^2.17.2",
     "commander": "^12",
+    "cross-keychain": "^1.1.0",
     "dotenv": "^17.4.2",
     "natural": "^8.1.1",
     "openai": "^6.34.0",

--- a/src/cli/commands/auto-resolver.test.ts
+++ b/src/cli/commands/auto-resolver.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+
+vi.mock('../../config/ApiKeyResolver.js', () => ({
+  resolveOpenAIKey: vi.fn().mockResolvedValue(null),
+  getKeySource:     vi.fn().mockResolvedValue('none'),
+}));
+
+vi.mock('../../telemetry/index.js', () => ({
+  writeTelemetry: vi.fn(),
+  TELEMETRY_PATH: '/mock/telemetry.jsonl',
+}));
+
+import * as resolver from '../../config/ApiKeyResolver.js';
+
+let savedEnvKey: string | undefined;
+
+beforeEach(() => {
+  savedEnvKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  vi.mocked(resolver.resolveOpenAIKey).mockClear();
+  vi.mocked(resolver.getKeySource).mockClear();
+});
+
+afterEach(() => {
+  if (savedEnvKey === undefined) delete process.env.OPENAI_API_KEY;
+  else                            process.env.OPENAI_API_KEY = savedEnvKey;
+  vi.restoreAllMocks();
+});
+
+async function runAutoCommand(args: string[]): Promise<void> {
+  const { Command } = await import('commander');
+  const { registerAutoCommand } = await import('./auto.js');
+  const program = new Command();
+  program.exitOverride();
+  registerAutoCommand(program);
+
+  const originalStdin = process.stdin;
+  const stream = new PassThrough();
+  (stream as unknown as Record<string, unknown>).isTTY = true;
+  Object.defineProperty(process, 'stdin', { value: stream, writable: true, configurable: true });
+
+  try {
+    await program.parseAsync(['node', 'nexpath', 'auto', ...args]);
+  } catch {
+    /* exitOverride may throw — fine */
+  } finally {
+    Object.defineProperty(process, 'stdin', { value: originalStdin, writable: true, configurable: true });
+  }
+}
+
+describe('auto.ts → ApiKeyResolver wiring', () => {
+  it('calls resolveOpenAIKey with the supplied --project path', async () => {
+    await runAutoCommand(['--project', '/explicit/project', '--db', ':memory:', 'ok']);
+    expect(resolver.resolveOpenAIKey).toHaveBeenCalledTimes(1);
+    expect(resolver.resolveOpenAIKey).toHaveBeenCalledWith('/explicit/project');
+  });
+
+  it('calls getKeySource with the same --project path (for the env_load debug log)', async () => {
+    await runAutoCommand(['--project', '/explicit/project', '--db', ':memory:', 'ok']);
+    expect(resolver.getKeySource).toHaveBeenCalledWith('/explicit/project');
+  });
+
+  it('defaults the project to process.cwd() when --project is not supplied', async () => {
+    await runAutoCommand(['--db', ':memory:', 'ok']);
+    expect(resolver.resolveOpenAIKey).toHaveBeenCalledWith(process.cwd());
+  });
+
+  it('auto continues without crashing when the resolver returns null (no key source found)', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce(null);
+    await expect(runAutoCommand(['--db', ':memory:', 'ok'])).resolves.toBeUndefined();
+  });
+
+  it('auto continues when resolveOpenAIKey resolves with a valid key', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce('sk-abcdefghij1234567890abcdefghij');
+    await expect(runAutoCommand(['--db', ':memory:', 'ok'])).resolves.toBeUndefined();
+    expect(resolver.resolveOpenAIKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolver is awaited before logger initialisation downstream', async () => {
+    let resolveResolver!: (v: string | null) => void;
+    vi.mocked(resolver.resolveOpenAIKey).mockReturnValueOnce(
+      new Promise<string | null>(r => { resolveResolver = r; }),
+    );
+    const runPromise = runAutoCommand(['--db', ':memory:', 'ok']);
+    await new Promise(r => setTimeout(r, 50));
+    expect(resolver.getKeySource).not.toHaveBeenCalled();
+    resolveResolver(null);
+    await runPromise;
+    expect(resolver.getKeySource).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/auto-resolver.test.ts
+++ b/src/cli/commands/auto-resolver.test.ts
@@ -106,6 +106,77 @@ describe('auto.ts → ApiKeyResolver wiring', () => {
     expect(warnEvents).not.toContain('openai_api_key_missing');
   });
 
+  it('env_load debug line carries the plan-mandated fields: cwd, project, keySource, keyFound', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce(null);
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+
+    const logger = await import('../../logger.js');
+    const debugSpy = vi.spyOn(logger.logger, 'debug');
+
+    await runAutoCommand(['--project', '/explicit/project', '--db', ':memory:', 'ok']);
+
+    const envLoadCall = debugSpy.mock.calls.find(c => c[0] === 'env_load');
+    expect(envLoadCall).toBeDefined();
+    const payload = envLoadCall![1] as Record<string, unknown>;
+    expect(Object.keys(payload).sort()).toEqual(['cwd', 'keyFound', 'keySource', 'project']);
+    expect(payload.project).toBe('/explicit/project');
+    expect(payload.keySource).toBe('keychain');
+    expect(typeof payload.cwd).toBe('string');
+    expect(typeof payload.keyFound).toBe('boolean');
+  });
+
+  it('keyFound reflects process.env.OPENAI_API_KEY presence after the resolver runs', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockImplementationOnce(async () => {
+      process.env.OPENAI_API_KEY = 'sk-abcdefghij1234567890abcdefghij';
+      return process.env.OPENAI_API_KEY;
+    });
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('env');
+
+    const logger = await import('../../logger.js');
+    const debugSpy = vi.spyOn(logger.logger, 'debug');
+
+    await runAutoCommand(['--db', ':memory:', 'ok']);
+
+    const envLoadCall = debugSpy.mock.calls.find(c => c[0] === 'env_load');
+    expect(envLoadCall).toBeDefined();
+    const payload = envLoadCall![1] as Record<string, unknown>;
+    expect(payload.keyFound).toBe(true);
+    expect(payload.keySource).toBe('env');
+  });
+
+  it('env_load debug payload no longer carries the removed envPath / envExists fields (regression guard)', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce(null);
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+
+    const logger = await import('../../logger.js');
+    const debugSpy = vi.spyOn(logger.logger, 'debug');
+
+    await runAutoCommand(['--db', ':memory:', 'ok']);
+
+    const envLoadCall = debugSpy.mock.calls.find(c => c[0] === 'env_load');
+    expect(envLoadCall).toBeDefined();
+    const payload = envLoadCall![1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('envPath');
+    expect(payload).not.toHaveProperty('envExists');
+  });
+
+  it('warn line "openai_api_key_missing" carries project + actionable hint', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce(null);
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+
+    const logger = await import('../../logger.js');
+    const warnSpy = vi.spyOn(logger.logger, 'warn');
+
+    await runAutoCommand(['--project', '/explicit/project', '--db', ':memory:', 'ok']);
+
+    const warnCall = warnSpy.mock.calls.find(c => c[0] === 'openai_api_key_missing');
+    expect(warnCall).toBeDefined();
+    const payload = warnCall![1] as Record<string, unknown>;
+    expect(payload.project).toBe('/explicit/project');
+    expect(typeof payload.actionable).toBe('string');
+    expect((payload.actionable as string).length).toBeGreaterThan(0);
+  });
+
   it('resolver is awaited before logger initialisation downstream', async () => {
     let resolveResolver!: (v: string | null) => void;
     vi.mocked(resolver.resolveOpenAIKey).mockReturnValueOnce(

--- a/src/cli/commands/auto-resolver.test.ts
+++ b/src/cli/commands/auto-resolver.test.ts
@@ -77,6 +77,35 @@ describe('auto.ts → ApiKeyResolver wiring', () => {
     expect(resolver.resolveOpenAIKey).toHaveBeenCalledTimes(1);
   });
 
+  it('logs a warn line "openai_api_key_missing" when no source produces a key', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockResolvedValueOnce(null);
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+
+    const logger = await import('../../logger.js');
+    const warnSpy = vi.spyOn(logger.logger, 'warn');
+
+    await runAutoCommand(['--db', ':memory:', 'ok']);
+
+    const warnEvents = warnSpy.mock.calls.map(c => c[0]);
+    expect(warnEvents).toContain('openai_api_key_missing');
+  });
+
+  it('does NOT log "openai_api_key_missing" when the resolver promotes a valid key', async () => {
+    vi.mocked(resolver.resolveOpenAIKey).mockImplementationOnce(async () => {
+      process.env.OPENAI_API_KEY = 'sk-abcdefghij1234567890abcdefghij';
+      return process.env.OPENAI_API_KEY;
+    });
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('env');
+
+    const logger = await import('../../logger.js');
+    const warnSpy = vi.spyOn(logger.logger, 'warn');
+
+    await runAutoCommand(['--db', ':memory:', 'ok']);
+
+    const warnEvents = warnSpy.mock.calls.map(c => c[0]);
+    expect(warnEvents).not.toContain('openai_api_key_missing');
+  });
+
   it('resolver is awaited before logger initialisation downstream', async () => {
     let resolveResolver!: (v: string | null) => void;
     vi.mocked(resolver.resolveOpenAIKey).mockReturnValueOnce(

--- a/src/cli/commands/auto.test.ts
+++ b/src/cli/commands/auto.test.ts
@@ -1373,28 +1373,28 @@ describe('runAuto — telemetry events', () => {
   it('emits prompt_received on every runAuto call', async () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-recv' }), store);
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-recv', 'prompt_received', expect.objectContaining({ promptCount: expect.any(Number) }),
+      '/test/tel-recv', 'prompt_received', expect.objectContaining({ promptCount: expect.any(Number) }), expect.anything(),
     );
   });
 
   it('emits prompt_classified after stage 1 classification', async () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-class' }), store);
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-class', 'prompt_classified', expect.objectContaining({ stage: expect.any(String), confidence: expect.any(Number) }),
+      '/test/tel-class', 'prompt_classified', expect.objectContaining({ stage: expect.any(String), confidence: expect.any(Number) }), expect.anything(),
     );
   });
 
   it('emits absence_flags_detected after absence detection', async () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-abs' }), store);
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-abs', 'absence_flags_detected', expect.objectContaining({ newFlagsCount: expect.any(Number), totalFlagsCount: expect.any(Number) }),
+      '/test/tel-abs', 'absence_flags_detected', expect.objectContaining({ newFlagsCount: expect.any(Number), totalFlagsCount: expect.any(Number) }), expect.anything(),
     );
   });
 
   it('emits advisory_min_prompts_blocked when promptCount < MIN_PROMPTS_BEFORE_ADVISORY', async () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-min' }), store);
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-min', 'advisory_min_prompts_blocked', expect.objectContaining({ promptCount: 1, minRequired: 3 }),
+      '/test/tel-min', 'advisory_min_prompts_blocked', expect.objectContaining({ promptCount: 1, minRequired: 3 }), expect.anything(),
     );
   });
 
@@ -1433,7 +1433,7 @@ describe('runAuto — telemetry events', () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-freq' }), store, makeMockOpenAI(FIRE_YES_RESPONSE));
 
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-freq', 'advisory_freq_blocked', expect.objectContaining({ freq: 'off' }),
+      '/test/tel-freq', 'advisory_freq_blocked', expect.objectContaining({ freq: 'off' }), expect.anything(),
     );
   });
 
@@ -1451,7 +1451,7 @@ describe('runAuto — telemetry events', () => {
     await runAuto(makeInput({ projectRoot: '/test/tel-cap' }), store, makeMockOpenAI(FIRE_YES_RESPONSE));
 
     expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-      '/test/tel-cap', 'advisory_cap_blocked', expect.objectContaining({ advisoryCount: 5, advisoryCap: 5 }),
+      '/test/tel-cap', 'advisory_cap_blocked', expect.objectContaining({ advisoryCount: 5, advisoryCap: 5 }), expect.anything(),
     );
   });
 
@@ -1464,7 +1464,7 @@ describe('runAuto — telemetry events', () => {
 
     if (result.outcome === 'pending') {
       expect(vi.mocked(writeTelemetry)).toHaveBeenCalledWith(
-        '/test/tel-pending', 'pipeline_advisory_pending', expect.objectContaining({ pinchLabel: 'Hold up.' }),
+        '/test/tel-pending', 'pipeline_advisory_pending', expect.objectContaining({ pinchLabel: 'Hold up.' }), expect.anything(),
       );
     }
   });

--- a/src/cli/commands/auto.test.ts
+++ b/src/cli/commands/auto.test.ts
@@ -1485,4 +1485,75 @@ describe('runAuto — telemetry events', () => {
       expect(s2Call[2]).toEqual(expect.objectContaining({ confirmed: expect.any(Boolean) }));
     }
   });
+
+  // ── Phase 4 — pipeline_advisory_pending enriched payload (Items B + H + J) ──
+
+  it('pipeline_advisory_pending carries advisoryCountInSession, decisionSessionCountInProject, recentPrompts', async () => {
+    const { SessionStateManager } = await import('../../classifier/SessionStateManager.js');
+    const mgr = SessionStateManager.load(store, '/test/tel-rich');
+    mgr.addAbsenceFlag(store, { signalKey: 'test_creation', stage: 'implementation', raisedAtIndex: 5, cooldownUntil: 100 });
+
+    // Run a couple prior prompts so promptHistory + counters have content.
+    for (let i = 0; i < 2; i++) {
+      await runAuto(makeInput({ projectRoot: '/test/tel-rich' }), store);
+    }
+    vi.mocked(writeTelemetry).mockClear();
+    await runAuto(makeInput({ projectRoot: '/test/tel-rich' }), store, makeMockOpenAI(FIRE_YES_RESPONSE, 'Hold up.'));
+
+    const pendingCall = vi.mocked(writeTelemetry).mock.calls.find(
+      ([, event]) => event === 'pipeline_advisory_pending',
+    );
+    if (pendingCall) {
+      const payload = pendingCall[2] as Record<string, unknown>;
+      expect(payload).toHaveProperty('advisoryCountInSession');
+      expect(typeof payload['advisoryCountInSession']).toBe('number');
+      expect(payload).toHaveProperty('decisionSessionCountInProject');
+      expect(typeof payload['decisionSessionCountInProject']).toBe('number');
+      expect(payload).toHaveProperty('recentPrompts');
+      expect(Array.isArray(payload['recentPrompts'])).toBe(true);
+    }
+  });
+
+  it('recentPrompts in pipeline_advisory_pending NEVER contains the text field (PII guarantee)', async () => {
+    const { SessionStateManager } = await import('../../classifier/SessionStateManager.js');
+    const mgr = SessionStateManager.load(store, '/test/tel-pii');
+    mgr.addAbsenceFlag(store, { signalKey: 'test_creation', stage: 'implementation', raisedAtIndex: 5, cooldownUntil: 100 });
+
+    for (let i = 0; i < 2; i++) {
+      await runAuto(makeInput({ promptText: `prior prompt ${i}`, projectRoot: '/test/tel-pii' }), store);
+    }
+    vi.mocked(writeTelemetry).mockClear();
+    await runAuto(makeInput({ promptText: 'sensitive prompt text', projectRoot: '/test/tel-pii' }), store, makeMockOpenAI(FIRE_YES_RESPONSE, 'Hold up.'));
+
+    const pendingCall = vi.mocked(writeTelemetry).mock.calls.find(
+      ([, event]) => event === 'pipeline_advisory_pending',
+    );
+    if (pendingCall) {
+      const payload = pendingCall[2] as { recentPrompts: Array<Record<string, unknown>> };
+      for (const entry of payload.recentPrompts) {
+        expect(entry).not.toHaveProperty('text');
+      }
+    }
+  });
+
+  it('recentPrompts is capped at 5 entries even after many prior prompts', async () => {
+    const { SessionStateManager } = await import('../../classifier/SessionStateManager.js');
+    const mgr = SessionStateManager.load(store, '/test/tel-cap5');
+    mgr.addAbsenceFlag(store, { signalKey: 'test_creation', stage: 'implementation', raisedAtIndex: 5, cooldownUntil: 100 });
+
+    // Build up promptHistory with 7+ prompts.
+    for (let i = 0; i < 7; i++) {
+      await runAuto(makeInput({ promptText: `prompt ${i}`, projectRoot: '/test/tel-cap5' }), store);
+    }
+    vi.mocked(writeTelemetry).mockClear();
+    await runAuto(makeInput({ promptText: 'fire', projectRoot: '/test/tel-cap5' }), store, makeMockOpenAI(FIRE_YES_RESPONSE, 'Hold up.'));
+
+    const pendingCall = vi.mocked(writeTelemetry).mock.calls.find(
+      ([, event]) => event === 'pipeline_advisory_pending',
+    );
+    if (pendingCall) {
+      const payload = pendingCall[2] as { recentPrompts: unknown[] };
+      expect(payload.recentPrompts.length).toBeLessThanOrEqual(5);
+    }
+  });
 });

--- a/src/cli/commands/auto.ts
+++ b/src/cli/commands/auto.ts
@@ -27,6 +27,7 @@ import { writeHookStats } from '../../store/hook-stats.js';
 import { upsertPendingAdvisory } from '../../store/pending-advisories.js';
 import { insertSkippedSession } from '../../store/skipped-sessions.js';
 import { writeTelemetry } from '../../telemetry/index.js';
+import { recentPromptMetadata } from '../../telemetry/recent-prompts.js';
 
 /**
  * nexpath auto — orchestration command (per decision-session-ux-research.md).
@@ -359,7 +360,17 @@ export async function runAuto(
     generatedL2: generatedOptions?.l2,
     generatedL3: generatedOptions?.l3,
   });
-  writeTelemetry(input.projectRoot, 'pipeline_advisory_pending', { flagType, stage: mgr.current.currentStage, pinchLabel }, store);
+  writeTelemetry(input.projectRoot, 'pipeline_advisory_pending', {
+    flagType,
+    stage:                         mgr.current.currentStage,
+    pinchLabel,
+    // Item H — session-scoped advisory counter (from session state).
+    advisoryCountInSession:        mgr.current.advisoryCount ?? 0,
+    // Item J — project-scoped decision-session counter (from projects table).
+    decisionSessionCountInProject: getProject(store, input.projectRoot)?.decisionSessionCount ?? 0,
+    // Item B — last-5 prompt metadata, PII-safe (no text).
+    recentPrompts:                 recentPromptMetadata(mgr.current.promptHistory),
+  }, store);
   mgr.markAdvisoryFired(store);
 
   logger.info('pipeline_outcome', { outcome: 'pending', pinchLabel });

--- a/src/cli/commands/auto.ts
+++ b/src/cli/commands/auto.ts
@@ -138,12 +138,12 @@ export async function runAuto(
   const mgr = SessionStateManager.load(store, input.projectRoot);
   const prevStage: Stage = mgr.current.currentStage;
   logger.debug('session_loaded', { promptCount: mgr.current.promptCount, stage: prevStage, project: input.projectRoot });
-  writeTelemetry(input.projectRoot, 'prompt_received', { promptCount: mgr.current.promptCount });
+  writeTelemetry(input.projectRoot, 'prompt_received', { promptCount: mgr.current.promptCount }, store);
 
   // ── 2. Stage 1 classifier ────────────────────────────────────────────────────
   const classification = await classifyPrompt(input.promptText);
   logger.debug('stage1_result', { classified: classification.stage, confidence: classification.confidence });
-  writeTelemetry(input.projectRoot, 'prompt_classified', { stage: classification.stage, confidence: classification.confidence });
+  writeTelemetry(input.projectRoot, 'prompt_classified', { stage: classification.stage, confidence: classification.confidence }, store);
 
   // ── 2.5. LLM profile classification — async, before processPrompt ────────────
   if (isProfileStale(mgr.current.profile, mgr.current.promptCount) &&
@@ -163,7 +163,7 @@ export async function runAuto(
       precisionOrdinal:   updatedProfile.precisionOrdinal,
       playfulnessOrdinal: updatedProfile.playfulnessOrdinal,
       computedAt:         updatedProfile.computedAt,
-    });
+    }, store);
   }
 
   // ── 3. Process prompt → updates state (stage, history, counters) ─────────────
@@ -192,11 +192,11 @@ export async function runAuto(
     newFlagsCount:   newFlags.length,
     totalFlagsCount: mgr.current.absenceFlags.length,
     flagKeys:        newFlags.map((f) => f.signalKey),
-  });
+  }, store);
 
   // ── 4.5. Minimum prompt guard ────────────────────────────────────────────────
   if (mgr.current.promptCount < MIN_PROMPTS_BEFORE_ADVISORY) {
-    writeTelemetry(input.projectRoot, 'advisory_min_prompts_blocked', { promptCount: mgr.current.promptCount, minRequired: MIN_PROMPTS_BEFORE_ADVISORY });
+    writeTelemetry(input.projectRoot, 'advisory_min_prompts_blocked', { promptCount: mgr.current.promptCount, minRequired: MIN_PROMPTS_BEFORE_ADVISORY }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'min_prompts_not_reached' });
     return { outcome: 'no_action' };
   }
@@ -210,7 +210,7 @@ export async function runAuto(
   logger.debug('should_fire', { flagType: flagType ?? null });
 
   if (!flagType) {
-    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'no_flag' });
+    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'no_flag' }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'no_flag' });
     return { outcome: 'no_action' };
   }
@@ -220,7 +220,7 @@ export async function runAuto(
   const alreadyFired = mgr.hasFiredDecisionSession(firedKey);
   logger.debug('dedup', { firedKey, alreadyFired });
   if (alreadyFired) {
-    writeTelemetry(input.projectRoot, 'advisory_dedup_blocked', { firedKey });
+    writeTelemetry(input.projectRoot, 'advisory_dedup_blocked', { firedKey }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'already_fired', firedKey });
     return { outcome: 'no_action' };
   }
@@ -232,17 +232,17 @@ export async function runAuto(
     'every_event';
 
   if (freq === 'off') {
-    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType });
+    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'freq_off' });
     return { outcome: 'no_action' };
   }
   if (freq === 'major_only' && flagType !== 'stage_transition') {
-    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType });
+    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'freq_major_only', flagType });
     return { outcome: 'no_action' };
   }
   if (freq === 'once_per_session' && mgr.current.firedDecisionSessions.length > 0) {
-    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType });
+    writeTelemetry(input.projectRoot, 'advisory_freq_blocked', { freq, flagType }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'freq_once_per_session' });
     return { outcome: 'no_action' };
   }
@@ -254,7 +254,7 @@ export async function runAuto(
       promptCount:       mgr.current.promptCount,
       lastAdvisoryAt:    lastAdvisory,
       cooldownRemaining: POST_ADVISORY_COOLDOWN - (mgr.current.promptCount - lastAdvisory),
-    });
+    }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'post_advisory_cooldown', promptsSinceLast: mgr.current.promptCount - lastAdvisory });
     return { outcome: 'no_action' };
   }
@@ -274,7 +274,7 @@ export async function runAuto(
       levelReached:         0,
       skippedAtPromptCount: mgr.current.promptCount,
     });
-    writeTelemetry(input.projectRoot, 'advisory_cap_blocked', { advisoryCount, advisoryCap });
+    writeTelemetry(input.projectRoot, 'advisory_cap_blocked', { advisoryCount, advisoryCap }, store);
     logger.info('pipeline_outcome', {
       outcome: 'no_action',
       reason:  'session_cap_reached',
@@ -296,16 +296,16 @@ export async function runAuto(
   try {
     stage2Output = await runStage2(stage2Input, openai);
     logger.debug('stage2_result', { fire: stage2Output.fire_decision_session, confidence: stage2Output.stage_confidence, reason: stage2Output.reason });
-    writeTelemetry(input.projectRoot, 'stage2_evaluated', { flagType, confirmed: stage2Output.fire_decision_session });
+    writeTelemetry(input.projectRoot, 'stage2_evaluated', { flagType, confirmed: stage2Output.fire_decision_session }, store);
   } catch (err) {
     logger.warn('stage2_error', { ...extractApiError(err, 'openai'), stage: mgr.current.currentStage });
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'stage2_error' });
-    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'stage2_error' });
+    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'stage2_error' }, store);
     return { outcome: 'no_action' };
   }
 
   if (!stage2Output.fire_decision_session) {
-    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'stage2_declined' });
+    writeTelemetry(input.projectRoot, 'pipeline_no_action', { reason: 'stage2_declined' }, store);
     logger.info('pipeline_outcome', { outcome: 'no_action', reason: 'stage2_declined', stage2Confidence: stage2Output.stage_confidence });
     return { outcome: 'no_action' };
   }
@@ -359,7 +359,7 @@ export async function runAuto(
     generatedL2: generatedOptions?.l2,
     generatedL3: generatedOptions?.l3,
   });
-  writeTelemetry(input.projectRoot, 'pipeline_advisory_pending', { flagType, stage: mgr.current.currentStage, pinchLabel });
+  writeTelemetry(input.projectRoot, 'pipeline_advisory_pending', { flagType, stage: mgr.current.currentStage, pinchLabel }, store);
   mgr.markAdvisoryFired(store);
 
   logger.info('pipeline_outcome', { outcome: 'pending', pinchLabel });

--- a/src/cli/commands/auto.ts
+++ b/src/cli/commands/auto.ts
@@ -456,12 +456,25 @@ export function registerAutoCommand(program: import('commander').Command): void 
 
       // Diagnostic: log the source layer that produced the key so a missing
       // key (Stage-2 failure) can be traced to the actual fallback chain.
+      const keySource = await getKeySource(opts.project);
+      const keyFound  = !!process.env['OPENAI_API_KEY'];
       logger.debug('env_load', {
         cwd:       process.cwd(),
         project:   opts.project,
-        keySource: await getKeySource(opts.project),
-        keyFound:  !!process.env['OPENAI_API_KEY'],
+        keySource,
+        keyFound,
       });
+
+      // Surface a single visible warn line when no source produced a key. We
+      // do NOT exit here — Stage-1-only hook calls (prompt capture, blocking
+      // gates, low-confidence classifications) don't need the key and should
+      // still run. Stage-2 paths surface a richer OpenAI error if they fire.
+      if (!keyFound) {
+        logger.warn('openai_api_key_missing', {
+          project:    opts.project,
+          actionable: 'Set OPENAI_API_KEY in the shell, in the project\'s .env file, or via the OS keychain — Stage 2 calls will fail until a key is configured.',
+        });
+      }
 
       try {
         const result = await runAuto(

--- a/src/cli/commands/auto.ts
+++ b/src/cli/commands/auto.ts
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { readFileSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
-import { config as loadDotenv } from 'dotenv';
+import { basename, join } from 'node:path';
+import { resolveOpenAIKey, getKeySource } from '../../config/ApiKeyResolver.js';
 import type { Store } from '../../store/db.js';
 import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
 import { classifyPrompt } from '../../classifier/PromptClassifier.js';
@@ -442,23 +442,24 @@ export function registerAutoCommand(program: import('commander').Command): void 
         process.exit(1);
       }
 
-      // Load project .env so OPENAI_API_KEY is available for Stage 2 calls.
-      // Uses override:true so the project key always wins over any ambient env var.
-      const envPath = join(opts.project, '.env');
-      loadDotenv({ path: envPath, override: true });
+      // Resolve OPENAI_API_KEY through the 4-layer chain (env → project .env →
+      // OS keychain → 0600 fallback file). The resolver promotes the first
+      // valid hit into process.env so downstream OpenAI() constructors pick it
+      // up transparently. Order shift from the prior dotenv-with-override
+      // behaviour: a pre-set env var now WINS over project .env.
+      await resolveOpenAIKey(opts.project);
 
       const store = await openStore(opts.db);
       // Initialise logger — level from config key, then NEXPATH_LOG_LEVEL env var
       const logLevel = getConfig(store.db, 'log_level') as LogLevel | undefined;
       initLogger('auto', logLevel);
 
-      // Diagnostic: log env resolution details so CWD mismatches are visible in the log
-      // instead of silently producing a missing-credentials error in Stage 2.
+      // Diagnostic: log the source layer that produced the key so a missing
+      // key (Stage-2 failure) can be traced to the actual fallback chain.
       logger.debug('env_load', {
-        cwd:      process.cwd(),
-        project:  opts.project,
-        envPath,
-        envExists: existsSync(envPath),
+        cwd:       process.cwd(),
+        project:   opts.project,
+        keySource: await getKeySource(opts.project),
         keyFound:  !!process.env['OPENAI_API_KEY'],
       });
 

--- a/src/cli/commands/config-apikey.test.ts
+++ b/src/cli/commands/config-apikey.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../config/ApiKeyResolver.js', () => ({
+  storeApiKey:    vi.fn(),
+  removeApiKey:   vi.fn(),
+  getKeySource:   vi.fn(),
+  isValidApiKey:  (key: string) => /^sk-[A-Za-z0-9_-]{20,}$/.test(key),
+}));
+
+import {
+  configSetApiKeyAction,
+  configRotateApiKeyAction,
+  configShowKeySourceAction,
+  configRemoveApiKeyAction,
+} from './config.js';
+import * as resolver from '../../config/ApiKeyResolver.js';
+
+function captureOutput(): { lines: string[]; print: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, print: (l) => lines.push(l) };
+}
+
+const VALID_KEY = 'sk-abcdefghij1234567890abcdefghij';
+
+beforeEach(() => {
+  vi.mocked(resolver.storeApiKey).mockReset().mockResolvedValue({ source: 'keychain' });
+  vi.mocked(resolver.removeApiKey).mockReset().mockResolvedValue(undefined);
+  vi.mocked(resolver.getKeySource).mockReset().mockResolvedValue('none');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = 0;
+});
+
+// ── configSetApiKeyAction ────────────────────────────────────────────────────
+
+describe('configSetApiKeyAction', () => {
+  it('prompts, validates the key, calls storeApiKey, and prints the storage source', async () => {
+    const { lines, print } = captureOutput();
+    await configSetApiKeyAction({
+      output:     print,
+      passwordFn: async () => VALID_KEY,
+    });
+    expect(resolver.storeApiKey).toHaveBeenCalledWith(VALID_KEY);
+    expect(lines.join('\n')).toContain('API key stored in keychain');
+  });
+
+  it('reports file fallback when storeApiKey returns source="file"', async () => {
+    vi.mocked(resolver.storeApiKey).mockResolvedValueOnce({ source: 'file' });
+    const { lines, print } = captureOutput();
+    await configSetApiKeyAction({
+      output:     print,
+      passwordFn: async () => VALID_KEY,
+    });
+    expect(lines.join('\n')).toContain('API key stored in file');
+  });
+
+  it('prints "Cancelled" and skips storeApiKey when user cancels the prompt', async () => {
+    const { lines, print } = captureOutput();
+    await configSetApiKeyAction({
+      output:     print,
+      passwordFn: async () => null,
+    });
+    expect(resolver.storeApiKey).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('Cancelled');
+  });
+});
+
+// ── configRotateApiKeyAction ─────────────────────────────────────────────────
+
+describe('configRotateApiKeyAction', () => {
+  it('errors with exit code 1 when no existing key is stored', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { lines, print } = captureOutput();
+    await configRotateApiKeyAction({
+      output:     print,
+      passwordFn: async () => VALID_KEY,
+    });
+    expect(process.exitCode).toBe(1);
+    expect(resolver.storeApiKey).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('No existing API key to rotate');
+  });
+
+  it('rotates when an existing key is present and reports the previous source', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { lines, print } = captureOutput();
+    await configRotateApiKeyAction({
+      output:     print,
+      passwordFn: async () => VALID_KEY,
+    });
+    expect(resolver.storeApiKey).toHaveBeenCalledWith(VALID_KEY);
+    const text = lines.join('\n');
+    expect(text).toContain('rotated');
+    expect(text).toContain('was in keychain');
+  });
+
+  it('cancelled rotation retains the existing key (no storeApiKey call)', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { lines, print } = captureOutput();
+    await configRotateApiKeyAction({
+      output:     print,
+      passwordFn: async () => null,
+    });
+    expect(resolver.storeApiKey).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('existing API key retained');
+  });
+});
+
+// ── configShowKeySourceAction ────────────────────────────────────────────────
+
+describe('configShowKeySourceAction', () => {
+  it.each(['env', 'dotenv', 'keychain', 'file', 'none'] as const)(
+    'prints the source returned by getKeySource: %s',
+    async (source) => {
+      vi.mocked(resolver.getKeySource).mockResolvedValueOnce(source);
+      const { lines, print } = captureOutput();
+      await configShowKeySourceAction({ output: print });
+      expect(lines.join('\n')).toContain(`API key source: ${source}`);
+    },
+  );
+
+  it('uses projectRoot from opts when supplied', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { print } = captureOutput();
+    await configShowKeySourceAction({ output: print, projectRoot: '/explicit/project' });
+    expect(resolver.getKeySource).toHaveBeenCalledWith('/explicit/project');
+  });
+});
+
+// ── configRemoveApiKeyAction ─────────────────────────────────────────────────
+
+describe('configRemoveApiKeyAction', () => {
+  it('calls removeApiKey and reports the previous source', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { lines, print } = captureOutput();
+    await configRemoveApiKeyAction({ output: print });
+    expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+    expect(lines.join('\n')).toContain('API key removed (was in keychain)');
+  });
+
+  it('reports "No API key was stored" when getKeySource returns "none"', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { lines, print } = captureOutput();
+    await configRemoveApiKeyAction({ output: print });
+    expect(lines.join('\n')).toContain('No API key was stored');
+  });
+
+  it('removeApiKey is called regardless of getKeySource result (defensive cleanup)', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { print } = captureOutput();
+    await configRemoveApiKeyAction({ output: print });
+    expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/commands/config-apikey.test.ts
+++ b/src/cli/commands/config-apikey.test.ts
@@ -87,6 +87,7 @@ describe('configRotateApiKeyAction', () => {
     const { lines, print } = captureOutput();
     await configRotateApiKeyAction({
       output:     print,
+      confirmFn:  async () => true,
       passwordFn: async () => VALID_KEY,
     });
     expect(resolver.storeApiKey).toHaveBeenCalledWith(VALID_KEY);
@@ -95,15 +96,41 @@ describe('configRotateApiKeyAction', () => {
     expect(text).toContain('was in keychain');
   });
 
-  it('cancelled rotation retains the existing key (no storeApiKey call)', async () => {
+  it('cancelled password prompt retains the existing key (no storeApiKey call)', async () => {
     vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
     const { lines, print } = captureOutput();
     await configRotateApiKeyAction({
       output:     print,
+      confirmFn:  async () => true,
       passwordFn: async () => null,
     });
     expect(resolver.storeApiKey).not.toHaveBeenCalled();
     expect(lines.join('\n')).toContain('existing API key retained');
+  });
+
+  it('declined overwrite confirmation skips the password prompt and storeApiKey', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const passwordFn = vi.fn<() => Promise<string | null>>().mockResolvedValue(VALID_KEY);
+    const { lines, print } = captureOutput();
+    await configRotateApiKeyAction({
+      output:     print,
+      confirmFn:  async () => false,
+      passwordFn,
+    });
+    expect(passwordFn).not.toHaveBeenCalled();
+    expect(resolver.storeApiKey).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('existing API key retained');
+  });
+
+  it('prints which layer holds the existing key before asking for confirmation', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('file');
+    const { lines, print } = captureOutput();
+    await configRotateApiKeyAction({
+      output:     print,
+      confirmFn:  async () => false,
+      passwordFn: async () => null,
+    });
+    expect(lines.join('\n')).toContain('Existing API key is stored in file');
   });
 });
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,4 +1,11 @@
+import { password, isCancel } from '@clack/prompts';
 import { openStore, closeStore, DEFAULT_DB_PATH, getConfig, setConfig, deleteConfig } from '../../store/index.js';
+import {
+  storeApiKey,
+  removeApiKey,
+  getKeySource,
+  isValidApiKey,
+} from '../../config/ApiKeyResolver.js';
 
 export async function configGetAction(key: string, dbPath = DEFAULT_DB_PATH): Promise<void> {
   const store = await openStore(dbPath);
@@ -24,4 +31,79 @@ export async function configUnsetAction(key: string, dbPath = DEFAULT_DB_PATH): 
   deleteConfig(store, key);
   closeStore(store);
   console.log(`${key} unset`);
+}
+
+// ── API key management (Plan #1 Phase 5) ─────────────────────────────────────
+
+export type ApiKeyPasswordFn = () => Promise<string | null>;
+
+const defaultApiKeyPasswordFn: ApiKeyPasswordFn = async () => {
+  const input = await password({
+    message:  'OpenAI API Key:',
+    validate: (value) => {
+      if (!isValidApiKey(value)) return 'Invalid OpenAI API key format (expected sk-...)';
+      return undefined;
+    },
+  });
+  if (isCancel(input)) return null;
+  return String(input);
+};
+
+export interface ConfigApiKeyOpts {
+  projectRoot?: string;
+  passwordFn?:  ApiKeyPasswordFn;
+  output?:      (line: string) => void;
+}
+
+const defaultPrint = (line: string): void => { console.log(line); };
+
+export async function configSetApiKeyAction(opts: ConfigApiKeyOpts = {}): Promise<void> {
+  const print       = opts.output      ?? defaultPrint;
+  const passwordFn  = opts.passwordFn  ?? defaultApiKeyPasswordFn;
+  const key = await passwordFn();
+  if (key === null || key === '') {
+    print('Cancelled — no API key stored.');
+    return;
+  }
+  const result = await storeApiKey(key);
+  print(`✓ API key stored in ${result.source}`);
+}
+
+export async function configRotateApiKeyAction(opts: ConfigApiKeyOpts = {}): Promise<void> {
+  const print       = opts.output      ?? defaultPrint;
+  const passwordFn  = opts.passwordFn  ?? defaultApiKeyPasswordFn;
+  const projectRoot = opts.projectRoot ?? process.cwd();
+
+  const currentSource = await getKeySource(projectRoot);
+  if (currentSource === 'none') {
+    print('Error: No existing API key to rotate. Use `nexpath config set-api-key` to store one first.');
+    process.exitCode = 1;
+    return;
+  }
+  const key = await passwordFn();
+  if (key === null || key === '') {
+    print('Cancelled — existing API key retained.');
+    return;
+  }
+  const result = await storeApiKey(key);
+  print(`✓ API key rotated; new key stored in ${result.source} (was in ${currentSource})`);
+}
+
+export async function configShowKeySourceAction(opts: ConfigApiKeyOpts = {}): Promise<void> {
+  const print       = opts.output      ?? defaultPrint;
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const source      = await getKeySource(projectRoot);
+  print(`API key source: ${source}`);
+}
+
+export async function configRemoveApiKeyAction(opts: ConfigApiKeyOpts = {}): Promise<void> {
+  const print       = opts.output      ?? defaultPrint;
+  const projectRoot = opts.projectRoot ?? process.cwd();
+  const sourceBefore = await getKeySource(projectRoot);
+  await removeApiKey();
+  if (sourceBefore === 'none') {
+    print('No API key was stored.');
+  } else {
+    print(`✓ API key removed (was in ${sourceBefore}).`);
+  }
 }

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,4 +1,4 @@
-import { password, isCancel } from '@clack/prompts';
+import { password, confirm, isCancel } from '@clack/prompts';
 import { openStore, closeStore, DEFAULT_DB_PATH, getConfig, setConfig, deleteConfig } from '../../store/index.js';
 import {
   storeApiKey,
@@ -36,6 +36,7 @@ export async function configUnsetAction(key: string, dbPath = DEFAULT_DB_PATH): 
 // ── API key management (Plan #1 Phase 5) ─────────────────────────────────────
 
 export type ApiKeyPasswordFn = () => Promise<string | null>;
+export type ApiKeyConfirmFn  = () => Promise<boolean>;
 
 const defaultApiKeyPasswordFn: ApiKeyPasswordFn = async () => {
   const input = await password({
@@ -49,9 +50,18 @@ const defaultApiKeyPasswordFn: ApiKeyPasswordFn = async () => {
   return String(input);
 };
 
+const defaultRotateConfirmFn: ApiKeyConfirmFn = async () => {
+  const answer = await confirm({
+    message:      'Overwrite the existing API key?',
+    initialValue: false,
+  });
+  return !isCancel(answer) && answer === true;
+};
+
 export interface ConfigApiKeyOpts {
   projectRoot?: string;
   passwordFn?:  ApiKeyPasswordFn;
+  confirmFn?:   ApiKeyConfirmFn;
   output?:      (line: string) => void;
 }
 
@@ -72,6 +82,7 @@ export async function configSetApiKeyAction(opts: ConfigApiKeyOpts = {}): Promis
 export async function configRotateApiKeyAction(opts: ConfigApiKeyOpts = {}): Promise<void> {
   const print       = opts.output      ?? defaultPrint;
   const passwordFn  = opts.passwordFn  ?? defaultApiKeyPasswordFn;
+  const confirmFn   = opts.confirmFn   ?? defaultRotateConfirmFn;
   const projectRoot = opts.projectRoot ?? process.cwd();
 
   const currentSource = await getKeySource(projectRoot);
@@ -80,6 +91,14 @@ export async function configRotateApiKeyAction(opts: ConfigApiKeyOpts = {}): Pro
     process.exitCode = 1;
     return;
   }
+
+  print(`Existing API key is stored in ${currentSource}.`);
+  const ok = await confirmFn();
+  if (!ok) {
+    print('Cancelled — existing API key retained.');
+    return;
+  }
+
   const key = await passwordFn();
   if (key === null || key === '') {
     print('Cancelled — existing API key retained.');

--- a/src/cli/commands/install-3step.test.ts
+++ b/src/cli/commands/install-3step.test.ts
@@ -19,7 +19,7 @@ import {
 } from './install.js';
 import * as resolver from '../../config/ApiKeyResolver.js';
 import { openStore, closeStore } from '../../store/db.js';
-import { getConfig } from '../../store/config.js';
+import { getConfig, isConfigSet } from '../../store/config.js';
 
 function tmpDirAgents(): { dir: string; cleanup: () => void } {
   const dir = join(tmpdir(), `nexpath-install3-${randomUUID()}`);
@@ -147,7 +147,7 @@ describe('install 3-step — Step 1: API key', () => {
 // ── Step 2: Telemetry consent ────────────────────────────────────────────────
 
 describe('install 3-step — Step 2: Telemetry consent', () => {
-  it('enable → telemetry.enabled set to "true" in config', async () => {
+  it('enable → telemetry.enabled AND telemetry_sync_enabled both set to "true" in config', async () => {
     const { dir, cleanup } = tmpDirAgents();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const dbPath = join(dir, 'telem.db');
@@ -161,11 +161,12 @@ describe('install 3-step — Step 2: Telemetry consent', () => {
       });
       const store = await openStore(dbPath);
       expect(getConfig(store.db, 'telemetry.enabled')).toBe('true');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
       closeStore(store);
     } finally { cleanup(); }
   });
 
-  it('disable → telemetry.enabled set to "false" in config', async () => {
+  it('disable → telemetry.enabled AND telemetry_sync_enabled both set to "false" in config', async () => {
     const { dir, cleanup } = tmpDirAgents();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const dbPath = join(dir, 'telem-off.db');
@@ -179,6 +180,26 @@ describe('install 3-step — Step 2: Telemetry consent', () => {
       });
       const store = await openStore(dbPath);
       expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('--yes mode → both telemetry.enabled and telemetry_sync_enabled set to "true" in DB', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'telem-yes-mode.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({ yes: true }, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+      });
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('true');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
+      expect(isConfigSet(store.db, 'telemetry.enabled')).toBe(true);
+      expect(isConfigSet(store.db, 'telemetry_sync_enabled')).toBe(true);
       closeStore(store);
     } finally { cleanup(); }
   });
@@ -402,12 +423,9 @@ describe('install 3-step — cancellation aborts subsequent steps', () => {
       });
       expect(summary).toBeNull();
       expect(telemetrySpy).not.toHaveBeenCalled();
-      // Fresh DB → no telemetry.enabled row was written (default still resolves on read)
       const store = await openStore(dbPath);
-      // Re-opening returns the DEFAULT_CONFIG fallback, so we cannot tell from
-      // getConfig alone whether the row was explicitly written. Use isConfigSet
-      // by reading the raw config table instead — but here we just assert the
-      // summary contract (null on cancel).
+      expect(isConfigSet(store.db, 'telemetry.enabled')).toBe(false);
+      expect(isConfigSet(store.db, 'telemetry_sync_enabled')).toBe(false);
       closeStore(store);
     } finally { cleanup(); }
   });
@@ -429,6 +447,11 @@ describe('install 3-step — cancellation aborts subsequent steps', () => {
       expect(summary).toBeNull();
       // Step 1 already wrote: storeApiKey was called.
       expect(resolver.storeApiKey).toHaveBeenCalledWith('sk-abcdefghij1234567890abcdefghij');
+      // Step 2 was cancelled → neither telemetry flag should be written.
+      const store = await openStore(dbPath);
+      expect(isConfigSet(store.db, 'telemetry.enabled')).toBe(false);
+      expect(isConfigSet(store.db, 'telemetry_sync_enabled')).toBe(false);
+      closeStore(store);
     } finally { cleanup(); }
   });
 });

--- a/src/cli/commands/install-3step.test.ts
+++ b/src/cli/commands/install-3step.test.ts
@@ -309,6 +309,130 @@ describe('install 3-step — Q4: clipboard install reflected in summary', () => 
   });
 });
 
+// ── Context detection: hasEnvKey / hasStoredKey ──────────────────────────────
+
+describe('install 3-step — apiKeyPrompt context detection', () => {
+  it('hasEnvKey=true when OPENAI_API_KEY env var is valid', async () => {
+    process.env.OPENAI_API_KEY = 'sk-abcdefghij1234567890abcdefghij';
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const apiKeyPrompt = vi.fn<InstallPrompts['apiKeyPrompt']>().mockResolvedValue({ kind: 'skip' });
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: { apiKeyPrompt, telemetryConsent: async () => ({ kind: 'enable' }) },
+      });
+      const ctx = apiKeyPrompt.mock.calls[0][0];
+      expect(ctx.hasEnvKey).toBe(true);
+    } finally { cleanup(); }
+  });
+
+  it('hasEnvKey=false when OPENAI_API_KEY env var has an invalid prefix', async () => {
+    process.env.OPENAI_API_KEY = 'invalid-not-sk-prefix';
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const apiKeyPrompt = vi.fn<InstallPrompts['apiKeyPrompt']>().mockResolvedValue({ kind: 'skip' });
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: { apiKeyPrompt, telemetryConsent: async () => ({ kind: 'enable' }) },
+      });
+      const ctx = apiKeyPrompt.mock.calls[0][0];
+      expect(ctx.hasEnvKey).toBe(false);
+    } finally { cleanup(); }
+  });
+
+  it('hasStoredKey=true when getKeySource returns "keychain" or "file" and env is unset', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const apiKeyPrompt = vi.fn<InstallPrompts['apiKeyPrompt']>().mockResolvedValue({ kind: 'keep_existing' });
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: { apiKeyPrompt, telemetryConsent: async () => ({ kind: 'enable' }) },
+      });
+      const ctx = apiKeyPrompt.mock.calls[0][0];
+      expect(ctx.hasStoredKey).toBe(true);
+      expect(ctx.hasEnvKey).toBe(false);
+    } finally { cleanup(); }
+  });
+
+  it('keychainName in context matches platformForKeychain override', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const apiKeyPrompt = vi.fn<InstallPrompts['apiKeyPrompt']>().mockResolvedValue({ kind: 'skip' });
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        platformForKeychain: 'win32',
+        confirmFn: async () => true,
+        promptFn: { apiKeyPrompt, telemetryConsent: async () => ({ kind: 'enable' }) },
+      });
+      const ctx = apiKeyPrompt.mock.calls[0][0];
+      expect(ctx.keychainName).toBe('Credential Manager');
+    } finally { cleanup(); }
+  });
+});
+
+// ── Cancellation semantics (non-transactional design documented) ─────────────
+
+describe('install 3-step — cancellation aborts subsequent steps', () => {
+  it('cancel at Step 1 → no telemetry config write and no agent registration', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'cancel-step1.db');
+    const telemetrySpy = vi.fn<InstallPrompts['telemetryConsent']>();
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        promptFn: {
+          apiKeyPrompt:     async () => ({ kind: 'cancel' }),
+          telemetryConsent: telemetrySpy,
+        },
+      });
+      expect(summary).toBeNull();
+      expect(telemetrySpy).not.toHaveBeenCalled();
+      // Fresh DB → no telemetry.enabled row was written (default still resolves on read)
+      const store = await openStore(dbPath);
+      // Re-opening returns the DEFAULT_CONFIG fallback, so we cannot tell from
+      // getConfig alone whether the row was explicitly written. Use isConfigSet
+      // by reading the raw config table instead — but here we just assert the
+      // summary contract (null on cancel).
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('cancel at Step 2 → telemetry config NOT written; Step 1 storeApiKey HAS already landed (non-transactional)', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'cancel-step2.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        promptFn: {
+          apiKeyPrompt:     async () => ({ kind: 'new_key', value: 'sk-abcdefghij1234567890abcdefghij' }),
+          telemetryConsent: async () => ({ kind: 'cancel' }),
+        },
+      });
+      expect(summary).toBeNull();
+      // Step 1 already wrote: storeApiKey was called.
+      expect(resolver.storeApiKey).toHaveBeenCalledWith('sk-abcdefghij1234567890abcdefghij');
+    } finally { cleanup(); }
+  });
+});
+
 // ── getKeychainName platform variants ────────────────────────────────────────
 
 describe('getKeychainName', () => {

--- a/src/cli/commands/install-3step.test.ts
+++ b/src/cli/commands/install-3step.test.ts
@@ -238,6 +238,77 @@ describe('install 3-step — Summary returned', () => {
   });
 });
 
+// ── Q3 + Q4 follow-ups: rich UI logs + clipboard in summary ─────────────────
+
+describe('install 3-step — Q3 rich UI: "Stored in <keychain>" confirmation line', () => {
+  it('logs "✓ Stored in <keychain>" after a new_key storeApiKey call', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      vi.mocked(resolver.storeApiKey).mockResolvedValueOnce({ source: 'keychain' });
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        platformForKeychain: 'darwin',
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'new_key', value: 'sk-abcdefghij1234567890abcdefghij' }),
+        }),
+      });
+      const output = logSpy.mock.calls.map(c => c[0] as string).join('\n');
+      expect(output).toContain('Stored in macOS Keychain');
+    } finally { cleanup(); }
+  });
+
+  it('logs "✓ Stored in fallback file" when storeApiKey falls back to the 0600 file', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      vi.mocked(resolver.storeApiKey).mockResolvedValueOnce({ source: 'file' });
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'new_key', value: 'sk-abcdefghij1234567890abcdefghij' }),
+        }),
+      });
+      const output = logSpy.mock.calls.map(c => c[0] as string).join('\n');
+      expect(output).toContain('Stored in fallback file');
+    } finally { cleanup(); }
+  });
+});
+
+describe('install 3-step — Q4: clipboard install reflected in summary', () => {
+  it('summary.extras has clipboardInstalled=false and clipboardTool=null when skipClipboardCheck is true', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({ yes: true }, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+      });
+      expect(summary!.extras.clipboardInstalled).toBe(false);
+      expect(summary!.extras.clipboardTool).toBeNull();
+    } finally { cleanup(); }
+  });
+
+  it('InstallSummary type includes extras { clipboardInstalled, clipboardTool } fields', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({ yes: true }, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+      });
+      expect(summary).not.toBeNull();
+      expect(summary!.extras).toBeDefined();
+      expect('clipboardInstalled' in summary!.extras).toBe(true);
+      expect('clipboardTool' in summary!.extras).toBe(true);
+    } finally { cleanup(); }
+  });
+});
+
 // ── getKeychainName platform variants ────────────────────────────────────────
 
 describe('getKeychainName', () => {

--- a/src/cli/commands/install-3step.test.ts
+++ b/src/cli/commands/install-3step.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync } from 'node:fs';
+
+vi.mock('../../config/ApiKeyResolver.js', () => ({
+  storeApiKey:     vi.fn().mockResolvedValue({ source: 'keychain' }),
+  isValidApiKey:   (key: string) => /^sk-[A-Za-z0-9_-]{20,}$/.test(key),
+  getKeySource:    vi.fn().mockResolvedValue('none'),
+  removeApiKey:    vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  installAction,
+  resolveAgentPaths,
+  getKeychainName,
+  type InstallPrompts,
+} from './install.js';
+import * as resolver from '../../config/ApiKeyResolver.js';
+import { openStore, closeStore } from '../../store/db.js';
+import { getConfig } from '../../store/config.js';
+
+function tmpDirAgents(): { dir: string; cleanup: () => void } {
+  const dir = join(tmpdir(), `nexpath-install3-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return { dir, cleanup: () => { try { rmSync(dir, { recursive: true }); } catch { /* ignore */ } } };
+}
+
+let savedEnvKey: string | undefined;
+
+beforeEach(() => {
+  savedEnvKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  vi.mocked(resolver.storeApiKey).mockReset().mockResolvedValue({ source: 'keychain' });
+  vi.mocked(resolver.getKeySource).mockReset().mockResolvedValue('none');
+});
+
+afterEach(() => {
+  if (savedEnvKey === undefined) delete process.env.OPENAI_API_KEY;
+  else                            process.env.OPENAI_API_KEY = savedEnvKey;
+  vi.restoreAllMocks();
+});
+
+function makePrompts(overrides: Partial<InstallPrompts> = {}): InstallPrompts {
+  return {
+    apiKeyPrompt:     async () => ({ kind: 'skip' }),
+    telemetryConsent: async () => ({ kind: 'enable' }),
+    ...overrides,
+  };
+}
+
+// ── Step 1: API key prompt ───────────────────────────────────────────────────
+
+describe('install 3-step — Step 1: API key', () => {
+  it('new_key result → storeApiKey called with the value; summary source = keychain', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'new_key', value: 'sk-abcdefghij1234567890abcdefghij' }),
+        }),
+      });
+      expect(resolver.storeApiKey).toHaveBeenCalledWith('sk-abcdefghij1234567890abcdefghij');
+      expect(summary).not.toBeNull();
+      expect(summary!.apiKey.source).toBe('keychain');
+    } finally { cleanup(); }
+  });
+
+  it('use_env result → storeApiKey called with process.env.OPENAI_API_KEY', async () => {
+    process.env.OPENAI_API_KEY = 'sk-fromenv1234567890abcdefghij1234';
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'use_env' }),
+        }),
+      });
+      expect(resolver.storeApiKey).toHaveBeenCalledWith('sk-fromenv1234567890abcdefghij1234');
+    } finally { cleanup(); }
+  });
+
+  it('keep_existing result → storeApiKey NOT called; summary source = kept', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'keep_existing' }),
+        }),
+      });
+      expect(resolver.storeApiKey).not.toHaveBeenCalled();
+      expect(summary!.apiKey.source).toBe('kept');
+    } finally { cleanup(); }
+  });
+
+  it('skip result → storeApiKey NOT called; summary source = skipped', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'skip' }),
+        }),
+      });
+      expect(resolver.storeApiKey).not.toHaveBeenCalled();
+      expect(summary!.apiKey.source).toBe('skipped');
+    } finally { cleanup(); }
+  });
+
+  it('cancel result → returns null and writes nothing', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'cancel.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'cancel' }),
+        }),
+      });
+      expect(summary).toBeNull();
+      expect(resolver.storeApiKey).not.toHaveBeenCalled();
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('true');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+});
+
+// ── Step 2: Telemetry consent ────────────────────────────────────────────────
+
+describe('install 3-step — Step 2: Telemetry consent', () => {
+  it('enable → telemetry.enabled set to "true" in config', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'telem.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        confirmFn: async () => true,
+        promptFn: makePrompts({ telemetryConsent: async () => ({ kind: 'enable' }) }),
+      });
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('true');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('disable → telemetry.enabled set to "false" in config', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'telem-off.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        confirmFn: async () => true,
+        promptFn: makePrompts({ telemetryConsent: async () => ({ kind: 'disable' }) }),
+      });
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('cancel → returns null and the telemetry config is NOT written', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'telem-cancel.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        dbPath,
+        promptFn: makePrompts({ telemetryConsent: async () => ({ kind: 'cancel' }) }),
+      });
+      expect(summary).toBeNull();
+    } finally { cleanup(); }
+  });
+});
+
+// ── Summary returned ─────────────────────────────────────────────────────────
+
+describe('install 3-step — Summary returned', () => {
+  it('summary object includes apiKey.source, telemetry.enabled, agents.registered/failed', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({}, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+        confirmFn: async () => true,
+        promptFn: makePrompts({
+          apiKeyPrompt: async () => ({ kind: 'skip' }),
+          telemetryConsent: async () => ({ kind: 'enable' }),
+        }),
+      });
+      expect(summary).not.toBeNull();
+      expect(summary!.apiKey.source).toBe('skipped');
+      expect(summary!.telemetry.enabled).toBe(true);
+      expect(Array.isArray(summary!.agents.registered)).toBe(true);
+      expect(Array.isArray(summary!.agents.failed)).toBe(true);
+    } finally { cleanup(); }
+  });
+
+  it('--yes bypasses prompts; summary still returned with default apiKey="skipped", telemetry=true', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      const summary = await installAction({ yes: true }, {
+        paths, isWin: false, execFn: () => {}, skipClipboardCheck: true,
+      });
+      expect(summary).not.toBeNull();
+      expect(summary!.apiKey.source).toBe('skipped');
+      expect(summary!.telemetry.enabled).toBe(true);
+    } finally { cleanup(); }
+  });
+});
+
+// ── getKeychainName platform variants ────────────────────────────────────────
+
+describe('getKeychainName', () => {
+  it('returns "macOS Keychain" on darwin', () => {
+    expect(getKeychainName('darwin')).toBe('macOS Keychain');
+  });
+
+  it('returns "Secret Service (libsecret)" on linux', () => {
+    expect(getKeychainName('linux')).toBe('Secret Service (libsecret)');
+  });
+
+  it('returns "Credential Manager" on win32', () => {
+    expect(getKeychainName('win32')).toBe('Credential Manager');
+  });
+
+  it('falls back to the encrypted-file message on other platforms', () => {
+    expect(getKeychainName('freebsd' as NodeJS.Platform)).toMatch(/Encrypted file/);
+  });
+});

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { openStore, closeStore } from '../../store/db.js';
-import { setConfig, isConfigSet } from '../../store/config.js';
+import { setConfig } from '../../store/config.js';
 
 import {
   MCP_SERVER_NAME,
@@ -616,7 +616,15 @@ describe('installAction', () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
       const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({}, { paths, isWin: false, execFn: () => {}, confirmFn: async () => false, skipClipboardCheck: true });
+      await installAction({}, {
+        paths, isWin: false, execFn: () => {},
+        confirmFn: async () => false,
+        promptFn: {
+          apiKeyPrompt:     async () => ({ kind: 'skip' }),
+          telemetryConsent: async () => ({ kind: 'disable' }),
+        },
+        skipClipboardCheck: true,
+      });
       expect(spy.mock.calls.some((c) => (c[0] as string).includes('Cancelled'))).toBe(true);
     } finally {
       cleanup();
@@ -1229,128 +1237,6 @@ describe('removeHookEntry', () => {
       removeHookEntry(file);
       expect(removeHookEntry(file)).toBe(false);
     } finally { cleanup(); }
-  });
-});
-
-// ── installAction — first-run disclosure (Issue 7 + 1.2) ─────────────────────
-
-describe('installAction — first-run disclosure', () => {
-  it('shows disclosure when first_run_shown is not set in config', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      // dbPath ':memory:' = fresh DB, first_run_shown never set
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath: ':memory:', skipClipboardCheck: true });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      expect(output).toContain('Before installing nexpath');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('does NOT show disclosure when first_run_shown is already set', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const dbPath = join(dir, 'test.db');
-    try {
-      // Pre-seed first_run_shown
-      const store = await openStore(dbPath);
-      setConfig(store, 'first_run_shown', 'true');
-      closeStore(store);
-
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath, skipClipboardCheck: true });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      expect(output).not.toContain('Before installing nexpath');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('disclosure contains OpenAI API key mention', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath: ':memory:', skipClipboardCheck: true });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      expect(output).toContain('OPENAI_API_KEY');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('disclosure contains local storage path mention', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath: ':memory:', skipClipboardCheck: true });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      expect(output).toContain('prompt-store.db');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('disclosure contains opt-out instructions (Ctrl+X and nexpath uninstall)', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath: ':memory:', skipClipboardCheck: true });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      expect(output).toContain('Ctrl+X');
-      expect(output).toContain('nexpath uninstall');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('sets first_run_shown in config after disclosure', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const dbPath = join(dir, 'test.db');
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({ yes: true }, { paths, isWin: false, execFn: () => {}, dbPath, skipClipboardCheck: true });
-
-      // Re-open same DB and check key is set
-      const store = await openStore(dbPath);
-      const result = isConfigSet(store.db, 'first_run_shown');
-      closeStore(store);
-      expect(result).toBe(true);
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
-  });
-
-  it('disclosure fires before confirmation — shown even when confirmFn cancels', async () => {
-    const { dir, cleanup } = tmpDir();
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    try {
-      const paths = resolveAgentPaths(dir, dir, dir);
-      await installAction({}, {
-        paths, isWin: false, execFn: () => {},
-        confirmFn: async () => false,
-        dbPath: ':memory:',
-        skipClipboardCheck: true,
-      });
-      const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
-      // Disclosure appeared even though install was cancelled
-      expect(output).toContain('Before installing nexpath');
-      expect(output).toContain('Cancelled');
-    } finally {
-      spy.mockRestore();
-      cleanup();
-    }
   });
 });
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -7,6 +7,7 @@ import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
 import { setConfig } from '../../store/config.js';
 import {
   storeApiKey,
+  removeApiKey,
   isValidApiKey,
   getKeySource,
   type KeySource,
@@ -785,13 +786,29 @@ export async function ensureLinuxClipboard(
 
 // ── uninstallAction ────────────────────────────────────────────────────────────
 
+export type UninstallApiKeyConfirmFn = () => Promise<boolean>;
+
+const defaultUninstallApiKeyConfirm: UninstallApiKeyConfirmFn = async () => {
+  const answer = await confirm({
+    message:      'Remove stored API key?',
+    initialValue: true,
+  });
+  return !isCancel(answer) && answer === true;
+};
+
 export async function uninstallAction(
   {
     paths = resolveAgentPaths(),
     execFn,
+    apiKeyConfirmFn = defaultUninstallApiKeyConfirm,
+    yes = false,
+    projectRoot = process.cwd(),
   }: {
-    paths?: AgentPaths;
-    execFn?: ExecFn;
+    paths?:           AgentPaths;
+    execFn?:          ExecFn;
+    apiKeyConfirmFn?: UninstallApiKeyConfirmFn;
+    yes?:             boolean;
+    projectRoot?:     string;
   } = {},
 ): Promise<void> {
   const agents = detectAgents(paths);
@@ -831,6 +848,22 @@ export async function uninstallAction(
 
   console.log('');
   console.log('MCP registration removed from all agents.');
+
+  // ── API key cleanup ──────────────────────────────────────────────────────
+  const currentSource = await getKeySource(projectRoot);
+  if (currentSource === 'none') {
+    console.log('No stored API key found, nothing to remove.');
+  } else {
+    const shouldRemove = yes || await apiKeyConfirmFn();
+    if (shouldRemove) {
+      await removeApiKey();
+      console.log(`✓ API key removed (was in ${currentSource}).`);
+    } else {
+      console.log('- API key retained; remove later with `nexpath config remove-api-key`.');
+    }
+  }
+
+  console.log('');
   console.log('Prompt history retained at ~/.nexpath/prompt-store.db');
   console.log('To delete it: nexpath store delete');
 }

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -2,9 +2,15 @@ import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
-import { confirm, isCancel } from '@clack/prompts';
+import { confirm, isCancel, password, note, intro, outro, cancel as clackCancel } from '@clack/prompts';
 import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
-import { isConfigSet, setConfig } from '../../store/config.js';
+import { setConfig } from '../../store/config.js';
+import {
+  storeApiKey,
+  isValidApiKey,
+  getKeySource,
+  type KeySource,
+} from '../../config/ApiKeyResolver.js';
 
 export const MCP_SERVER_NAME = 'nexpath-prompt-store';
 
@@ -380,6 +386,82 @@ const defaultConfirm: ConfirmFn = async () => {
   return !isCancel(answer) && answer === true;
 };
 
+// ── 3-step install UX prompt interface ───────────────────────────────────────
+
+export type ApiKeyPromptContext = {
+  hasEnvKey:    boolean;
+  hasStoredKey: boolean;
+  keychainName: string;
+};
+
+export type ApiKeyPromptResult =
+  | { kind: 'use_env' }
+  | { kind: 'keep_existing' }
+  | { kind: 'new_key'; value: string }
+  | { kind: 'skip' }
+  | { kind: 'cancel' };
+
+export type TelemetryConsentResult =
+  | { kind: 'enable' }
+  | { kind: 'disable' }
+  | { kind: 'cancel' };
+
+export interface InstallPrompts {
+  apiKeyPrompt:     (ctx: ApiKeyPromptContext) => Promise<ApiKeyPromptResult>;
+  telemetryConsent: () => Promise<TelemetryConsentResult>;
+}
+
+export function getKeychainName(platform: NodeJS.Platform = process.platform): string {
+  switch (platform) {
+    case 'darwin': return 'macOS Keychain';
+    case 'linux':  return 'Secret Service (libsecret)';
+    case 'win32':  return 'Credential Manager';
+    default:       return 'Encrypted file at ~/.nexpath/config.json';
+  }
+}
+
+const defaultInstallPrompts: InstallPrompts = {
+  apiKeyPrompt: async (ctx) => {
+    if (ctx.hasEnvKey) {
+      const useEnv = await confirm({
+        message:      'Detected existing API key in environment. Use it?',
+        initialValue: true,
+      });
+      if (isCancel(useEnv)) return { kind: 'cancel' };
+      if (useEnv === true)  return { kind: 'use_env' };
+    }
+    const promptMsg = ctx.hasStoredKey
+      ? `API Key (Enter to keep existing key stored in ${ctx.keychainName}):`
+      : `API Key (will be stored in ${ctx.keychainName}):`;
+    const input = await password({
+      message:  promptMsg,
+      validate: (value) => {
+        if (ctx.hasStoredKey && value === '') return undefined;
+        if (!isValidApiKey(value)) return 'Invalid OpenAI API key format (expected sk-...)';
+        return undefined;
+      },
+    });
+    if (isCancel(input)) return { kind: 'cancel' };
+    if (input === '' && ctx.hasStoredKey) return { kind: 'keep_existing' };
+    if (input === '') return { kind: 'skip' };
+    return { kind: 'new_key', value: String(input) };
+  },
+  telemetryConsent: async () => {
+    const answer = await confirm({
+      message:      'Enable telemetry?',
+      initialValue: true,
+    });
+    if (isCancel(answer)) return { kind: 'cancel' };
+    return answer === true ? { kind: 'enable' } : { kind: 'disable' };
+  },
+};
+
+export interface InstallSummary {
+  apiKey:    { source: 'keychain' | 'file' | 'kept' | 'skipped' };
+  telemetry: { enabled: boolean };
+  agents:    { registered: string[]; failed: string[] };
+}
+
 export async function installAction(
   opts: { yes?: boolean } = {},
   {
@@ -387,38 +469,83 @@ export async function installAction(
     paths = resolveAgentPaths(),
     execFn,
     confirmFn = defaultConfirm,
+    promptFn  = defaultInstallPrompts,
     dbPath = ':memory:',
     skipClipboardCheck = false,
+    platformForKeychain = process.platform,
   }: {
-    isWin?: boolean;
-    paths?: AgentPaths;
-    execFn?: ExecFn;
-    confirmFn?: ConfirmFn;
-    dbPath?: string;
-    skipClipboardCheck?: boolean;
+    isWin?:               boolean;
+    paths?:               AgentPaths;
+    execFn?:              ExecFn;
+    confirmFn?:           ConfirmFn;
+    promptFn?:            InstallPrompts;
+    dbPath?:              string;
+    skipClipboardCheck?:  boolean;
+    platformForKeychain?: NodeJS.Platform;
   } = {},
-): Promise<void> {
-  // ── First-run disclosure ───────────────────────────────────────────────────
-  const disclosureStore = await openStore(dbPath);
+): Promise<InstallSummary | null> {
+  intro('Installing nexpath');
+
+  const store = await openStore(dbPath);
+
+  let apiKeySource:  InstallSummary['apiKey']['source'] = 'skipped';
+  let telemetryEnabled = true;
+
   try {
-    if (!isConfigSet(disclosureStore.db, 'first_run_shown')) {
-      console.log('');
-      console.log('Before installing nexpath, a few things to know:');
-      console.log('  1. An OpenAI API key is required (OPENAI_API_KEY) for advisory generation');
-      console.log(`  2. Prompts are stored locally at ${DEFAULT_DB_PATH} — nothing leaves your machine`);
-      console.log(`  3. To opt out at any time: press ${process.platform === 'darwin' ? 'Cmd' : 'Ctrl'}+X during an advisory, or run nexpath uninstall`);
-      console.log('');
-      setConfig(disclosureStore, 'first_run_shown', 'true');
+    // ── Step 1: API key ───────────────────────────────────────────────────────
+    if (!opts.yes) {
+      const envKey       = process.env.OPENAI_API_KEY ?? '';
+      const hasEnvKey    = envKey !== '' && isValidApiKey(envKey);
+      const storedSource = await getKeySource(process.cwd());
+      const hasStoredKey = !hasEnvKey && (storedSource === 'keychain' || storedSource === 'file');
+      const keychainName = getKeychainName(platformForKeychain);
+
+      const result = await promptFn.apiKeyPrompt({ hasEnvKey, hasStoredKey, keychainName });
+
+      if (result.kind === 'cancel') {
+        clackCancel('Setup aborted — no changes made');
+        closeStore(store);
+        return null;
+      }
+      if (result.kind === 'new_key') {
+        const stored = await storeApiKey(result.value);
+        apiKeySource = stored.source;
+      } else if (result.kind === 'use_env') {
+        const stored = await storeApiKey(envKey);
+        apiKeySource = stored.source;
+      } else if (result.kind === 'keep_existing') {
+        apiKeySource = 'kept';
+      } else {
+        apiKeySource = 'skipped';
+      }
+    } else {
+      apiKeySource = 'skipped';
     }
+
+    // ── Step 2: Telemetry ─────────────────────────────────────────────────────
+    if (!opts.yes) {
+      const consent = await promptFn.telemetryConsent();
+      if (consent.kind === 'cancel') {
+        clackCancel('Setup aborted — no changes made');
+        closeStore(store);
+        return null;
+      }
+      telemetryEnabled = consent.kind === 'enable';
+    }
+    setConfig(store, 'telemetry.enabled', String(telemetryEnabled));
   } finally {
-    closeStore(disclosureStore);
+    if (store.dbPath !== ':memory:' || telemetryEnabled !== true) {
+      // close happens at end of step 3 path; nothing to do here
+    }
   }
 
+  // ── Step 3: Agent detection + registration ────────────────────────────────
   const agents = detectAgents(paths);
 
   if (agents.length === 0) {
     console.log('No supported agents detected. Run nexpath install --help for details.');
-    return;
+    closeStore(store);
+    return { apiKey: { source: apiKeySource }, telemetry: { enabled: telemetryEnabled }, agents: { registered: [], failed: [] } };
   }
 
   const detectedNames = agents.map((a) => a.label).join(', ');
@@ -428,13 +555,17 @@ export async function installAction(
     const ok = await confirmFn();
     if (!ok) {
       console.log('Cancelled.');
-      return;
+      closeStore(store);
+      return null;
     }
   }
 
   // NOTE: Enable REGISTER_MCP_SERVER when MCP tools are added to src/server/tools.ts.
   // Currently TOOLS is empty — no reason to spin up the MCP server process yet.
   const REGISTER_MCP_SERVER = false;
+
+  const registered: string[] = [];
+  const failed:     string[] = [];
 
   for (const agent of agents) {
     try {
@@ -453,8 +584,10 @@ export async function installAction(
         try {
           writeHookEntry(paths.claudeSettings, homedir(), isWin ? 'win32' : process.platform);
           console.log(`\u2713 ${'Claude Code'.padEnd(12)} \u2014 advisory hook written to ${paths.claudeSettings}`);
+          registered.push('Claude Code');
         } catch (err) {
           console.log(`\u26a0 ${'Claude Code'.padEnd(12)} \u2014 hook write failed: ${(err as Error).message}`);
+          failed.push('Claude Code');
         }
       } else if (REGISTER_MCP_SERVER) {
         if (agent.type === 'cline') {
@@ -470,9 +603,11 @@ export async function installAction(
           writeMcpEntry(agent.configPath, buildStandardEntry(isWin));
           console.log(`\u2713 ${agent.label.padEnd(12)} \u2014 written to ${agent.configPath}`);
         }
+        registered.push(agent.label);
       }
     } catch (err) {
       console.log(`\u2717 ${agent.label.padEnd(12)} \u2014 failed: ${(err as Error).message}`);
+      failed.push(agent.label);
     }
   }
 
@@ -481,9 +616,30 @@ export async function installAction(
   console.log('Note: advisory pipeline (nexpath auto) auto-wired for Claude Code only.');
   console.log('Run: nexpath status  to verify connections.');
 
+  closeStore(store);
+
   if (!skipClipboardCheck) {
     await ensureLinuxClipboard({ autoConfirm: opts.yes });
   }
+
+  // ── Final summary (note + outro) ─────────────────────────────────────────
+  const summary: InstallSummary = {
+    apiKey:    { source: apiKeySource },
+    telemetry: { enabled: telemetryEnabled },
+    agents:    { registered, failed },
+  };
+  const summaryLines = [
+    `API key:    ${apiKeySource}`,
+    `Telemetry:  ${telemetryEnabled ? 'enabled' : 'disabled'}`,
+    `Agents:     ${registered.length > 0 ? registered.join(', ') : 'none'}`,
+    failed.length > 0 ? `Failed:     ${failed.join(', ')}` : null,
+    '',
+    'Run `nexpath status` to verify connections.',
+  ].filter((l): l is string => l !== null).join('\n');
+  note(summaryLines, 'Setup Complete');
+  outro('Done!');
+
+  return summary;
 }
 
 // ── Linux clipboard tool auto-install ─────────────────────────────────────────

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -470,6 +470,9 @@ const defaultInstallPrompts: InstallPrompts = {
         "What's NOT sent:   your code, prompts, API key,",
         '                   file paths, personal information',
         '',
+        'Yes  → events captured locally AND auto-synced to our server',
+        'No   → no capture, no sync — full stop',
+        '',
         'Change anytime: `nexpath config set telemetry.enabled true|false`',
       ].join('\n'),
       'Step 2 of 3 — Telemetry',
@@ -562,7 +565,8 @@ export async function installAction(
       }
       telemetryEnabled = consent.kind === 'enable';
     }
-    setConfig(store, 'telemetry.enabled', String(telemetryEnabled));
+    setConfig(store, 'telemetry.enabled',      String(telemetryEnabled));
+    setConfig(store, 'telemetry_sync_enabled', String(telemetryEnabled));
   } finally {
     if (store.dbPath !== ':memory:' || telemetryEnabled !== true) {
       // close happens at end of step 3 path; nothing to do here

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -422,6 +422,17 @@ export function getKeychainName(platform: NodeJS.Platform = process.platform): s
 
 const defaultInstallPrompts: InstallPrompts = {
   apiKeyPrompt: async (ctx) => {
+    note(
+      [
+        'Nexpath needs an OpenAI API key to generate advisories.',
+        'Enter it once here — it will be stored securely and used',
+        'for all your projects until you run `nexpath uninstall`.',
+        '',
+        'Get a key: https://platform.openai.com/api-keys',
+      ].join('\n'),
+      'Step 1 of 3 — OpenAI API Key (required)',
+    );
+
     if (ctx.hasEnvKey) {
       const useEnv = await confirm({
         message:      'Detected existing API key in environment. Use it?',
@@ -447,6 +458,21 @@ const defaultInstallPrompts: InstallPrompts = {
     return { kind: 'new_key', value: String(input) };
   },
   telemetryConsent: async () => {
+    note(
+      [
+        'We highly recommend you provide us logs so we can',
+        'get better information to improve nexpath as much',
+        'as possible.',
+        '',
+        "What's collected:  anonymous usage events (command",
+        '                   names, timings, error types)',
+        "What's NOT sent:   your code, prompts, API key,",
+        '                   file paths, personal information',
+        '',
+        'Change anytime: `nexpath config set telemetry.enabled true|false`',
+      ].join('\n'),
+      'Step 2 of 3 — Telemetry',
+    );
     const answer = await confirm({
       message:      'Enable telemetry?',
       initialValue: true,
@@ -460,6 +486,7 @@ export interface InstallSummary {
   apiKey:    { source: 'keychain' | 'file' | 'kept' | 'skipped' };
   telemetry: { enabled: boolean };
   agents:    { registered: string[]; failed: string[] };
+  extras:    { clipboardInstalled: boolean; clipboardTool: string | null };
 }
 
 export async function installAction(
@@ -510,9 +537,11 @@ export async function installAction(
       if (result.kind === 'new_key') {
         const stored = await storeApiKey(result.value);
         apiKeySource = stored.source;
+        console.log(`✓ Stored in ${stored.source === 'keychain' ? keychainName : 'fallback file (~/.nexpath/config.json)'}`);
       } else if (result.kind === 'use_env') {
         const stored = await storeApiKey(envKey);
         apiKeySource = stored.source;
+        console.log(`✓ Stored in ${stored.source === 'keychain' ? keychainName : 'fallback file (~/.nexpath/config.json)'}`);
       } else if (result.kind === 'keep_existing') {
         apiKeySource = 'kept';
       } else {
@@ -545,7 +574,12 @@ export async function installAction(
   if (agents.length === 0) {
     console.log('No supported agents detected. Run nexpath install --help for details.');
     closeStore(store);
-    return { apiKey: { source: apiKeySource }, telemetry: { enabled: telemetryEnabled }, agents: { registered: [], failed: [] } };
+    return {
+      apiKey:    { source: apiKeySource },
+      telemetry: { enabled: telemetryEnabled },
+      agents:    { registered: [], failed: [] },
+      extras:    { clipboardInstalled: false, clipboardTool: null },
+    };
   }
 
   const detectedNames = agents.map((a) => a.label).join(', ');
@@ -618,8 +652,9 @@ export async function installAction(
 
   closeStore(store);
 
+  let clipboardResult: ClipboardEnsureResult = { installed: false, toolName: null, alreadyHad: false };
   if (!skipClipboardCheck) {
-    await ensureLinuxClipboard({ autoConfirm: opts.yes });
+    clipboardResult = await ensureLinuxClipboard({ autoConfirm: opts.yes });
   }
 
   // ── Final summary (note + outro) ─────────────────────────────────────────
@@ -627,12 +662,20 @@ export async function installAction(
     apiKey:    { source: apiKeySource },
     telemetry: { enabled: telemetryEnabled },
     agents:    { registered, failed },
+    extras:    {
+      clipboardInstalled: clipboardResult.installed,
+      clipboardTool:      clipboardResult.toolName,
+    },
   };
+  const extrasLine = clipboardResult.installed
+    ? `Extras:     ${clipboardResult.toolName} installed for clipboard`
+    : null;
   const summaryLines = [
     `API key:    ${apiKeySource}`,
     `Telemetry:  ${telemetryEnabled ? 'enabled' : 'disabled'}`,
     `Agents:     ${registered.length > 0 ? registered.join(', ') : 'none'}`,
     failed.length > 0 ? `Failed:     ${failed.join(', ')}` : null,
+    extrasLine,
     '',
     'Run `nexpath status` to verify connections.',
   ].filter((l): l is string => l !== null).join('\n');
@@ -665,6 +708,12 @@ const PKG_MANAGERS: PkgManager[] = [
  * Clipboard is optional — if install is skipped or fails, decision sessions
  * still work but "Copy to clipboard" silently does nothing.
  */
+export interface ClipboardEnsureResult {
+  installed:    boolean;
+  toolName:     string | null;
+  alreadyHad:   boolean;
+}
+
 export async function ensureLinuxClipboard(
   deps: {
     platform?: string;
@@ -674,15 +723,17 @@ export async function ensureLinuxClipboard(
     autoConfirm?: boolean;
     waylandDisplay?: string;
   } = {},
-): Promise<void> {
+): Promise<ClipboardEnsureResult> {
   const plat  = deps.platform ?? process.platform;
   const spawn = deps.spawnFn  ?? spawnSync;
   const exec  = deps.execFn   ?? execSync;
 
-  if (plat !== 'linux') return;
+  if (plat !== 'linux') return { installed: false, toolName: null, alreadyHad: false };
 
   for (const cmd of ['xclip', 'wl-copy', 'xsel']) {
-    if (spawn('which', [cmd], { stdio: 'pipe' }).status === 0) return;
+    if (spawn('which', [cmd], { stdio: 'pipe' }).status === 0) {
+      return { installed: false, toolName: cmd, alreadyHad: true };
+    }
   }
 
   // Wayland prefers wl-clipboard (provides wl-copy); X11 prefers xclip
@@ -699,7 +750,7 @@ export async function ensureLinuxClipboard(
   const pm = pkgManagers.find((p) => spawn('which', [p.cmd], { stdio: 'pipe' }).status === 0);
   if (!pm) {
     console.log(`\u26a0 No clipboard tool (xclip/wl-copy/xsel) found. Install one manually for clipboard support.`);
-    return;
+    return { installed: false, toolName: null, alreadyHad: false };
   }
 
   console.log('');
@@ -713,7 +764,7 @@ export async function ensureLinuxClipboard(
     const ok = await confirmFn();
     if (!ok) {
       console.log('\u26a0 Skipped \u2014 "Copy to clipboard" in decision sessions will not work.');
-      return;
+      return { installed: false, toolName: null, alreadyHad: false };
     }
   }
 
@@ -722,11 +773,13 @@ export async function ensureLinuxClipboard(
     // Verify installation succeeded
     if (spawn('which', [toolName], { stdio: 'pipe' }).status === 0) {
       console.log(`\u2713 ${pkgName} installed successfully`);
-    } else {
-      console.log(`\u26a0 ${pkgName} install command ran but ${toolName} not found \u2014 check output above`);
+      return { installed: true, toolName, alreadyHad: false };
     }
+    console.log(`\u26a0 ${pkgName} install command ran but ${toolName} not found \u2014 check output above`);
+    return { installed: false, toolName: null, alreadyHad: false };
   } catch {
     console.log(`\u26a0 ${pkgName} installation failed \u2014 install manually: sudo ${pm.cmd} install ${pkgName}`);
+    return { installed: false, toolName: null, alreadyHad: false };
   }
 }
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -807,12 +807,14 @@ export async function uninstallAction(
     apiKeyConfirmFn = defaultUninstallApiKeyConfirm,
     yes = false,
     projectRoot = process.cwd(),
+    dbPath,
   }: {
     paths?:           AgentPaths;
     execFn?:          ExecFn;
     apiKeyConfirmFn?: UninstallApiKeyConfirmFn;
     yes?:             boolean;
     projectRoot?:     string;
+    dbPath?:          string;
   } = {},
 ): Promise<void> {
   const agents = detectAgents(paths);
@@ -865,6 +867,20 @@ export async function uninstallAction(
     } else {
       console.log('- API key retained; remove later with `nexpath config remove-api-key`.');
     }
+  }
+
+  // ── Telemetry config cleanup ─────────────────────────────────────────────
+  try {
+    const store = await openStore(dbPath ?? DEFAULT_DB_PATH);
+    try {
+      setConfig(store, 'telemetry.enabled',      'false');
+      setConfig(store, 'telemetry_sync_enabled', 'false');
+      console.log('✓ Telemetry disabled in local config.');
+    } finally {
+      closeStore(store);
+    }
+  } catch {
+    // Best-effort — never crash uninstall over a config write failure.
   }
 
   console.log('');

--- a/src/cli/commands/stop.test.ts
+++ b/src/cli/commands/stop.test.ts
@@ -506,7 +506,7 @@ describe('runStop — telemetry events', () => {
 
   it('emits stop_no_pending when no advisory is queued', async () => {
     await runStop(makePayload(), store);
-    expect(writeTelemetry).toHaveBeenCalledWith('/test/project', 'stop_no_pending');
+    expect(writeTelemetry).toHaveBeenCalledWith('/test/project', 'stop_no_pending', undefined, expect.anything());
   });
 
   it('does not emit stop_no_pending when an advisory is present', async () => {
@@ -527,6 +527,7 @@ describe('runStop — telemetry events', () => {
         stage:            'implementation',
         generatedOptions: false,
       }),
+      expect.anything(),
     );
   });
 
@@ -547,6 +548,7 @@ describe('runStop — telemetry events', () => {
       '/test/project',
       'stop_advisory_shown',
       expect.objectContaining({ generatedOptions: true }),
+      expect.anything(),
     );
   });
 
@@ -561,6 +563,7 @@ describe('runStop — telemetry events', () => {
       '/test/project',
       'language_detected',
       expect.objectContaining({ detectedLanguage: expect.anything() }),
+      expect.anything(),
     );
   });
 

--- a/src/cli/commands/stop.test.ts
+++ b/src/cli/commands/stop.test.ts
@@ -5,6 +5,10 @@ vi.mock('../../telemetry/index.js', () => ({
   TELEMETRY_PATH: '/mock/telemetry.jsonl',
 }));
 
+vi.mock('../../telemetry/recent-prompts.js', () => ({
+  recentPromptMetadata: vi.fn().mockReturnValue([]),
+}));
+
 import { openStore } from '../../store/db.js';
 import type { Store } from '../../store/db.js';
 import { runStop } from './stop.js';
@@ -19,6 +23,7 @@ import { insertPrompt } from '../../store/prompts.js';
 import { upsertProject, getProject } from '../../store/projects.js';
 import { LANG_DETECT_INTERVAL } from '../../classifier/LanguageDetector.js';
 import { writeTelemetry } from '../../telemetry/index.js';
+import { recentPromptMetadata } from '../../telemetry/recent-prompts.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -575,5 +580,28 @@ describe('runStop — telemetry events', () => {
     await runStop(makePayload(), store);
     const calls = vi.mocked(writeTelemetry).mock.calls;
     expect(calls.some(([, evt]) => evt === 'language_detected')).toBe(false);
+  });
+
+  // ── Phase 4 — stop.ts plumbs recentPrompts into runDecisionSession input ────
+
+  it('decision_session_started carries recentPrompts populated from session state', async () => {
+    // Sentinel return — if stop.ts drops the `recentPrompts` line in its
+    // runDecisionSession input, the helper is never called and/or the
+    // payload defaults to []. Either way, this assertion fails.
+    const sentinel = [
+      { index: 99, classifiedStage: 'planning' as const, confidence: 0.5, capturedAt: 100 },
+    ];
+    vi.mocked(recentPromptMetadata).mockReturnValueOnce(sentinel);
+
+    upsertPendingAdvisory(store, makeAdvisory());
+    await runStop(makePayload(), store, mockSelect(SKIP_NOW));
+
+    expect(recentPromptMetadata).toHaveBeenCalledTimes(1);
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_started',
+      expect.objectContaining({ recentPrompts: sentinel }),
+      expect.anything(),
+    );
   });
 });

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -14,6 +14,7 @@ import { logger, initLogger } from '../../logger.js';
 import type { LogLevel } from '../../logger.js';
 import { writeHookStats } from '../../store/hook-stats.js';
 import { writeTelemetry } from '../../telemetry/index.js';
+import { recentPromptMetadata } from '../../telemetry/recent-prompts.js';
 import { readStdin } from './auto.js';
 
 /**
@@ -150,6 +151,8 @@ export async function runStop(
       decisionSessionCount,
       generatedOptions,
       profile:              mgr.current.profile,
+      // Phase 4 — Item B: last-5 prompt metadata for decision_session_started.
+      recentPrompts:        recentPromptMetadata(mgr.current.promptHistory),
     },
     store,
     effectiveSelectFn,

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -78,7 +78,7 @@ export async function runStop(
     const detected = detectLanguage(recentPrompts.map((p) => p.text), currentDetected);
     setDetectedLanguage(store, payload.cwd, detected);
     logger.debug('stop_lang_detected', { cwd: payload.cwd, detected: detected ?? null });
-    writeTelemetry(payload.cwd, 'language_detected', { detectedLanguage: detected ?? null });
+    writeTelemetry(payload.cwd, 'language_detected', { detectedLanguage: detected ?? null }, store);
   }
 
   // 1.7. Read decision_session_count for help-line gating in the decision session UI
@@ -88,7 +88,7 @@ export async function runStop(
   const advisory = getPendingAdvisory(store, payload.cwd);
   if (!advisory) {
     logger.debug('stop_no_pending', { cwd: payload.cwd });
-    writeTelemetry(payload.cwd, 'stop_no_pending');
+    writeTelemetry(payload.cwd, 'stop_no_pending', undefined, store);
     return { outcome: 'no_pending' };
   }
 
@@ -137,7 +137,7 @@ export async function runStop(
     flagType:         advisory.flagType,
     stage:            advisory.stage,
     generatedOptions: !!(advisory.generatedL1 && advisory.generatedL2 && advisory.generatedL3),
-  });
+  }, store);
 
   const dsResult = await runDecisionSession(
     {

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  telemetrySyncStatusAction,
+  telemetrySyncEnableAction,
+  telemetrySyncDisableAction,
+  telemetrySyncResetCursorAction,
+  telemetrySyncRunAction,
+} from './telemetry-sync.js';
+import { openStore, closeStore } from '../../store/db.js';
+import { setConfig, getConfig } from '../../store/config.js';
+import { saveCursor, loadCursor } from '../../telemetry/TelemetryCursor.js';
+import { saveSyncState } from '../../telemetry/TelemetrySyncScheduler.js';
+
+let tmpDir:       string;
+let dbPath:       string;
+let statePath:    string;
+let cursorPath:   string;
+let livePath:     string;
+let rotPath:      string;
+let errorLogPath: string;
+
+beforeEach(() => {
+  tmpDir       = mkdtempSync(join(tmpdir(), 'nexpath-cli-ts-'));
+  dbPath       = join(tmpDir, `${randomUUID()}.db`);
+  statePath    = join(tmpDir, 'state.json');
+  cursorPath   = join(tmpDir, 'cursor.json');
+  livePath     = join(tmpDir, 'telemetry.jsonl');
+  rotPath      = `${livePath}.1`;
+  errorLogPath = join(tmpDir, 'sync-errors.log');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  process.exitCode = 0;
+});
+
+async function withConfig(setup: (store: Awaited<ReturnType<typeof openStore>>) => void) {
+  const store = await openStore(dbPath);
+  setup(store);
+  closeStore(store);
+}
+
+function captureOutput(): { lines: string[]; print: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, print: (l) => lines.push(l) };
+}
+
+describe('telemetrySyncStatusAction', () => {
+  it('prints status with defaults when no state, cursor, or config is set', async () => {
+    const { lines, print } = captureOutput();
+    await telemetrySyncStatusAction({ dbPath, statePath, cursorPath, output: print });
+    const text = lines.join('\n');
+    expect(text).toContain('Enabled:              no');
+    expect(text).toContain('Endpoint:             https://us.i.posthog.com/capture/');
+    expect(text).toContain('API key configured:   no');
+    expect(text).toContain('Last attempt:         (never)');
+    expect(text).toContain('Last success:         (never)');
+    expect(text).toContain('Consecutive failures: 0');
+    expect(text).toContain('Cursor offset:        0');
+  });
+
+  it('reflects config and persisted state', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry_sync_api_key', 'phc_abc');
+      setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/');
+    });
+    saveSyncState({
+      next_sync_at:         '2026-05-19T12:00:00.000Z',
+      last_attempt_at:      '2026-05-19T11:50:00.000Z',
+      last_success_at:      '2026-05-19T11:50:01.000Z',
+      last_error:           null,
+      consecutive_failures: 0,
+    }, statePath);
+    saveCursor({ inode: 12345, offset: 67890, last_synced_ts: null }, cursorPath);
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncStatusAction({ dbPath, statePath, cursorPath, output: print });
+    const text = lines.join('\n');
+    expect(text).toContain('Enabled:              yes');
+    expect(text).toContain('Endpoint:             https://eu.example/capture/');
+    expect(text).toContain('API key configured:   yes');
+    expect(text).toContain('Last success:         2026-05-19T11:50:01.000Z');
+    expect(text).toContain('Cursor inode:         12345');
+    expect(text).toContain('Cursor offset:        67890');
+  });
+});
+
+describe('telemetrySyncEnableAction', () => {
+  it('sets telemetry_sync_enabled to "true"', async () => {
+    const { lines, print } = captureOutput();
+    await telemetrySyncEnableAction({ dbPath, output: print });
+
+    const store = await openStore(dbPath);
+    expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
+    closeStore(store);
+    expect(lines.join('\n')).toContain('Telemetry sync enabled.');
+  });
+});
+
+describe('telemetrySyncDisableAction', () => {
+  it('sets telemetry_sync_enabled to "false"', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_enabled', 'true'));
+    const { lines, print } = captureOutput();
+    await telemetrySyncDisableAction({ dbPath, output: print });
+
+    const store = await openStore(dbPath);
+    expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+    closeStore(store);
+    expect(lines.join('\n')).toContain('Telemetry sync disabled.');
+  });
+});
+
+describe('telemetrySyncResetCursorAction', () => {
+  it('moves cursor to current end-of-file (offset = file size)', async () => {
+    appendFileSync(livePath, '{"ts":"2026-05-19T10:00:00.000Z","v":1,"event":"prompt_received","projectRoot":"/tmp"}\n', 'utf8');
+    appendFileSync(livePath, '{"ts":"2026-05-19T10:01:00.000Z","v":1,"event":"prompt_classified","projectRoot":"/tmp"}\n', 'utf8');
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncResetCursorAction({ liveLogPath: livePath, cursorPath, output: print });
+
+    const cursor = loadCursor(cursorPath);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.offset).toBe(statSync(livePath).size);
+    expect(cursor!.inode).toBe(statSync(livePath).ino);
+    expect(lines.join('\n')).toContain('Cursor reset to end of telemetry log');
+  });
+
+  it('clears cursor file when telemetry log does not exist', async () => {
+    writeFileSync(cursorPath, JSON.stringify({ inode: 1, offset: 100, last_synced_ts: null }), 'utf8');
+    const { lines, print } = captureOutput();
+    await telemetrySyncResetCursorAction({ liveLogPath: livePath, cursorPath, output: print });
+    expect(existsSync(cursorPath)).toBe(false);
+    expect(lines.join('\n')).toContain('No telemetry log present');
+  });
+});
+
+describe('telemetrySyncRunAction', () => {
+  it('bails with exit code 1 when api_key is unset', async () => {
+    const { lines, print } = captureOutput();
+    await telemetrySyncRunAction({ dbPath, output: print });
+    expect(process.exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('telemetry_sync_api_key is not configured');
+  });
+
+  it('runs the sync attempt and prints the result status', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key', 'phc_test');
+    });
+
+    const ev = {
+      ts:             '2026-05-19T10:00:00.000Z',
+      v:              1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId:         'u',
+      teamId:         't',
+      projectRoot:    '/tmp/p',
+      event:          'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }) as unknown as Response,
+    );
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const text = lines.join('\n');
+    expect(text).toContain('Status:      ok');
+    expect(text).toContain('Sent events: 1');
+  });
+
+  it('non-ok / non-noop result sets exit code 1', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key', 'phc_test');
+    });
+    const ev = {
+      ts:             '2026-05-19T10:00:00.000Z',
+      v:              1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId:         'u',
+      teamId:         't',
+      projectRoot:    '/tmp/p',
+      event:          'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 503 }) as unknown as Response,
+    );
+
+    const { print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -474,6 +474,22 @@ describe('telemetrySyncPingAction', () => {
     await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
     expect(lines.join('\n')).toContain('Retry-After: 60s');
   });
+
+  it('does NOT touch cursor or sync-state files (ping is isolated debug-only)', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', 'phc_test'));
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+
+    const cursorPathBefore = existsSync(cursorPath);
+    const statePathBefore  = existsSync(statePath);
+
+    const { print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+
+    expect(existsSync(cursorPath)).toBe(cursorPathBefore);
+    expect(existsSync(statePath)).toBe(statePathBefore);
+  });
 });
 
 describe('telemetrySyncRunAction (continued)', () => {

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -9,7 +9,9 @@ import {
   telemetrySyncDisableAction,
   telemetrySyncResetCursorAction,
   telemetrySyncRunAction,
+  telemetrySyncPingAction,
 } from './telemetry-sync.js';
+import type { FetchLike } from '../../telemetry/TelemetryClient.js';
 import { openStore, closeStore } from '../../store/db.js';
 import { setConfig, getConfig } from '../../store/config.js';
 import { saveCursor, loadCursor } from '../../telemetry/TelemetryCursor.js';
@@ -395,6 +397,84 @@ describe('telemetrySyncRunAction', () => {
     expect(process.exitCode).toBe(1);
   });
 
+});
+
+describe('telemetrySyncPingAction', () => {
+  it('exits 1 when api_key is not configured', async () => {
+    const { lines, print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print });
+    expect(process.exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('telemetry_sync_api_key is not configured');
+  });
+
+  it('sends a single test event with valid PostHog shape and reports success', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', 'phc_ping_test'));
+
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+    expect(process.exitCode).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const init = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(init.body);
+    expect(body.api_key).toBe('phc_ping_test');
+    expect(body.batch).toHaveLength(1);
+    expect(body.batch[0].event).toBe('nexpath_ping_test');
+    expect(body.batch[0].properties.ping).toBe(true);
+    expect(body.batch[0].properties.$lib).toBe('nexpath');
+    expect(lines.join('\n')).toContain('Ping succeeded');
+  });
+
+  it('uses configured endpoint when set', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key',  'phc_test');
+      setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/');
+    });
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+    const { print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://eu.example/capture/');
+  });
+
+  it('reports network error and exits 1', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', 'phc_test'));
+    const fetchMock = vi.fn<FetchLike>(async () => { throw new Error('ENETDOWN'); });
+    const { lines, print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+    expect(process.exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('Network error');
+  });
+
+  it('reports HTTP error with status and exits 1', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', 'phc_test'));
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 401, headers: { get: () => null },
+    }));
+    const { lines, print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+    expect(process.exitCode).toBe(1);
+    expect(lines.join('\n')).toContain('HTTP 401');
+  });
+
+  it('prints retry-after seconds on 429', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', 'phc_test'));
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 429,
+      headers: { get: (h: string) => h === 'Retry-After' ? '60' : null },
+    }));
+    const { lines, print } = captureOutput();
+    await telemetrySyncPingAction({ dbPath, output: print }, fetchMock);
+    expect(lines.join('\n')).toContain('Retry-After: 60s');
+  });
+});
+
+describe('telemetrySyncRunAction (continued)', () => {
   it('non-ok / non-noop result sets exit code 1', async () => {
     await withConfig(store => {
       setConfig(store, 'telemetry_sync_api_key', 'phc_test');

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -118,7 +118,7 @@ describe('telemetrySyncEnableAction — first-time consent flow', () => {
     expect(text).toContain('What is NEVER uploaded:');
     expect(text).toContain('Raw user prompt text');
     expect(text).toContain('How often:  every 10–30 minutes');
-    expect(text).toContain('PostHog');
+    expect(text).toContain('Where to:   https://us.i.posthog.com/capture/');
     expect(text).toContain('Telemetry sync enabled.');
 
     const store = await openStore(dbPath);
@@ -197,6 +197,38 @@ describe('telemetrySyncEnableAction — first-time consent flow', () => {
       endpoint:          'https://eu.example/capture/',
       hash_project_root: true,
     });
+  });
+
+  it('banner shows the configured endpoint, not just the PostHog default', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/'));
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncEnableAction(
+      { dbPath, output: print },
+      async () => false,
+      () => {},
+    );
+    const text = lines.join('\n');
+    expect(text).toContain('Where to:   https://eu.example/capture/');
+    expect(text).not.toContain('https://us.i.posthog.com');
+  });
+
+  it('default audit swallows logger failures (enable still completes)', async () => {
+    const loggerModule = await import('../../logger.js');
+    vi.spyOn(loggerModule.logger, 'info').mockImplementation(() => {
+      throw new Error('logger broken');
+    });
+
+    const { lines, print } = captureOutput();
+    await expect(
+      telemetrySyncEnableAction({ dbPath, output: print }, async () => true),
+    ).resolves.toBeUndefined();
+
+    const store = await openStore(dbPath);
+    expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
+    expect(getConfig(store.db, 'telemetry_sync_consent_granted')).toBe('true');
+    closeStore(store);
+    expect(lines.join('\n')).toContain('Telemetry sync enabled.');
   });
 });
 

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -370,7 +370,7 @@ describe('telemetrySyncRunAction', () => {
     });
     const init = fetchSpy.mock.calls[0][1] as { body: string };
     const body = JSON.parse(init.body);
-    expect(body.batch[0].properties.projectRoot).toBe('/home/jemi/raw-path');
+    expect(body.properties.projectRoot).toBe('/home/jemi/raw-path');
   });
 
   it('prints Retry-After value on 429', async () => {
@@ -424,10 +424,11 @@ describe('telemetrySyncPingAction', () => {
     const init = fetchMock.mock.calls[0][1];
     const body = JSON.parse(init.body);
     expect(body.api_key).toBe('phc_ping_test');
-    expect(body.batch).toHaveLength(1);
-    expect(body.batch[0].event).toBe('nexpath_ping_test');
-    expect(body.batch[0].properties.ping).toBe(true);
-    expect(body.batch[0].properties.$lib).toBe('nexpath');
+    expect(body.event).toBe('nexpath_ping_test');
+    expect(body.distinct_id).toMatch(/^nexpath-ping-/);
+    expect(body.properties.ping).toBe(true);
+    expect(body.properties.$lib).toBe('nexpath');
+    expect(body.batch).toBeUndefined();
     expect(lines.join('\n')).toContain('Ping succeeded');
   });
 

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -59,7 +59,7 @@ describe('telemetrySyncStatusAction', () => {
     const text = lines.join('\n');
     expect(text).toContain('Enabled:              no');
     expect(text).toContain('Endpoint:             https://us.i.posthog.com/capture/');
-    expect(text).toContain('API key configured:   no');
+    expect(text).toContain('API key configured:   yes');
     expect(text).toContain('Last attempt:         (never)');
     expect(text).toContain('Last success:         (never)');
     expect(text).toContain('Consecutive failures: 0');
@@ -272,7 +272,8 @@ describe('telemetrySyncResetCursorAction', () => {
 });
 
 describe('telemetrySyncRunAction', () => {
-  it('bails with exit code 1 when api_key is unset', async () => {
+  it('bails with exit code 1 when api_key is cleared (empty)', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', ''));
     const { lines, print } = captureOutput();
     await telemetrySyncRunAction({ dbPath, output: print });
     expect(process.exitCode).toBe(1);
@@ -400,7 +401,8 @@ describe('telemetrySyncRunAction', () => {
 });
 
 describe('telemetrySyncPingAction', () => {
-  it('exits 1 when api_key is not configured', async () => {
+  it('exits 1 when api_key is cleared (empty)', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_api_key', ''));
     const { lines, print } = captureOutput();
     await telemetrySyncPingAction({ dbPath, output: print });
     expect(process.exitCode).toBe(1);

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -102,15 +102,101 @@ describe('telemetrySyncStatusAction', () => {
   });
 });
 
-describe('telemetrySyncEnableAction', () => {
-  it('sets telemetry_sync_enabled to "true"', async () => {
+describe('telemetrySyncEnableAction — first-time consent flow', () => {
+  it('shows privacy banner on first invocation and sets flag when confirmed', async () => {
     const { lines, print } = captureOutput();
-    await telemetrySyncEnableAction({ dbPath, output: print });
+    const audit            = vi.fn();
+    await telemetrySyncEnableAction(
+      { dbPath, output: print },
+      async () => true,
+      audit,
+    );
+
+    const text = lines.join('\n');
+    expect(text).toContain('Telemetry sync — privacy notice');
+    expect(text).toContain('What is uploaded:');
+    expect(text).toContain('What is NEVER uploaded:');
+    expect(text).toContain('Raw user prompt text');
+    expect(text).toContain('How often:  every 10–30 minutes');
+    expect(text).toContain('PostHog');
+    expect(text).toContain('Telemetry sync enabled.');
+
+    const store = await openStore(dbPath);
+    expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
+    expect(getConfig(store.db, 'telemetry_sync_consent_granted')).toBe('true');
+    closeStore(store);
+
+    expect(audit).toHaveBeenCalledWith('telemetry_sync_consent_granted', expect.objectContaining({
+      nexpath_version:   '0.1.1',
+      hash_project_root: true,
+    }));
+  });
+
+  it('does NOT set flag when user declines confirmation', async () => {
+    const { lines, print } = captureOutput();
+    const audit            = vi.fn();
+    await telemetrySyncEnableAction(
+      { dbPath, output: print },
+      async () => false,
+      audit,
+    );
+
+    const store = await openStore(dbPath);
+    expect(getConfig(store.db, 'telemetry_sync_enabled')).toBeUndefined();
+    expect(getConfig(store.db, 'telemetry_sync_consent_granted')).toBeUndefined();
+    closeStore(store);
+
+    expect(audit).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('Telemetry sync NOT enabled');
+  });
+
+  it('skips the banner on subsequent invocations once consent is granted', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_consent_granted', 'true'));
+
+    const { lines, print } = captureOutput();
+    const confirmFn        = vi.fn(async () => true);
+    const audit            = vi.fn();
+    await telemetrySyncEnableAction({ dbPath, output: print }, confirmFn, audit);
+
+    const text = lines.join('\n');
+    expect(text).not.toContain('Telemetry sync — privacy notice');
+    expect(confirmFn).not.toHaveBeenCalled();
+    expect(audit).not.toHaveBeenCalled();
 
     const store = await openStore(dbPath);
     expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('true');
     closeStore(store);
-    expect(lines.join('\n')).toContain('Telemetry sync enabled.');
+  });
+
+  it('banner reflects hash_project_root config — "raw" when disabled', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_hash_project_root', 'false'));
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncEnableAction(
+      { dbPath, output: print },
+      async () => false,
+      () => {},
+    );
+    const text = lines.join('\n');
+    expect(text).toContain('Project root path (raw');
+  });
+
+  it('audit payload includes endpoint and hash flag', async () => {
+    await withConfig(store => setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/'));
+
+    const audit = vi.fn();
+    const { print } = captureOutput();
+    await telemetrySyncEnableAction(
+      { dbPath, output: print },
+      async () => true,
+      audit,
+    );
+
+    expect(audit).toHaveBeenCalledWith('telemetry_sync_consent_granted', {
+      nexpath_version:   '0.1.1',
+      endpoint:          'https://eu.example/capture/',
+      hash_project_root: true,
+    });
   });
 });
 

--- a/src/cli/commands/telemetry-sync.test.ts
+++ b/src/cli/commands/telemetry-sync.test.ts
@@ -64,6 +64,17 @@ describe('telemetrySyncStatusAction', () => {
     expect(text).toContain('Cursor offset:        0');
   });
 
+  it('gracefully shows defaults when state and cursor files are corrupt JSON', async () => {
+    writeFileSync(statePath,  'not-json{', 'utf8');
+    writeFileSync(cursorPath, 'also-corrupt}}}', 'utf8');
+    const { lines, print } = captureOutput();
+    await telemetrySyncStatusAction({ dbPath, statePath, cursorPath, output: print });
+    const text = lines.join('\n');
+    expect(text).toContain('Last attempt:         (never)');
+    expect(text).toContain('Cursor inode:         (uninitialised)');
+    expect(text).toContain('Cursor offset:        0');
+  });
+
   it('reflects config and persisted state', async () => {
     await withConfig(store => {
       setConfig(store, 'telemetry_sync_enabled', 'true');
@@ -176,6 +187,94 @@ describe('telemetrySyncRunAction', () => {
     const text = lines.join('\n');
     expect(text).toContain('Status:      ok');
     expect(text).toContain('Sent events: 1');
+  });
+
+  it('prints "noop" and exit code 0 when there are no events to send', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key', 'phc_test');
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+    expect(lines.join('\n')).toContain('Status:      noop');
+  });
+
+  it('uses telemetry_sync_endpoint config override when sending', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key',  'phc_test');
+      setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/');
+    });
+    const ev = {
+      ts: '2026-05-19T10:00:00.000Z', v: 1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId: 'u', teamId: 't', projectRoot: '/tmp/p', event: 'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }) as unknown as Response,
+    );
+
+    const { print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://eu.example/capture/');
+  });
+
+  it('sends raw projectRoot when telemetry_sync_hash_project_root=false', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key',              'phc_test');
+      setConfig(store, 'telemetry_sync_hash_project_root',    'false');
+    });
+    const ev = {
+      ts: '2026-05-19T10:00:00.000Z', v: 1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId: 'u', teamId: 't', projectRoot: '/home/jemi/raw-path', event: 'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }) as unknown as Response,
+    );
+
+    const { print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    const init = fetchSpy.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(init.body);
+    expect(body.batch[0].properties.projectRoot).toBe('/home/jemi/raw-path');
+  });
+
+  it('prints Retry-After value on 429', async () => {
+    await withConfig(store => {
+      setConfig(store, 'telemetry_sync_api_key', 'phc_test');
+    });
+    const ev = {
+      ts: '2026-05-19T10:00:00.000Z', v: 1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId: 'u', teamId: 't', projectRoot: '/tmp/p', event: 'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 429, headers: { 'Retry-After': '120' } }) as unknown as Response,
+    );
+
+    const { lines, print } = captureOutput();
+    await telemetrySyncRunAction({
+      dbPath, cursorPath, liveLogPath: livePath, rotatedLogPath: rotPath, errorLogPath, output: print,
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('Status:      rate_limited');
+    expect(text).toContain('Retry-After: 120s');
+    expect(process.exitCode).toBe(1);
   });
 
   it('non-ok / non-noop result sets exit code 1', async () => {

--- a/src/cli/commands/telemetry-sync.ts
+++ b/src/cli/commands/telemetry-sync.ts
@@ -1,4 +1,5 @@
 import { statSync } from 'node:fs';
+import { confirm, isCancel } from '@clack/prompts';
 import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
 import { getConfig, setConfig } from '../../store/config.js';
 import { loadSyncState } from '../../telemetry/TelemetrySyncScheduler.js';
@@ -6,6 +7,9 @@ import { loadCursor, saveCursor, clearCursor } from '../../telemetry/TelemetryCu
 import { runSyncAttempt } from '../../telemetry/TelemetrySyncRunner.js';
 import { DEFAULT_POSTHOG_ENDPOINT } from '../../telemetry/TelemetryClient.js';
 import { TELEMETRY_PATH, TELEMETRY_SYNC_CURSOR_PATH } from '../../telemetry/paths.js';
+import { logger } from '../../logger.js';
+
+const NEXPATH_VERSION = '0.1.1';
 
 export interface TelemetrySyncActionOpts {
   dbPath?:         string;
@@ -18,6 +22,47 @@ export interface TelemetrySyncActionOpts {
 }
 
 const defaultPrint = (line: string): void => { console.log(line); };
+
+export type ConfirmFn = () => Promise<boolean>;
+export type AuditFn   = (event: string, props: Record<string, unknown>) => void;
+
+const defaultEnableConfirm: ConfirmFn = async () => {
+  const answer = await confirm({
+    message:      'Enable telemetry sync?',
+    initialValue: false,
+  });
+  return !isCancel(answer) && answer === true;
+};
+
+const defaultAudit: AuditFn = (event, props) => {
+  try {
+    logger.info(event, props);
+  } catch {
+    // Audit logging failure must never crash the command.
+  }
+};
+
+function printPrivacyBanner(print: (line: string) => void, hashEnabled: boolean): void {
+  print('');
+  print('Telemetry sync — privacy notice');
+  print('');
+  print('What is uploaded:');
+  print('  • Event names (e.g. prompt_received, decision_session_started)');
+  print('  • Structured metadata (counters, classifications, timestamps)');
+  print('  • Auto-generated installation / user / team UUIDs');
+  print(`  • Project root path (${hashEnabled ? 'SHA-256 hashed' : 'raw'} — toggle via telemetry_sync_hash_project_root)`);
+  print('');
+  print('What is NEVER uploaded:');
+  print('  • Raw user prompt text');
+  print('  • Your source code');
+  print('  • OpenAI API key');
+  print('  • Any personal information beyond what is listed above');
+  print('');
+  print('How often:  every 10–30 minutes (random)');
+  print('Where to:   PostHog (https://us.i.posthog.com)');
+  print('To disable: nexpath telemetry-sync disable');
+  print('');
+}
 
 export async function telemetrySyncStatusAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
   const print = opts.output ?? defaultPrint;
@@ -45,10 +90,34 @@ export async function telemetrySyncStatusAction(opts: TelemetrySyncActionOpts = 
   }
 }
 
-export async function telemetrySyncEnableAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+export async function telemetrySyncEnableAction(
+  opts:       TelemetrySyncActionOpts = {},
+  confirmFn:  ConfirmFn = defaultEnableConfirm,
+  audit:      AuditFn   = defaultAudit,
+): Promise<void> {
   const print = opts.output ?? defaultPrint;
   const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
   try {
+    const alreadyConsented = getConfig(store.db, 'telemetry_sync_consent_granted') === 'true';
+
+    if (!alreadyConsented) {
+      const hashEnabled = getConfig(store.db, 'telemetry_sync_hash_project_root') !== 'false';
+      printPrivacyBanner(print, hashEnabled);
+
+      const confirmed = await confirmFn();
+      if (!confirmed) {
+        print('Telemetry sync NOT enabled. Run "nexpath telemetry-sync enable" again to opt in.');
+        return;
+      }
+
+      setConfig(store, 'telemetry_sync_consent_granted', 'true');
+      audit('telemetry_sync_consent_granted', {
+        nexpath_version:    NEXPATH_VERSION,
+        endpoint:           getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT,
+        hash_project_root:  hashEnabled,
+      });
+    }
+
     setConfig(store, 'telemetry_sync_enabled', 'true');
     print('Telemetry sync enabled.');
     print('Sync window: 10–30 minutes (override via telemetry_sync_min_minutes / _max_minutes).');

--- a/src/cli/commands/telemetry-sync.ts
+++ b/src/cli/commands/telemetry-sync.ts
@@ -1,0 +1,141 @@
+import { statSync } from 'node:fs';
+import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
+import { getConfig, setConfig } from '../../store/config.js';
+import { loadSyncState } from '../../telemetry/TelemetrySyncScheduler.js';
+import { loadCursor, saveCursor, clearCursor } from '../../telemetry/TelemetryCursor.js';
+import { runSyncAttempt } from '../../telemetry/TelemetrySyncRunner.js';
+import { DEFAULT_POSTHOG_ENDPOINT } from '../../telemetry/TelemetryClient.js';
+import { TELEMETRY_PATH, TELEMETRY_SYNC_CURSOR_PATH } from '../../telemetry/paths.js';
+
+export interface TelemetrySyncActionOpts {
+  dbPath?:         string;
+  statePath?:      string;
+  cursorPath?:     string;
+  liveLogPath?:    string;
+  rotatedLogPath?: string;
+  errorLogPath?:   string;
+  output?:         (line: string) => void;
+}
+
+const defaultPrint = (line: string): void => { console.log(line); };
+
+export async function telemetrySyncStatusAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+  const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
+  try {
+    const enabled    = getConfig(store.db, 'telemetry_sync_enabled') === 'true';
+    const endpoint   = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    const apiKeySet  = (getConfig(store.db, 'telemetry_sync_api_key') ?? '').length > 0;
+    const state      = loadSyncState(opts.statePath);
+    const cursor     = loadCursor(opts.cursorPath);
+
+    print('Telemetry sync status:');
+    print(`  Enabled:              ${enabled ? 'yes' : 'no'}`);
+    print(`  Endpoint:             ${endpoint}`);
+    print(`  API key configured:   ${apiKeySet ? 'yes' : 'no'}`);
+    print(`  Last attempt:         ${state?.last_attempt_at  ?? '(never)'}`);
+    print(`  Last success:         ${state?.last_success_at  ?? '(never)'}`);
+    print(`  Last error:           ${state?.last_error       ?? '(none)'}`);
+    print(`  Consecutive failures: ${state?.consecutive_failures ?? 0}`);
+    print(`  Next scheduled:       ${state?.next_sync_at     ?? '(not scheduled)'}`);
+    print(`  Cursor inode:         ${cursor?.inode  ?? '(uninitialised)'}`);
+    print(`  Cursor offset:        ${cursor?.offset ?? 0}`);
+  } finally {
+    closeStore(store);
+  }
+}
+
+export async function telemetrySyncEnableAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+  const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
+  try {
+    setConfig(store, 'telemetry_sync_enabled', 'true');
+    print('Telemetry sync enabled.');
+    print('Sync window: 10–30 minutes (override via telemetry_sync_min_minutes / _max_minutes).');
+    print('Disable anytime: nexpath telemetry-sync disable');
+  } finally {
+    closeStore(store);
+  }
+}
+
+export async function telemetrySyncDisableAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+  const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
+  try {
+    setConfig(store, 'telemetry_sync_enabled', 'false');
+    print('Telemetry sync disabled.');
+    print('Note: in-flight syncs will complete; no new ones will fire.');
+  } finally {
+    closeStore(store);
+  }
+}
+
+export async function telemetrySyncResetCursorAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+  const print       = opts.output      ?? defaultPrint;
+  const liveLogPath = opts.liveLogPath ?? TELEMETRY_PATH;
+  const cursorPath  = opts.cursorPath  ?? TELEMETRY_SYNC_CURSOR_PATH;
+  try {
+    const stat = statSync(liveLogPath);
+    saveCursor({
+      inode:          stat.ino,
+      offset:         stat.size,
+      last_synced_ts: new Date().toISOString(),
+    }, cursorPath);
+    print(`Cursor reset to end of telemetry log (offset=${stat.size}).`);
+    print('Existing backlog will be skipped; new events from this point forward will sync.');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      clearCursor(cursorPath);
+      print('No telemetry log present — cursor cleared.');
+      return;
+    }
+    print(`Error: ${(err as Error).message}`);
+    process.exitCode = 1;
+  }
+}
+
+export async function telemetrySyncRunAction(opts: TelemetrySyncActionOpts = {}): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+  const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
+  try {
+    const apiKey = getConfig(store.db, 'telemetry_sync_api_key');
+    if (!apiKey) {
+      print('Error: telemetry_sync_api_key is not configured.');
+      print('Set it with: nexpath config set telemetry_sync_api_key <token>');
+      process.exitCode = 1;
+      return;
+    }
+
+    const endpoint        = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    const timeoutMsRaw    = getConfig(store.db, 'telemetry_sync_timeout_ms');
+    const maxEventsRaw    = getConfig(store.db, 'telemetry_sync_batch_max_events');
+    const maxBytesRaw     = getConfig(store.db, 'telemetry_sync_batch_max_bytes');
+    const hashFlag        = getConfig(store.db, 'telemetry_sync_hash_project_root');
+
+    const runnerOpts: Parameters<typeof runSyncAttempt>[0] = { apiKey, endpoint };
+    if (opts.liveLogPath    !== undefined) runnerOpts.liveLogPath    = opts.liveLogPath;
+    if (opts.rotatedLogPath !== undefined) runnerOpts.rotatedLogPath = opts.rotatedLogPath;
+    if (opts.cursorPath     !== undefined) runnerOpts.cursorPath     = opts.cursorPath;
+    if (opts.errorLogPath   !== undefined) runnerOpts.errorLogPath   = opts.errorLogPath;
+    if (timeoutMsRaw && Number.isFinite(Number(timeoutMsRaw))) runnerOpts.timeoutMs         = Number(timeoutMsRaw);
+    if (maxEventsRaw && Number.isFinite(Number(maxEventsRaw))) runnerOpts.maxEventsPerBatch = Number(maxEventsRaw);
+    if (maxBytesRaw  && Number.isFinite(Number(maxBytesRaw)))  runnerOpts.maxBytesPerBatch  = Number(maxBytesRaw);
+    if (hashFlag !== undefined) runnerOpts.hashProjectRoot = hashFlag !== 'false';
+
+    print('Running sync...');
+    const result = await runSyncAttempt(runnerOpts);
+
+    print(`Status:      ${result.status}`);
+    print(`Sent events: ${result.sentEvents}`);
+    if (result.httpStatus        !== undefined) print(`HTTP status: ${result.httpStatus}`);
+    if (result.retryAfterSeconds !== undefined) print(`Retry-After: ${result.retryAfterSeconds}s`);
+    if (result.shouldDisableSync) {
+      print('Threshold reached — auto-disable would trigger in scheduled mode.');
+    }
+    if (result.status !== 'ok' && result.status !== 'noop') {
+      process.exitCode = 1;
+    }
+  } finally {
+    closeStore(store);
+  }
+}

--- a/src/cli/commands/telemetry-sync.ts
+++ b/src/cli/commands/telemetry-sync.ts
@@ -5,9 +5,11 @@ import { getConfig, setConfig } from '../../store/config.js';
 import { loadSyncState } from '../../telemetry/TelemetrySyncScheduler.js';
 import { loadCursor, saveCursor, clearCursor } from '../../telemetry/TelemetryCursor.js';
 import { runSyncAttempt } from '../../telemetry/TelemetrySyncRunner.js';
-import { DEFAULT_POSTHOG_ENDPOINT } from '../../telemetry/TelemetryClient.js';
+import { DEFAULT_POSTHOG_ENDPOINT, postBatch, type FetchLike } from '../../telemetry/TelemetryClient.js';
+import { POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION } from '../../telemetry/TelemetryBatcher.js';
 import { TELEMETRY_PATH, TELEMETRY_SYNC_CURSOR_PATH } from '../../telemetry/paths.js';
 import { logger } from '../../logger.js';
+import type { PostHogBatchEnvelope } from '../../telemetry/types.js';
 
 const NEXPATH_VERSION = '0.1.1';
 
@@ -165,6 +167,56 @@ export async function telemetrySyncResetCursorAction(opts: TelemetrySyncActionOp
     }
     print(`Error: ${(err as Error).message}`);
     process.exitCode = 1;
+  }
+}
+
+export async function telemetrySyncPingAction(
+  opts:      TelemetrySyncActionOpts = {},
+  fetchImpl: FetchLike = globalThis.fetch as unknown as FetchLike,
+): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+  const store = await openStore(opts.dbPath ?? DEFAULT_DB_PATH);
+  try {
+    const apiKey = getConfig(store.db, 'telemetry_sync_api_key');
+    if (!apiKey) {
+      print('Error: telemetry_sync_api_key is not configured.');
+      print('Set it with: nexpath config set telemetry_sync_api_key <token>');
+      process.exitCode = 1;
+      return;
+    }
+    const endpoint = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+
+    const envelope: PostHogBatchEnvelope = {
+      api_key: apiKey,
+      batch: [{
+        event:       'nexpath_ping_test',
+        distinct_id: `nexpath-ping-${Date.now()}`,
+        timestamp:   new Date().toISOString(),
+        properties: {
+          $lib:          POSTHOG_LIB_NAME,
+          $lib_version:  POSTHOG_LIB_VERSION,
+          ping:          true,
+        },
+      }],
+    };
+
+    print(`Pinging ${endpoint}...`);
+    const result = await postBatch(endpoint, envelope, { fetch: fetchImpl });
+
+    if (result.ok) {
+      print(`✓ Ping succeeded (HTTP ${result.status}). Telemetry sync is reachable.`);
+      return;
+    }
+    if (result.kind === 'network') {
+      print('✗ Network error. Check connectivity and endpoint.');
+      process.exitCode = 1;
+      return;
+    }
+    print(`✗ HTTP ${result.status}. Check api_key and endpoint config.`);
+    if (result.retryAfterSeconds !== undefined) print(`  Retry-After: ${result.retryAfterSeconds}s`);
+    process.exitCode = 1;
+  } finally {
+    closeStore(store);
   }
 }
 

--- a/src/cli/commands/telemetry-sync.ts
+++ b/src/cli/commands/telemetry-sync.ts
@@ -5,11 +5,11 @@ import { getConfig, setConfig } from '../../store/config.js';
 import { loadSyncState } from '../../telemetry/TelemetrySyncScheduler.js';
 import { loadCursor, saveCursor, clearCursor } from '../../telemetry/TelemetryCursor.js';
 import { runSyncAttempt } from '../../telemetry/TelemetrySyncRunner.js';
-import { DEFAULT_POSTHOG_ENDPOINT, postBatch, type FetchLike } from '../../telemetry/TelemetryClient.js';
+import { DEFAULT_POSTHOG_ENDPOINT, postEvent, type FetchLike } from '../../telemetry/TelemetryClient.js';
 import { POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION } from '../../telemetry/TelemetryBatcher.js';
 import { TELEMETRY_PATH, TELEMETRY_SYNC_CURSOR_PATH } from '../../telemetry/paths.js';
 import { logger } from '../../logger.js';
-import type { PostHogBatchEnvelope } from '../../telemetry/types.js';
+import type { PostHogSingleEnvelope } from '../../telemetry/types.js';
 
 const NEXPATH_VERSION = '0.1.1';
 
@@ -186,22 +186,20 @@ export async function telemetrySyncPingAction(
     }
     const endpoint = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
 
-    const envelope: PostHogBatchEnvelope = {
-      api_key: apiKey,
-      batch: [{
-        event:       'nexpath_ping_test',
-        distinct_id: `nexpath-ping-${Date.now()}`,
-        timestamp:   new Date().toISOString(),
-        properties: {
-          $lib:          POSTHOG_LIB_NAME,
-          $lib_version:  POSTHOG_LIB_VERSION,
-          ping:          true,
-        },
-      }],
+    const envelope: PostHogSingleEnvelope = {
+      api_key:     apiKey,
+      event:       'nexpath_ping_test',
+      distinct_id: `nexpath-ping-${Date.now()}`,
+      timestamp:   new Date().toISOString(),
+      properties: {
+        $lib:          POSTHOG_LIB_NAME,
+        $lib_version:  POSTHOG_LIB_VERSION,
+        ping:          true,
+      },
     };
 
     print(`Pinging ${endpoint}...`);
-    const result = await postBatch(endpoint, envelope, { fetch: fetchImpl });
+    const result = await postEvent(endpoint, envelope, { fetch: fetchImpl });
 
     if (result.ok) {
       print(`✓ Ping succeeded (HTTP ${result.status}). Telemetry sync is reachable.`);

--- a/src/cli/commands/telemetry-sync.ts
+++ b/src/cli/commands/telemetry-sync.ts
@@ -42,7 +42,11 @@ const defaultAudit: AuditFn = (event, props) => {
   }
 };
 
-function printPrivacyBanner(print: (line: string) => void, hashEnabled: boolean): void {
+function printPrivacyBanner(
+  print:       (line: string) => void,
+  hashEnabled: boolean,
+  endpoint:    string,
+): void {
   print('');
   print('Telemetry sync — privacy notice');
   print('');
@@ -59,7 +63,7 @@ function printPrivacyBanner(print: (line: string) => void, hashEnabled: boolean)
   print('  • Any personal information beyond what is listed above');
   print('');
   print('How often:  every 10–30 minutes (random)');
-  print('Where to:   PostHog (https://us.i.posthog.com)');
+  print(`Where to:   ${endpoint}`);
   print('To disable: nexpath telemetry-sync disable');
   print('');
 }
@@ -102,7 +106,8 @@ export async function telemetrySyncEnableAction(
 
     if (!alreadyConsented) {
       const hashEnabled = getConfig(store.db, 'telemetry_sync_hash_project_root') !== 'false';
-      printPrivacyBanner(print, hashEnabled);
+      const endpoint    = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+      printPrivacyBanner(print, hashEnabled, endpoint);
 
       const confirmed = await confirmFn();
       if (!confirmed) {
@@ -113,7 +118,7 @@ export async function telemetrySyncEnableAction(
       setConfig(store, 'telemetry_sync_consent_granted', 'true');
       audit('telemetry_sync_consent_granted', {
         nexpath_version:    NEXPATH_VERSION,
-        endpoint:           getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT,
+        endpoint,
         hash_project_root:  hashEnabled,
       });
     }

--- a/src/cli/commands/uninstall-apikey.test.ts
+++ b/src/cli/commands/uninstall-apikey.test.ts
@@ -136,4 +136,72 @@ describe('uninstallAction — API key cleanup (Plan #1 Phase 6)', () => {
       expect(resolver.getKeySource).toHaveBeenCalledWith('/explicit/project');
     } finally { cleanup(); }
   });
+
+  it('removeApiKey throws → uninstall surfaces the error but still completes the MCP cleanup', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    vi.mocked(resolver.removeApiKey).mockRejectedValueOnce(new Error('keychain unavailable'));
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await expect(uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => true,
+      })).rejects.toThrow(/keychain unavailable/);
+      expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+    } finally { cleanup(); }
+  });
+
+  it('--yes flag with no stored key still silently skips removal (yes does not force a remove call)', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        yes: true,
+      });
+      expect(resolver.removeApiKey).not.toHaveBeenCalled();
+      expect(logSpy.mock.calls.map(c => c[0] as string).join('\n')).toContain('No stored API key found');
+    } finally { cleanup(); }
+  });
+
+  it('"Prompt history retained" line appears AFTER the API key cleanup section', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => true,
+      });
+      const lines = logSpy.mock.calls.map(c => c[0] as string);
+      const keyIdx     = lines.findIndex(l => l.includes('API key removed'));
+      const historyIdx = lines.findIndex(l => l.includes('Prompt history retained'));
+      expect(keyIdx).toBeGreaterThanOrEqual(0);
+      expect(historyIdx).toBeGreaterThanOrEqual(0);
+      expect(keyIdx).toBeLessThan(historyIdx);
+    } finally { cleanup(); }
+  });
+
+  it('agent MCP unregistration still runs regardless of the API key cleanup branch (none source)', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+      });
+      const text = logSpy.mock.calls.map(c => c[0] as string).join('\n');
+      expect(text).toContain('MCP registration removed from all agents');
+      expect(text).toContain('No stored API key found');
+    } finally { cleanup(); }
+  });
 });

--- a/src/cli/commands/uninstall-apikey.test.ts
+++ b/src/cli/commands/uninstall-apikey.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync } from 'node:fs';
+
+vi.mock('../../config/ApiKeyResolver.js', () => ({
+  storeApiKey:    vi.fn(),
+  removeApiKey:   vi.fn(),
+  getKeySource:   vi.fn(),
+  isValidApiKey:  (key: string) => /^sk-[A-Za-z0-9_-]{20,}$/.test(key),
+}));
+
+import { uninstallAction, resolveAgentPaths } from './install.js';
+import * as resolver from '../../config/ApiKeyResolver.js';
+
+function tmpDirAgents(): { dir: string; cleanup: () => void } {
+  const dir = join(tmpdir(), `nexpath-uninstall-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return { dir, cleanup: () => { try { rmSync(dir, { recursive: true }); } catch { /* ignore */ } } };
+}
+
+beforeEach(() => {
+  vi.mocked(resolver.removeApiKey).mockReset().mockResolvedValue(undefined);
+  vi.mocked(resolver.getKeySource).mockReset().mockResolvedValue('none');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('uninstallAction — API key cleanup (Plan #1 Phase 6)', () => {
+  it('confirm Y → calls removeApiKey and logs the previous source', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => true,
+      });
+      expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls.map(c => c[0] as string).join('\n')).toContain('API key removed (was in keychain)');
+    } finally { cleanup(); }
+  });
+
+  it('confirm n → key retained, removeApiKey NOT called, retain hint shown', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => false,
+      });
+      expect(resolver.removeApiKey).not.toHaveBeenCalled();
+      const text = logSpy.mock.calls.map(c => c[0] as string).join('\n');
+      expect(text).toContain('API key retained');
+      expect(text).toContain('nexpath config remove-api-key');
+    } finally { cleanup(); }
+  });
+
+  it('no key stored (getKeySource=none) → silent skip, no confirm prompt fired', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const confirmFn = vi.fn<() => Promise<boolean>>();
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: confirmFn,
+      });
+      expect(confirmFn).not.toHaveBeenCalled();
+      expect(resolver.removeApiKey).not.toHaveBeenCalled();
+      expect(logSpy.mock.calls.map(c => c[0] as string).join('\n')).toContain('No stored API key found');
+    } finally { cleanup(); }
+  });
+
+  it('--yes flag bypasses confirm prompt and removes the key directly', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('file');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const confirmFn = vi.fn<() => Promise<boolean>>();
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        yes: true,
+        apiKeyConfirmFn: confirmFn,
+      });
+      expect(confirmFn).not.toHaveBeenCalled();
+      expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls.map(c => c[0] as string).join('\n')).toContain('API key removed (was in file)');
+    } finally { cleanup(); }
+  });
+
+  it('logs MCP-removal summary BEFORE the API key cleanup section', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => true,
+      });
+      const lines = logSpy.mock.calls.map(c => c[0] as string);
+      const mcpIdx = lines.findIndex(l => l.includes('MCP registration removed'));
+      const keyIdx = lines.findIndex(l => l.includes('API key removed'));
+      expect(mcpIdx).toBeGreaterThanOrEqual(0);
+      expect(keyIdx).toBeGreaterThanOrEqual(0);
+      expect(mcpIdx).toBeLessThan(keyIdx);
+    } finally { cleanup(); }
+  });
+
+  it('projectRoot override flows through to getKeySource', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('none');
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        projectRoot: '/explicit/project',
+        apiKeyConfirmFn: async () => true,
+      });
+      expect(resolver.getKeySource).toHaveBeenCalledWith('/explicit/project');
+    } finally { cleanup(); }
+  });
+});

--- a/src/cli/commands/uninstall-telemetry.test.ts
+++ b/src/cli/commands/uninstall-telemetry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync } from 'node:fs';
+
+vi.mock('../../config/ApiKeyResolver.js', () => ({
+  storeApiKey:    vi.fn(),
+  removeApiKey:   vi.fn(),
+  getKeySource:   vi.fn(),
+  isValidApiKey:  (key: string) => /^sk-[A-Za-z0-9_-]{20,}$/.test(key),
+}));
+
+import { uninstallAction, resolveAgentPaths } from './install.js';
+import * as resolver from '../../config/ApiKeyResolver.js';
+import { openStore, closeStore } from '../../store/db.js';
+import { getConfig, setConfig } from '../../store/config.js';
+
+function tmpDirAgents(): { dir: string; cleanup: () => void } {
+  const dir = join(tmpdir(), `nexpath-uninstall-telem-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return { dir, cleanup: () => { try { rmSync(dir, { recursive: true }); } catch { /* ignore */ } } };
+}
+
+beforeEach(() => {
+  vi.mocked(resolver.removeApiKey).mockReset().mockResolvedValue(undefined);
+  vi.mocked(resolver.getKeySource).mockReset().mockResolvedValue('none');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('uninstallAction — telemetry config cleanup', () => {
+  it('sets both telemetry.enabled and telemetry_sync_enabled to "false" in DB', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'uninstall-telem.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => false,
+        dbPath,
+      });
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('clears pre-existing "true" flags from a prior install', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'uninstall-after-install.db');
+    try {
+      // Simulate a prior install having set both flags to 'true'.
+      const seed = await openStore(dbPath);
+      setConfig(seed, 'telemetry.enabled',      'true');
+      setConfig(seed, 'telemetry_sync_enabled', 'true');
+      closeStore(seed);
+
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => false,
+        dbPath,
+      });
+
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('logs a confirmation line when telemetry is disabled', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'uninstall-log.db');
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => false,
+        dbPath,
+      });
+      const text = logSpy.mock.calls.map(c => c[0] as string).join('\n');
+      expect(text).toContain('Telemetry disabled');
+    } finally { cleanup(); }
+  });
+
+  it('does not crash when the store cannot be opened (best-effort)', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Point dbPath at an existing directory — openStore expects a file path,
+    // so this will fail and the catch block must swallow it.
+    try {
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await expect(uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => false,
+        dbPath: dir,
+      })).resolves.toBeUndefined();
+    } finally { cleanup(); }
+  });
+});

--- a/src/cli/commands/uninstall-telemetry.test.ts
+++ b/src/cli/commands/uninstall-telemetry.test.ts
@@ -109,4 +109,66 @@ describe('uninstallAction — telemetry config cleanup', () => {
       })).resolves.toBeUndefined();
     } finally { cleanup(); }
   });
+
+  it('--yes mode → both flags still cleared (telemetry cleanup runs unconditionally)', async () => {
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'uninstall-yes.db');
+    const confirmFn = vi.fn<() => Promise<boolean>>();
+    try {
+      // Seed prior install state.
+      const seed = await openStore(dbPath);
+      setConfig(seed, 'telemetry.enabled',      'true');
+      setConfig(seed, 'telemetry_sync_enabled', 'true');
+      closeStore(seed);
+
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: confirmFn,
+        yes: true,
+        dbPath,
+      });
+
+      // --yes bypasses the API key prompt entirely.
+      expect(confirmFn).not.toHaveBeenCalled();
+
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
+
+  it('clears telemetry flags even when the API key is also being removed (full flow)', async () => {
+    vi.mocked(resolver.getKeySource).mockResolvedValueOnce('keychain');
+    const { dir, cleanup } = tmpDirAgents();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const dbPath = join(dir, 'uninstall-full-flow.db');
+    try {
+      // Seed prior install state — both flags 'true'.
+      const seed = await openStore(dbPath);
+      setConfig(seed, 'telemetry.enabled',      'true');
+      setConfig(seed, 'telemetry_sync_enabled', 'true');
+      closeStore(seed);
+
+      const paths = resolveAgentPaths(dir, dir, dir);
+      await uninstallAction({
+        paths,
+        execFn: () => {},
+        apiKeyConfirmFn: async () => true,  // user confirms API key removal
+        dbPath,
+      });
+
+      // API key removal happened.
+      expect(resolver.removeApiKey).toHaveBeenCalledTimes(1);
+
+      // AND telemetry flags also cleared in the same run.
+      const store = await openStore(dbPath);
+      expect(getConfig(store.db, 'telemetry.enabled')).toBe('false');
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      closeStore(store);
+    } finally { cleanup(); }
+  });
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -16,6 +16,7 @@ import {
   telemetrySyncDisableAction,
   telemetrySyncResetCursorAction,
   telemetrySyncRunAction,
+  telemetrySyncPingAction,
 } from './commands/telemetry-sync.js';
 
 export function createProgram(): Command {
@@ -190,6 +191,14 @@ export function createProgram(): Command {
     .description('Skip backlog: jump cursor to current end-of-file')
     .action(async () => {
       await telemetrySyncResetCursorAction();
+    });
+
+  telemetrySyncCmd
+    .command('ping')
+    .description('Smoke-test: send one event to verify network + api_key reachability')
+    .option('--db <path>', 'Path to the SQLite database file')
+    .action(async (opts: { db?: string }) => {
+      await telemetrySyncPingAction(opts.db ? { dbPath: opts.db } : {});
     });
 
   // ── DB command ────────────────────────────────────────────────────────────────

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -48,9 +48,12 @@ export function createProgram(): Command {
 
   program
     .command('uninstall')
-    .description('Remove nexpath-serve MCP registration from all agents')
-    .action(async () => {
-      await uninstallAction();
+    .description('Remove nexpath-serve MCP registration from all agents (and stored API key)')
+    .option('-y, --yes', 'Skip confirmation prompt for API key removal (assumes yes)')
+    .action(async (opts: { yes?: boolean }) => {
+      const uninstallOpts: { yes?: boolean } = {};
+      if (opts.yes) uninstallOpts.yes = true;
+      await uninstallAction(uninstallOpts);
     });
 
   program

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,6 +10,13 @@ import { registerAutoCommand } from './commands/auto.js';
 import { registerStopCommand } from './commands/stop.js';
 import { registerOptimizeCommand } from './commands/optimize.js';
 import { registerStatusCommand } from './commands/status.js';
+import {
+  telemetrySyncStatusAction,
+  telemetrySyncEnableAction,
+  telemetrySyncDisableAction,
+  telemetrySyncResetCursorAction,
+  telemetrySyncRunAction,
+} from './commands/telemetry-sync.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -138,6 +145,51 @@ export function createProgram(): Command {
     .option('--db <path>', 'Path to the SQLite database file')
     .action(async (opts: { olderThan?: string; project?: string; db?: string }) => {
       await storePruneAction(opts, opts.db);
+    });
+
+  // ── Telemetry sync command ────────────────────────────────────────────────────
+
+  const telemetrySyncCmd = program
+    .command('telemetry-sync')
+    .description('Manage the telemetry sync module');
+
+  telemetrySyncCmd
+    .command('status')
+    .description('Show telemetry sync state, cursor position, and config')
+    .option('--db <path>', 'Path to the SQLite database file')
+    .action(async (opts: { db?: string }) => {
+      await telemetrySyncStatusAction(opts.db ? { dbPath: opts.db } : {});
+    });
+
+  telemetrySyncCmd
+    .command('run')
+    .description('Force one sync attempt now (bypasses random window — debug only)')
+    .option('--db <path>', 'Path to the SQLite database file')
+    .action(async (opts: { db?: string }) => {
+      await telemetrySyncRunAction(opts.db ? { dbPath: opts.db } : {});
+    });
+
+  telemetrySyncCmd
+    .command('enable')
+    .description('Set telemetry_sync_enabled = true')
+    .option('--db <path>', 'Path to the SQLite database file')
+    .action(async (opts: { db?: string }) => {
+      await telemetrySyncEnableAction(opts.db ? { dbPath: opts.db } : {});
+    });
+
+  telemetrySyncCmd
+    .command('disable')
+    .description('Set telemetry_sync_enabled = false (in-flight syncs finish; no new ones fire)')
+    .option('--db <path>', 'Path to the SQLite database file')
+    .action(async (opts: { db?: string }) => {
+      await telemetrySyncDisableAction(opts.db ? { dbPath: opts.db } : {});
+    });
+
+  telemetrySyncCmd
+    .command('reset-cursor')
+    .description('Skip backlog: jump cursor to current end-of-file')
+    .action(async () => {
+      await telemetrySyncResetCursorAction();
     });
 
   // ── DB command ────────────────────────────────────────────────────────────────

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,14 @@
 import { Command } from 'commander';
 import { openStore, closeStore, DEFAULT_DB_PATH } from '../store/db.js';
-import { configGetAction, configSetAction, configUnsetAction } from './commands/config.js';
+import {
+  configGetAction,
+  configSetAction,
+  configUnsetAction,
+  configSetApiKeyAction,
+  configRotateApiKeyAction,
+  configShowKeySourceAction,
+  configRemoveApiKeyAction,
+} from './commands/config.js';
 import { runMigrations } from '../store/schema.js';
 import { logAction } from './commands/log.js';
 import { storeDeleteAction, storeEnableAction, storeDisableAction, storePruneAction } from './commands/store.js';
@@ -104,6 +112,34 @@ export function createProgram(): Command {
     .option('--db <path>', 'Path to the SQLite database file')
     .action(async (key: string, opts: { db?: string }) => {
       await configUnsetAction(key, opts.db);
+    });
+
+  configCmd
+    .command('set-api-key')
+    .description('Prompt for an OpenAI API key and store it securely (keychain → fallback file)')
+    .action(async () => {
+      await configSetApiKeyAction();
+    });
+
+  configCmd
+    .command('rotate-api-key')
+    .description('Replace the stored OpenAI API key (errors if no key is currently stored)')
+    .action(async () => {
+      await configRotateApiKeyAction();
+    });
+
+  configCmd
+    .command('show-key-source')
+    .description('Print which layer is supplying the OpenAI API key (env / dotenv / keychain / file / none)')
+    .action(async () => {
+      await configShowKeySourceAction();
+    });
+
+  configCmd
+    .command('remove-api-key')
+    .description('Remove the stored OpenAI API key from both the keychain and the fallback file')
+    .action(async () => {
+      await configRemoveApiKeyAction();
     });
 
   // ── Store command ─────────────────────────────────────────────────────────────

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -39,8 +39,8 @@ export function createProgram(): Command {
 
   program
     .command('install')
-    .description('Register nexpath-serve MCP server with all detected AI coding agents')
-    .option('-y, --yes', 'Skip confirmation prompt')
+    .description('Interactive 3-step setup: OpenAI API key → telemetry consent → agent registration')
+    .option('-y, --yes', 'Non-interactive mode: skip the API key and telemetry prompts and auto-confirm agent registration')
     .option('--db <path>', 'Path to the SQLite database file')
     .action(async (opts: { yes?: boolean; db?: string }) => {
       await installAction(opts, { dbPath: opts.db ?? DEFAULT_DB_PATH });

--- a/src/config/ApiKeyResolver.test.ts
+++ b/src/config/ApiKeyResolver.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, statSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('cross-keychain', () => ({
+  getPassword:    vi.fn(),
+  setPassword:    vi.fn(),
+  deletePassword: vi.fn(),
+}));
+
+import {
+  resolveOpenAIKey,
+  storeApiKey,
+  removeApiKey,
+  getKeySource,
+  isValidApiKey,
+  KEYCHAIN_SERVICE,
+  KEYCHAIN_ACCOUNT,
+  API_KEY_REGEX,
+} from './ApiKeyResolver.js';
+import * as keychain from 'cross-keychain';
+
+const VALID_KEY  = 'sk-abcdefghij1234567890ABCDEFGHIJ';
+const VALID_KEY2 = 'sk-zyxwvutsrq0987654321ABCDEFGHIJ';
+const INVALID_KEY = 'not-a-valid-key';
+
+let tmpDir:        string;
+let fallbackPath:  string;
+let projectRoot:   string;
+let savedEnvKey:   string | undefined;
+
+beforeEach(() => {
+  tmpDir        = mkdtempSync(join(tmpdir(), 'nexpath-resolver-'));
+  fallbackPath  = join(tmpDir, 'config.json');
+  projectRoot   = join(tmpDir, 'project');
+  savedEnvKey   = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  vi.mocked(keychain.getPassword).mockReset();
+  vi.mocked(keychain.setPassword).mockReset();
+  vi.mocked(keychain.deletePassword).mockReset();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (savedEnvKey === undefined) delete process.env.OPENAI_API_KEY;
+  else                            process.env.OPENAI_API_KEY = savedEnvKey;
+});
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+describe('isValidApiKey', () => {
+  it('accepts a standard sk- prefixed key with 20+ chars', () => {
+    expect(isValidApiKey(VALID_KEY)).toBe(true);
+  });
+
+  it('accepts keys with hyphens (e.g. sk-proj-...)', () => {
+    expect(isValidApiKey('sk-proj-abc123XYZ_underscore-hyphen')).toBe(true);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidApiKey('')).toBe(false);
+  });
+
+  it('rejects unprefixed keys', () => {
+    expect(isValidApiKey('abcdefghij1234567890')).toBe(false);
+  });
+
+  it('rejects too-short keys', () => {
+    expect(isValidApiKey('sk-short')).toBe(false);
+  });
+
+  it('rejects keys with disallowed characters', () => {
+    expect(isValidApiKey('sk-abc def ghi 12345678901234')).toBe(false);
+  });
+});
+
+// ── Resolution order ─────────────────────────────────────────────────────────
+
+describe('resolveOpenAIKey — layer 1: env var', () => {
+  it('returns the env key when OPENAI_API_KEY is set and valid', async () => {
+    process.env.OPENAI_API_KEY = VALID_KEY;
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+
+  it('ignores an invalid env key and falls through to lower layers', async () => {
+    process.env.OPENAI_API_KEY = INVALID_KEY;
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+});
+
+describe('resolveOpenAIKey — layer 2: project .env', () => {
+  it('resolves from project .env when env var is unset', async () => {
+    require('node:fs').mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, '.env'), `OPENAI_API_KEY=${VALID_KEY}\n`, 'utf8');
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_KEY);
+  });
+
+  it('ignores an invalid key in .env and falls through', async () => {
+    require('node:fs').mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, '.env'), `OPENAI_API_KEY=${INVALID_KEY}\n`, 'utf8');
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+
+  it('does NOT promote a dotenv value into process.env unless the resolver chooses it', async () => {
+    require('node:fs').mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, '.env'), `OPENAI_API_KEY=${VALID_KEY}\n`, 'utf8');
+    // process.env.OPENAI_API_KEY is undefined at start
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_KEY);
+  });
+});
+
+describe('resolveOpenAIKey — layer 3: keychain', () => {
+  it('resolves from keychain when env + .env are unset', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+    expect(keychain.getPassword).toHaveBeenCalledWith(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+  });
+
+  it('falls through when keychain throws (headless Linux scenario)', async () => {
+    vi.mocked(keychain.getPassword).mockRejectedValue(new Error('NoKeyringError'));
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+
+  it('falls through when keychain returns an invalid key', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(INVALID_KEY);
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+});
+
+describe('resolveOpenAIKey — layer 4: fallback file', () => {
+  it('resolves from the fallback file when keychain returns null', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
+  });
+
+  it('returns null when no source has a key', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBeNull();
+  });
+
+  it('ignores a corrupt fallback file and returns null', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    writeFileSync(fallbackPath, 'not-json{', 'utf8');
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBeNull();
+  });
+});
+
+// ── storeApiKey ──────────────────────────────────────────────────────────────
+
+describe('storeApiKey', () => {
+  it('writes to keychain when keychain is available', async () => {
+    vi.mocked(keychain.setPassword).mockResolvedValue(undefined);
+    const result = await storeApiKey(VALID_KEY, { fallbackPath });
+    expect(result.source).toBe('keychain');
+    expect(keychain.setPassword).toHaveBeenCalledWith(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, VALID_KEY);
+    expect(existsSync(fallbackPath)).toBe(false);
+  });
+
+  it('falls back to the 0600 file when keychain throws', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('NoKeyringError'));
+    const result = await storeApiKey(VALID_KEY, { fallbackPath });
+    expect(result.source).toBe('file');
+    expect(existsSync(fallbackPath)).toBe(true);
+    const parsed = JSON.parse(require('node:fs').readFileSync(fallbackPath, 'utf8'));
+    expect(parsed.openai_api_key).toBe(VALID_KEY);
+  });
+
+  it('the fallback file is created with 0600 permissions (owner read/write only)', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('NoKeyringError'));
+    await storeApiKey(VALID_KEY, { fallbackPath });
+    const mode = statSync(fallbackPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('overwriting an existing fallback file preserves 0600 mode', async () => {
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o644 });
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('NoKeyringError'));
+    await storeApiKey(VALID_KEY2, { fallbackPath });
+    const mode = statSync(fallbackPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('throws on invalid key format', async () => {
+    await expect(storeApiKey('bad-key', { fallbackPath })).rejects.toThrow(/Invalid OpenAI API key/);
+    expect(keychain.setPassword).not.toHaveBeenCalled();
+  });
+});
+
+// ── removeApiKey ─────────────────────────────────────────────────────────────
+
+describe('removeApiKey', () => {
+  it('removes from both keychain and fallback file', async () => {
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    vi.mocked(keychain.deletePassword).mockResolvedValue(undefined);
+    await removeApiKey({ fallbackPath });
+    expect(keychain.deletePassword).toHaveBeenCalledWith(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    expect(existsSync(fallbackPath)).toBe(false);
+  });
+
+  it('silently succeeds when keychain delete throws', async () => {
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    vi.mocked(keychain.deletePassword).mockRejectedValue(new Error('NoKeyringError'));
+    await expect(removeApiKey({ fallbackPath })).resolves.toBeUndefined();
+    expect(existsSync(fallbackPath)).toBe(false);
+  });
+
+  it('silently succeeds when fallback file does not exist', async () => {
+    vi.mocked(keychain.deletePassword).mockResolvedValue(undefined);
+    await expect(removeApiKey({ fallbackPath })).resolves.toBeUndefined();
+  });
+});
+
+// ── getKeySource ─────────────────────────────────────────────────────────────
+
+describe('getKeySource', () => {
+  it('returns "env" when env var is set', async () => {
+    process.env.OPENAI_API_KEY = VALID_KEY;
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('env');
+  });
+
+  it('returns "dotenv" when only project .env has a key', async () => {
+    require('node:fs').mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, '.env'), `OPENAI_API_KEY=${VALID_KEY}\n`, 'utf8');
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('dotenv');
+  });
+
+  it('returns "keychain" when only keychain has a key', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('keychain');
+  });
+
+  it('returns "file" when only the fallback file has a key', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('file');
+  });
+
+  it('returns "none" when no source has a key', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('none');
+  });
+});
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+describe('exported constants', () => {
+  it('KEYCHAIN_SERVICE is "nexpath"', () => {
+    expect(KEYCHAIN_SERVICE).toBe('nexpath');
+  });
+
+  it('KEYCHAIN_ACCOUNT is "openai_api_key"', () => {
+    expect(KEYCHAIN_ACCOUNT).toBe('openai_api_key');
+  });
+
+  it('API_KEY_REGEX accepts sk- with 20+ chars', () => {
+    expect(API_KEY_REGEX.test('sk-' + 'a'.repeat(20))).toBe(true);
+    expect(API_KEY_REGEX.test('sk-' + 'a'.repeat(19))).toBe(false);
+  });
+});

--- a/src/config/ApiKeyResolver.test.ts
+++ b/src/config/ApiKeyResolver.test.ts
@@ -139,6 +139,13 @@ describe('resolveOpenAIKey — layer 3: keychain', () => {
     const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
     expect(result).toBe(VALID_KEY);
   });
+
+  it('promotes the keychain key into process.env.OPENAI_API_KEY', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_KEY);
+  });
 });
 
 describe('resolveOpenAIKey — layer 4: fallback file', () => {
@@ -160,6 +167,25 @@ describe('resolveOpenAIKey — layer 4: fallback file', () => {
     writeFileSync(fallbackPath, 'not-json{', 'utf8');
     const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
     expect(result).toBeNull();
+  });
+
+  it('promotes the fallback-file key into process.env.OPENAI_API_KEY', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_KEY }), { mode: 0o600 });
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_KEY);
+  });
+
+  it('reads openai_api_key from a fallback file that also contains unrelated extra fields', async () => {
+    vi.mocked(keychain.getPassword).mockResolvedValue(null);
+    writeFileSync(fallbackPath, JSON.stringify({
+      openai_api_key: VALID_KEY,
+      something_else: 'ignored',
+      nested: { also: 'ignored' },
+    }), { mode: 0o600 });
+    const result = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(result).toBe(VALID_KEY);
   });
 });
 
@@ -201,6 +227,13 @@ describe('storeApiKey', () => {
   it('throws on invalid key format', async () => {
     await expect(storeApiKey('bad-key', { fallbackPath })).rejects.toThrow(/Invalid OpenAI API key/);
     expect(keychain.setPassword).not.toHaveBeenCalled();
+  });
+
+  it('creates the parent directory before writing the fallback file', async () => {
+    const nestedFallback = join(tmpDir, 'deep', 'nested', 'config.json');
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('NoKeyringError'));
+    await storeApiKey(VALID_KEY, { fallbackPath: nestedFallback });
+    expect(existsSync(nestedFallback)).toBe(true);
   });
 });
 
@@ -256,6 +289,13 @@ describe('getKeySource', () => {
   it('returns "none" when no source has a key', async () => {
     vi.mocked(keychain.getPassword).mockResolvedValue(null);
     expect(await getKeySource(projectRoot, { fallbackPath })).toBe('none');
+  });
+
+  it('ignores an invalid value in project .env and falls through to lower layers', async () => {
+    require('node:fs').mkdirSync(projectRoot, { recursive: true });
+    writeFileSync(join(projectRoot, '.env'), `OPENAI_API_KEY=${INVALID_KEY}\n`, 'utf8');
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_KEY);
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('keychain');
   });
 });
 

--- a/src/config/ApiKeyResolver.ts
+++ b/src/config/ApiKeyResolver.ts
@@ -22,8 +22,8 @@ export function isValidApiKey(key: string): boolean {
 export async function resolveOpenAIKey(projectRoot: string, opts: ResolveOptions = {}): Promise<string | null> {
   const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
 
-  const envKey = process.env.OPENAI_API_KEY;
-  if (envKey && isValidApiKey(envKey)) return envKey;
+  const envKey = tryEnv();
+  if (envKey) return envKey;
 
   const dotenvKey = tryProjectDotenv(projectRoot);
   if (dotenvKey) {
@@ -49,10 +49,9 @@ export async function resolveOpenAIKey(projectRoot: string, opts: ResolveOptions
 export async function getKeySource(projectRoot: string, opts: ResolveOptions = {}): Promise<KeySource> {
   const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
 
-  const envKey = process.env.OPENAI_API_KEY;
-  if (envKey && isValidApiKey(envKey)) return 'env';
-  if (tryProjectDotenv(projectRoot))    return 'dotenv';
-  if (await tryKeychain())              return 'keychain';
+  if (tryEnv())                            return 'env';
+  if (tryProjectDotenv(projectRoot))       return 'dotenv';
+  if (await tryKeychain())                 return 'keychain';
   if (await tryFallbackFile(fallbackPath)) return 'file';
   return 'none';
 }
@@ -77,6 +76,12 @@ export async function removeApiKey(opts: ResolveOptions = {}): Promise<void> {
 
   try { await deletePassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT); } catch { /* silent */ }
   try { await fs.unlink(fallbackPath); } catch { /* silent */ }
+}
+
+function tryEnv(): string | null {
+  const key = process.env.OPENAI_API_KEY;
+  if (key && isValidApiKey(key)) return key;
+  return null;
 }
 
 function tryProjectDotenv(projectRoot: string): string | null {

--- a/src/config/ApiKeyResolver.ts
+++ b/src/config/ApiKeyResolver.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { config as loadDotenv } from 'dotenv';
+import { getPassword, setPassword, deletePassword } from 'cross-keychain';
+
+export const KEYCHAIN_SERVICE = 'nexpath';
+export const KEYCHAIN_ACCOUNT = 'openai_api_key';
+export const FALLBACK_PATH    = join(homedir(), '.nexpath', 'config.json');
+export const API_KEY_REGEX    = /^sk-[A-Za-z0-9_-]{20,}$/;
+
+export type KeySource = 'env' | 'dotenv' | 'keychain' | 'file' | 'none';
+
+export interface ResolveOptions {
+  fallbackPath?: string;
+}
+
+export function isValidApiKey(key: string): boolean {
+  return API_KEY_REGEX.test(key);
+}
+
+export async function resolveOpenAIKey(projectRoot: string, opts: ResolveOptions = {}): Promise<string | null> {
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  const envKey = process.env.OPENAI_API_KEY;
+  if (envKey && isValidApiKey(envKey)) return envKey;
+
+  const dotenvKey = tryProjectDotenv(projectRoot);
+  if (dotenvKey) {
+    process.env.OPENAI_API_KEY = dotenvKey;
+    return dotenvKey;
+  }
+
+  const keychainKey = await tryKeychain();
+  if (keychainKey) {
+    process.env.OPENAI_API_KEY = keychainKey;
+    return keychainKey;
+  }
+
+  const fileKey = await tryFallbackFile(fallbackPath);
+  if (fileKey) {
+    process.env.OPENAI_API_KEY = fileKey;
+    return fileKey;
+  }
+
+  return null;
+}
+
+export async function getKeySource(projectRoot: string, opts: ResolveOptions = {}): Promise<KeySource> {
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  const envKey = process.env.OPENAI_API_KEY;
+  if (envKey && isValidApiKey(envKey)) return 'env';
+  if (tryProjectDotenv(projectRoot))    return 'dotenv';
+  if (await tryKeychain())              return 'keychain';
+  if (await tryFallbackFile(fallbackPath)) return 'file';
+  return 'none';
+}
+
+export async function storeApiKey(key: string, opts: ResolveOptions = {}): Promise<{ source: 'keychain' | 'file' }> {
+  if (!isValidApiKey(key)) {
+    throw new Error('Invalid OpenAI API key format (expected /^sk-[A-Za-z0-9_-]{20,}$/)');
+  }
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  try {
+    await setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, key);
+    return { source: 'keychain' };
+  } catch {
+    await writeFallbackFile(fallbackPath, key);
+    return { source: 'file' };
+  }
+}
+
+export async function removeApiKey(opts: ResolveOptions = {}): Promise<void> {
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  try { await deletePassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT); } catch { /* silent */ }
+  try { await fs.unlink(fallbackPath); } catch { /* silent */ }
+}
+
+function tryProjectDotenv(projectRoot: string): string | null {
+  try {
+    const envPath = join(projectRoot, '.env');
+    const result  = loadDotenv({ path: envPath, processEnv: {}, quiet: true });
+    if (result.error) return null;
+    const key = result.parsed?.OPENAI_API_KEY;
+    if (key && isValidApiKey(key)) return key;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function tryKeychain(): Promise<string | null> {
+  try {
+    const key = await getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    if (key && isValidApiKey(key)) return key;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function tryFallbackFile(fallbackPath: string): Promise<string | null> {
+  try {
+    const raw    = await fs.readFile(fallbackPath, 'utf8');
+    const parsed = JSON.parse(raw) as { openai_api_key?: string };
+    const key    = parsed.openai_api_key;
+    if (key && isValidApiKey(key)) return key;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeFallbackFile(fallbackPath: string, key: string): Promise<void> {
+  await fs.mkdir(dirname(fallbackPath), { recursive: true });
+  const payload = JSON.stringify({ openai_api_key: key }, null, 2);
+  await fs.writeFile(fallbackPath, payload, { mode: 0o600 });
+  await fs.chmod(fallbackPath, 0o600);
+}

--- a/src/decision-session/DecisionSession.ts
+++ b/src/decision-session/DecisionSession.ts
@@ -14,6 +14,7 @@ import {
 } from './options.js';
 import type { GeneratedOptions } from './OptionGenerator.js';
 import { writeTelemetry } from '../telemetry/index.js';
+import { type RecentPromptMetadata } from '../telemetry/recent-prompts.js';
 
 /**
  * Decision session terminal UI (per decision-session-ux-research.md).
@@ -92,6 +93,8 @@ export interface DecisionSessionInput {
   generatedOptions?:    GeneratedOptions;
   /** User profile — used to route beginner/cool_geek to BEGINNER content blocks. */
   profile?:             UserProfile | null;
+  /** Last-5 prompt metadata for the `decision_session_started` telemetry event (Item B). */
+  recentPrompts?:       RecentPromptMetadata[];
 }
 
 /**
@@ -300,10 +303,14 @@ export async function runDecisionSession(
   }
 
   writeTelemetry(input.projectRoot, 'decision_session_started', {
-    flagType:   input.flagType,
-    stage:      input.stage,
-    pinchLabel: input.pinchLabel,
-    sessionId:  input.sessionId,
+    flagType:                      input.flagType,
+    stage:                         input.stage,
+    pinchLabel:                    input.pinchLabel,
+    sessionId:                     input.sessionId,
+    // Item J — project counter, populated by the call site (stop.ts).
+    decisionSessionCountInProject: input.decisionSessionCount ?? 0,
+    // Item B — last-5 prompt metadata, populated by the call site.
+    recentPrompts:                 input.recentPrompts ?? [],
   }, store);
 
   let level: 1 | 2 | 3 = 1;

--- a/src/decision-session/DecisionSession.ts
+++ b/src/decision-session/DecisionSession.ts
@@ -278,7 +278,7 @@ export async function runDecisionSession(
     stage:      input.stage,
     pinchLabel: input.pinchLabel,
     sessionId:  input.sessionId,
-  });
+  }, store);
 
   let level: 1 | 2 | 3 = 1;
 

--- a/src/decision-session/DecisionSession.ts
+++ b/src/decision-session/DecisionSession.ts
@@ -2,7 +2,7 @@ import { select, isCancel } from '@clack/prompts';
 import type { Stage, UserProfile } from '../classifier/types.js';
 import type { FlagType } from '../classifier/Stage2Trigger.js';
 import type { Store } from '../store/db.js';
-import { insertSkippedSession } from '../store/skipped-sessions.js';
+import { insertSkippedSession, getSkippedSessions } from '../store/skipped-sessions.js';
 import { incrementDecisionSessionCount } from '../store/projects.js';
 import { setConfig } from '../store/config.js';
 import {
@@ -167,6 +167,7 @@ export async function runLevel(
   input:     DecisionSessionInput,
   level:     1 | 2 | 3,
   selectFn:  SelectFn,
+  store?:    Store,
 ): Promise<'skip' | 'next' | 'clipboard_only' | string> {
   const content  = resolveDecisionContent(input.stage, input.flagType, input.profile);
   const gen      = input.generatedOptions;
@@ -210,7 +211,7 @@ export async function runLevel(
   writeTelemetry(input.projectRoot, 'level_rendered', {
     level,
     optionCount: clackOptions.filter(o => !o.value.startsWith(OPTION_SEPARATOR)).length,
-  });
+  }, store);
 
   if (process.env['NEXPATH_SIM'] === '1') {
     const first = clackOptions.find(o => !o.value.startsWith(OPTION_SEPARATOR));
@@ -225,28 +226,53 @@ export async function runLevel(
     await new Promise<void>(r => setTimeout(r, 400));
     writeTelemetry(input.projectRoot, 'decision_session_sim_dismissed', {
       level, autoSelectedText: label.slice(0, 120),
-    });
+    }, store);
     return value as string;
   }
 
   const result = await selectFn({ message, options: clackOptions });
 
+  // Item A: 5 context fields from input (no lookups) + Item I: skip count from store.
+  // Snapshot once; reused across whichever dismissal branch fires.
+  const dismissPayloadBase = {
+    flagType:           input.flagType,
+    stage:              input.stage,
+    pinchLabel:         input.pinchLabel,
+    sessionId:          input.sessionId,
+    promptCount:        input.promptCount,
+    skipCountInProject: store
+      ? getSkippedSessions(store, input.projectRoot).length
+      : null,
+  };
+
   if (isCancel(result) || typeof result === 'symbol') {
-    writeTelemetry(input.projectRoot, 'decision_session_dismissed', { level, reason: 'cancel' });
+    writeTelemetry(input.projectRoot, 'decision_session_dismissed', {
+      level,
+      reason: 'cancel',
+      ...dismissPayloadBase,
+    }, store);
     return 'skip';
   }
   if (typeof result === 'string' && result.startsWith(OPTION_SEPARATOR)) {
-    writeTelemetry(input.projectRoot, 'decision_session_dismissed', { level, reason: 'skip' });
+    writeTelemetry(input.projectRoot, 'decision_session_dismissed', {
+      level,
+      reason: 'skip',
+      ...dismissPayloadBase,
+    }, store);
     return 'skip';
   }
   if (result === CLIPBOARD_ONLY) return 'clipboard_only';
   if (result === SKIP_NOW) {
-    writeTelemetry(input.projectRoot, 'decision_session_dismissed', { level, reason: 'skip' });
+    writeTelemetry(input.projectRoot, 'decision_session_dismissed', {
+      level,
+      reason: 'skip',
+      ...dismissPayloadBase,
+    }, store);
     return 'skip';
   }
   if (result === SHOW_SIMPLER) return 'next';
 
-  writeTelemetry(input.projectRoot, 'option_selected', { level, selectedText: (result as string).slice(0, 120) });
+  writeTelemetry(input.projectRoot, 'option_selected', { level, selectedText: (result as string).slice(0, 120) }, store);
   return result as string;
 }
 
@@ -283,7 +309,7 @@ export async function runDecisionSession(
   let level: 1 | 2 | 3 = 1;
 
   while (true) {
-    const levelResult = await runLevel(input, level, selectFn);
+    const levelResult = await runLevel(input, level, selectFn, store);
 
     // Windows sentinel: Ctrl+X opt-out — write config and skip (no skipped_sessions entry)
     if (levelResult === OPT_OUT_SENTINEL) {

--- a/src/decision-session/decision-session.test.ts
+++ b/src/decision-session/decision-session.test.ts
@@ -3151,6 +3151,7 @@ describe('runLevel — NEXPATH_SIM=1 support', () => {
         level: 1,
         autoSelectedText: expect.any(String),
       }),
+      undefined,
     );
   }, 2000);
 
@@ -3158,6 +3159,101 @@ describe('runLevel — NEXPATH_SIM=1 support', () => {
     const selectFn = mockSelect(SKIP_NOW);
     await runLevel(makeInput(), 1, selectFn);
     expect(selectFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── runLevel — Phase 3 enriched decision_session_dismissed payload ────────────
+
+describe('runLevel — telemetry: decision_session_dismissed enriched payload (Phase 3)', () => {
+  beforeEach(() => { vi.mocked(writeTelemetry).mockClear(); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  // Common assertion helper — the 6 context fields land verbatim from `input`.
+  const expectRichDismissPayload = (reason: 'cancel' | 'skip', level: 1 | 2 | 3) =>
+    expect.objectContaining({
+      level,
+      reason,
+      flagType:    'stage_transition',
+      stage:       'implementation',
+      pinchLabel:  'Hold up.',
+      sessionId:   'session-test',
+      promptCount: 20,
+    });
+
+  it('emits 6 context fields when user cancels (Ctrl+C) at Level 1', async () => {
+    await runLevel(makeInput(), 1, mockCancel());
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_dismissed',
+      expectRichDismissPayload('cancel', 1),
+      undefined,
+    );
+  });
+
+  it('emits 6 context fields when user clicks SKIP_NOW at Level 2', async () => {
+    await runLevel(makeInput(), 2, mockSelect(SKIP_NOW));
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_dismissed',
+      expectRichDismissPayload('skip', 2),
+      undefined,
+    );
+  });
+
+  it('emits 6 context fields when user clicks a blank separator at Level 3', async () => {
+    // Separator values look like __nexpath_sep__<n> — runLevel treats those as skip.
+    await runLevel(makeInput(), 3, mockSelect(`${OPTION_SEPARATOR}0`));
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_dismissed',
+      expectRichDismissPayload('skip', 3),
+      undefined,
+    );
+  });
+
+  it('skipCountInProject reflects real DB state when store is provided', async () => {
+    const store = await openStore(':memory:');
+    try {
+      // Seed 3 prior skips for this project so the next dismissal observes count=3.
+      const { insertSkippedSession } = await import('../store/skipped-sessions.js');
+      for (let i = 0; i < 3; i++) {
+        insertSkippedSession(store, {
+          projectRoot:          '/proj/skip-count',
+          sessionId:            `prior-${i}`,
+          flagType:             'absence:test_creation',
+          stage:                'implementation',
+          levelReached:         1,
+          skippedAtPromptCount: 5 + i,
+        });
+      }
+
+      vi.mocked(writeTelemetry).mockClear();
+      await runLevel(
+        makeInput({ projectRoot: '/proj/skip-count' }),
+        1,
+        mockSelect(SKIP_NOW),
+        store,
+      );
+
+      expect(writeTelemetry).toHaveBeenCalledWith(
+        '/proj/skip-count',
+        'decision_session_dismissed',
+        expect.objectContaining({ skipCountInProject: 3 }),
+        store,
+      );
+    } finally {
+      store.db.close();
+    }
+  });
+
+  it('skipCountInProject is null when no store is provided (graceful degradation)', async () => {
+    await runLevel(makeInput(), 1, mockSelect(SKIP_NOW));
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_dismissed',
+      expect.objectContaining({ skipCountInProject: null }),
+      undefined,
+    );
   });
 });
 

--- a/src/decision-session/decision-session.test.ts
+++ b/src/decision-session/decision-session.test.ts
@@ -3255,6 +3255,47 @@ describe('runLevel — telemetry: decision_session_dismissed enriched payload (P
       undefined,
     );
   });
+
+  it('runDecisionSession plumbs store through runLevel — full chain delivers rich payload', async () => {
+    // End-to-end guard: if a future refactor accidentally drops `store` from
+    // the runLevel() call inside runDecisionSession, this test catches it
+    // even though both runLevel and runDecisionSession individually still work.
+    const store = await openStore(':memory:');
+    try {
+      const { insertSkippedSession } = await import('../store/skipped-sessions.js');
+      for (let i = 0; i < 2; i++) {
+        insertSkippedSession(store, {
+          projectRoot:          '/proj/plumb',
+          sessionId:            `prior-${i}`,
+          flagType:             'absence:test_creation',
+          stage:                'implementation',
+          levelReached:         1,
+          skippedAtPromptCount: 5 + i,
+        });
+      }
+
+      vi.mocked(writeTelemetry).mockClear();
+      await runDecisionSession(
+        makeInput({ projectRoot: '/proj/plumb' }),
+        store,
+        mockSelect(SKIP_NOW),
+      );
+
+      expect(writeTelemetry).toHaveBeenCalledWith(
+        '/proj/plumb',
+        'decision_session_dismissed',
+        expect.objectContaining({
+          level:              1,
+          reason:             'skip',
+          flagType:           'stage_transition',
+          skipCountInProject: 2,
+        }),
+        store,
+      );
+    } finally {
+      store.db.close();
+    }
+  });
 });
 
 // ── DecisionContent structure — Sub-4 Group A formal/casual (idea signals) ───

--- a/src/decision-session/decision-session.test.ts
+++ b/src/decision-session/decision-session.test.ts
@@ -3123,6 +3123,64 @@ describe('runDecisionSession — telemetry: decision_session_started', () => {
       undefined,
     );
   });
+
+  // ── Phase 4 — decision_session_started enriched payload (Items B + J) ──────
+
+  it('decision_session_started carries decisionSessionCountInProject from input', async () => {
+    await runDecisionSession(
+      makeInput({ decisionSessionCount: 7 }),
+      undefined,
+      mockSelect(SKIP_NOW),
+    );
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_started',
+      expect.objectContaining({ decisionSessionCountInProject: 7 }),
+      undefined,
+    );
+  });
+
+  it('decision_session_started defaults decisionSessionCountInProject to 0 when input is 0', async () => {
+    await runDecisionSession(
+      makeInput({ decisionSessionCount: 0 }),
+      undefined,
+      mockSelect(SKIP_NOW),
+    );
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_started',
+      expect.objectContaining({ decisionSessionCountInProject: 0 }),
+      undefined,
+    );
+  });
+
+  it('decision_session_started carries recentPrompts from input when provided', async () => {
+    const recentPrompts = [
+      { index: 1, classifiedStage: 'planning',       confidence: 0.7, capturedAt: 100 },
+      { index: 2, classifiedStage: 'implementation', confidence: 0.9, capturedAt: 200 },
+    ];
+    await runDecisionSession(
+      makeInput({ recentPrompts }),
+      undefined,
+      mockSelect(SKIP_NOW),
+    );
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_started',
+      expect.objectContaining({ recentPrompts }),
+      undefined,
+    );
+  });
+
+  it('decision_session_started defaults recentPrompts to [] when input is undefined', async () => {
+    await runDecisionSession(makeInput(), undefined, mockSelect(SKIP_NOW));
+    expect(writeTelemetry).toHaveBeenCalledWith(
+      '/test/project',
+      'decision_session_started',
+      expect.objectContaining({ recentPrompts: [] }),
+      undefined,
+    );
+  });
 });
 
 describe('runLevel — NEXPATH_SIM=1 support', () => {

--- a/src/decision-session/decision-session.test.ts
+++ b/src/decision-session/decision-session.test.ts
@@ -3110,6 +3110,7 @@ describe('runDecisionSession — telemetry: decision_session_started', () => {
         pinchLabel: 'Hold up.',
         sessionId:  'session-test',
       }),
+      undefined,
     );
   });
 
@@ -3119,6 +3120,7 @@ describe('runDecisionSession — telemetry: decision_session_started', () => {
       '/test/project',
       'decision_session_started',
       expect.any(Object),
+      undefined,
     );
   });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,22 +21,30 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { openStore, closeStore } from '../store/index.js';
 import { TOOLS } from './tools.js';
+import { createDefaultScheduler } from '../telemetry/TelemetrySyncScheduler.js';
 
 // ── Open prompt store ─────────────────────────────────────────────────────────
 
 const store = await openStore();
 process.stderr.write(`[nexpath-serve] store opened\n`);
 
+// ── Telemetry sync scheduler ──────────────────────────────────────────────────
+
+const scheduler = createDefaultScheduler(store);
+scheduler.start();
+
 // ── Shutdown handlers ─────────────────────────────────────────────────────────
 
 process.stdin.on('end', () => {
   process.stderr.write('[nexpath-serve] stdin closed — shutting down\n');
+  scheduler.stop();
   closeStore(store);
   process.exit(0);
 });
 
 process.on('SIGTERM', () => {
   process.stderr.write('[nexpath-serve] SIGTERM received — shutting down\n');
+  scheduler.stop();
   closeStore(store);
   process.exit(0);
 });

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -7,6 +7,7 @@ export const DEFAULT_CONFIG: Record<string, string> = {
   prompt_store_max_per_project: '500',
   prompt_store_max_db_mb: '100',
   log_level: 'info',
+  'telemetry.enabled': 'true',
 };
 
 /** Returns true only if the key has been explicitly written to the config table. */

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -9,7 +9,7 @@ export const DEFAULT_CONFIG: Record<string, string> = {
   log_level: 'info',
   'telemetry.enabled': 'true',
   telemetry_sync_endpoint: 'https://us.i.posthog.com/capture/',
-  telemetry_sync_api_key:  'phc_nL63UqSD2meGY4wPhBFAkB2yu34QZbwxvwbacA8922DJ',
+  telemetry_sync_api_key:  'phc_mBETUUXjX2MLDCBpHmRoVMqHmRF2dUpnuByqVGw5qej9',
 };
 
 /** Returns true only if the key has been explicitly written to the config table. */

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -8,6 +8,8 @@ export const DEFAULT_CONFIG: Record<string, string> = {
   prompt_store_max_db_mb: '100',
   log_level: 'info',
   'telemetry.enabled': 'true',
+  telemetry_sync_endpoint: 'https://us.i.posthog.com/capture/',
+  telemetry_sync_api_key:  'phc_nL63UqSD2meGY4wPhBFAkB2yu34QZbwxvwbacA8922DJ',
 };
 
 /** Returns true only if the key has been explicitly written to the config table. */

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -478,6 +478,32 @@ describe('store — config', () => {
     expect(all['telemetry_sync_api_key']).toMatch(/^phc_/);
   });
 
+  it('getConfig returns the telemetry_sync_endpoint default on a fresh store', () => {
+    expect(getConfig(store.db, 'telemetry_sync_endpoint')).toBe('https://us.i.posthog.com/capture/');
+  });
+
+  it('getConfig returns the telemetry_sync_api_key default on a fresh store', () => {
+    const v = getConfig(store.db, 'telemetry_sync_api_key');
+    expect(v).toMatch(/^phc_/);
+    expect(v!.length).toBeGreaterThan(20);
+  });
+
+  it('isConfigSet returns false for telemetry_sync defaults (they are fallbacks, not stored)', () => {
+    expect(isConfigSet(store.db, 'telemetry_sync_endpoint')).toBe(false);
+    expect(isConfigSet(store.db, 'telemetry_sync_api_key')).toBe(false);
+    expect(getConfig(store.db, 'telemetry_sync_endpoint')).toBeDefined();
+    expect(getConfig(store.db, 'telemetry_sync_api_key')).toBeDefined();
+  });
+
+  it('setConfig overrides the telemetry_sync defaults (user-supplied values win)', () => {
+    setConfig(store, 'telemetry_sync_endpoint', 'https://eu.example/capture/');
+    setConfig(store, 'telemetry_sync_api_key',  'phc_custom_user_token');
+    expect(getConfig(store.db, 'telemetry_sync_endpoint')).toBe('https://eu.example/capture/');
+    expect(getConfig(store.db, 'telemetry_sync_api_key')).toBe('phc_custom_user_token');
+    expect(isConfigSet(store.db, 'telemetry_sync_endpoint')).toBe(true);
+    expect(isConfigSet(store.db, 'telemetry_sync_api_key')).toBe(true);
+  });
+
   // ── isConfigSet ──────────────────────────────────────────────────────────────
 
   it('isConfigSet returns false for a key that has never been written', () => {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -463,6 +463,7 @@ describe('store — config', () => {
     expect(all['prompt_capture_enabled']).toBe('false');       // overridden
     expect(all['prompt_store_max_per_project']).toBe('500');   // still default
     expect(all['prompt_store_max_db_mb']).toBe('100');         // still default
+    expect(all['telemetry.enabled']).toBe('true');             // still default
   });
 
   it('getAllConfig includes stored custom keys', () => {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -439,6 +439,7 @@ describe('store — config', () => {
     expect(getConfig(store.db, 'prompt_capture_enabled')).toBe('true');
     expect(getConfig(store.db, 'prompt_store_max_per_project')).toBe('500');
     expect(getConfig(store.db, 'prompt_store_max_db_mb')).toBe('100');
+    expect(getConfig(store.db, 'telemetry.enabled')).toBe('true');
   });
 
   it('getConfig returns undefined for unknown non-default keys', () => {

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -472,6 +472,12 @@ describe('store — config', () => {
     expect(all['language_override']).toBe('es');
   });
 
+  it('telemetry_sync_endpoint and telemetry_sync_api_key have built-in defaults', () => {
+    const all = getAllConfig(store.db);
+    expect(all['telemetry_sync_endpoint']).toBe('https://us.i.posthog.com/capture/');
+    expect(all['telemetry_sync_api_key']).toMatch(/^phc_/);
+  });
+
   // ── isConfigSet ──────────────────────────────────────────────────────────────
 
   it('isConfigSet returns false for a key that has never been written', () => {

--- a/src/telemetry/TelemetryBatcher.test.ts
+++ b/src/telemetry/TelemetryBatcher.test.ts
@@ -239,6 +239,36 @@ describe('TelemetryBatcher — defaults & integration', () => {
   });
 });
 
+describe('TelemetryBatcher — batchEndIndices', () => {
+  it('empty events: batchEndIndices is empty', () => {
+    const result = partitionEvents([], { apiKey: API_KEY });
+    expect(result.batchEndIndices).toEqual([]);
+  });
+
+  it('single batch covering all events: one entry equal to consumedCount', () => {
+    const result = partitionEvents([ev(), ev(), ev()], { apiKey: API_KEY });
+    expect(result.batchEndIndices).toEqual([3]);
+    expect(result.consumedCount).toBe(3);
+  });
+
+  it('multiple batches: indices are monotonically increasing', () => {
+    const events = Array.from({ length: 7 }, () => ev());
+    const result = partitionEvents(events, {
+      apiKey: API_KEY, maxEventsPerBatch: 3, maxBatchesPerRun: 10,
+    });
+    expect(result.batchEndIndices).toEqual([3, 6, 7]);
+  });
+
+  it('skipped events (no installationId) count toward indices', () => {
+    const noId = ev(); delete noId.installationId;
+    const result = partitionEvents([ev(), noId, ev()], {
+      apiKey: API_KEY, maxEventsPerBatch: 10, maxBatchesPerRun: 10,
+    });
+    expect(result.batchEndIndices).toEqual([3]);
+    expect(result.consumedCount).toBe(3);
+  });
+});
+
 describe('TelemetryBatcher → TelemetryClient integration', () => {
   it('partitioned envelope reaches fetch with valid PostHog shape and returns ok=true', async () => {
     const events = [

--- a/src/telemetry/TelemetryBatcher.test.ts
+++ b/src/telemetry/TelemetryBatcher.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import {
-  partitionEvents,
-  toPostHogEvent,
+  buildEnvelopes,
+  toPostHogEnvelope,
   hashProjectRootValue,
   ALLOWED_PROPERTY_KEYS,
   POSTHOG_LIB_NAME,
   POSTHOG_LIB_VERSION,
 } from './TelemetryBatcher.js';
-import { postBatch, type FetchLike } from './TelemetryClient.js';
+import { postEvent, type FetchLike } from './TelemetryClient.js';
 import type { TelemetryEvent } from './types.js';
 
 const API_KEY = 'phc_test_key';
@@ -26,22 +26,35 @@ function ev(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
   };
 }
 
-describe('TelemetryBatcher — toPostHogEvent', () => {
-  it('maps installationId → distinct_id', () => {
-    const out = toPostHogEvent(ev(), { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+describe('TelemetryBatcher — toPostHogEnvelope (single-event shape)', () => {
+  it('maps installationId → distinct_id at the top level', () => {
+    const out = toPostHogEnvelope(ev(), API_KEY, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
     expect(out?.distinct_id).toBe('550e8400-e29b-41d4-a716-446655440000');
   });
 
-  it('maps ts → timestamp', () => {
-    const out = toPostHogEvent(ev({ ts: '2026-05-19T11:22:33.444Z' }), {
+  it('maps ts → timestamp at the top level', () => {
+    const out = toPostHogEnvelope(ev({ ts: '2026-05-19T11:22:33.444Z' }), API_KEY, {
       hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
     });
     expect(out?.timestamp).toBe('2026-05-19T11:22:33.444Z');
   });
 
+  it('places event name at the top level (not inside properties)', () => {
+    const out = toPostHogEnvelope(ev({ event: 'prompt_classified' }), API_KEY, {
+      hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
+    });
+    expect(out?.event).toBe('prompt_classified');
+  });
+
+  it('places api_key at the top level', () => {
+    const out = toPostHogEnvelope(ev(), API_KEY, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    expect(out?.api_key).toBe(API_KEY);
+  });
+
   it('moves remaining whitelisted fields into properties', () => {
-    const out = toPostHogEvent(
+    const out = toPostHogEnvelope(
       ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.92 }),
+      API_KEY,
       { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS },
     );
     expect(out?.properties.userId).toBe('8a3f1c2e-5b6d-4e7f-9a2c-1d3e5f7b9c0d');
@@ -51,13 +64,13 @@ describe('TelemetryBatcher — toPostHogEvent', () => {
   });
 
   it('injects $lib and $lib_version properties', () => {
-    const out = toPostHogEvent(ev(), { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    const out = toPostHogEnvelope(ev(), API_KEY, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
     expect(out?.properties.$lib).toBe(POSTHOG_LIB_NAME);
     expect(out?.properties.$lib_version).toBe('0.1.1');
   });
 
   it('hashes projectRoot when hashProjectRoot=true (sha256: prefix)', () => {
-    const out = toPostHogEvent(ev({ projectRoot: '/home/jemi/x' }), {
+    const out = toPostHogEnvelope(ev({ projectRoot: '/home/jemi/x' }), API_KEY, {
       hashProjectRoot: true, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
     });
     const expected = `sha256:${createHash('sha256').update('/home/jemi/x').digest('hex')}`;
@@ -65,7 +78,7 @@ describe('TelemetryBatcher — toPostHogEvent', () => {
   });
 
   it('passes projectRoot raw when hashProjectRoot=false', () => {
-    const out = toPostHogEvent(ev({ projectRoot: '/home/jemi/x' }), {
+    const out = toPostHogEnvelope(ev({ projectRoot: '/home/jemi/x' }), API_KEY, {
       hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
     });
     expect(out?.properties.projectRoot).toBe('/home/jemi/x');
@@ -74,20 +87,21 @@ describe('TelemetryBatcher — toPostHogEvent', () => {
   it('returns null when installationId is missing', () => {
     const raw = ev();
     delete raw.installationId;
-    const out = toPostHogEvent(raw, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    const out = toPostHogEnvelope(raw, API_KEY, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
     expect(out).toBeNull();
   });
 
   it('drops keys not on the whitelist (security)', () => {
     const raw = ev({ secretApiKey: 'sk-leaked-key', somethingElse: 'wat' }) as TelemetryEvent;
-    const out = toPostHogEvent(raw, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    const out = toPostHogEnvelope(raw, API_KEY, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
     expect(out?.properties.secretApiKey).toBeUndefined();
     expect(out?.properties.somethingElse).toBeUndefined();
   });
 
   it('honours custom allowedKeys parameter', () => {
-    const out = toPostHogEvent(
+    const out = toPostHogEnvelope(
       ev({ stage: 'planning', confidence: 0.92 }),
+      API_KEY,
       { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ['stage'] },
     );
     expect(out?.properties.stage).toBe('planning');
@@ -110,172 +124,89 @@ describe('TelemetryBatcher — hashProjectRootValue', () => {
   });
 });
 
-describe('TelemetryBatcher — partitionEvents envelope shape', () => {
-  it('empty events produce empty batches', () => {
-    const result = partitionEvents([], { apiKey: API_KEY });
-    expect(result.batches).toHaveLength(0);
+describe('TelemetryBatcher — buildEnvelopes (one envelope per event)', () => {
+  it('empty events produce empty envelopes', () => {
+    const result = buildEnvelopes([], { apiKey: API_KEY });
+    expect(result.envelopes).toHaveLength(0);
     expect(result.consumedCount).toBe(0);
   });
 
-  it('single event produces one batch with one PostHogEvent', () => {
-    const result = partitionEvents([ev()], { apiKey: API_KEY, hashProjectRoot: false });
-    expect(result.batches).toHaveLength(1);
-    expect(result.batches[0].api_key).toBe(API_KEY);
-    expect(result.batches[0].batch).toHaveLength(1);
+  it('single event produces one envelope', () => {
+    const result = buildEnvelopes([ev()], { apiKey: API_KEY, hashProjectRoot: false });
+    expect(result.envelopes).toHaveLength(1);
+    expect(result.envelopes[0].api_key).toBe(API_KEY);
+    expect(result.envelopes[0].event).toBe('prompt_received');
     expect(result.consumedCount).toBe(1);
   });
 
-  it('envelope wraps with api_key + batch keys (PostHog shape)', () => {
-    const result = partitionEvents([ev()], { apiKey: API_KEY });
-    expect(Object.keys(result.batches[0]).sort()).toEqual(['api_key', 'batch']);
+  it('envelope keys are the PostHog single-event shape (api_key, event, distinct_id, timestamp, properties)', () => {
+    const result = buildEnvelopes([ev()], { apiKey: API_KEY });
+    expect(Object.keys(result.envelopes[0]).sort()).toEqual(['api_key', 'distinct_id', 'event', 'properties', 'timestamp']);
   });
 
   it('events without installationId are skipped but consumedCount advances', () => {
     const valid   = ev();
     const noId    = ev();
     delete noId.installationId;
-    const result = partitionEvents([valid, noId, valid], { apiKey: API_KEY });
-    expect(result.batches[0].batch).toHaveLength(2);
+    const result = buildEnvelopes([valid, noId, valid], { apiKey: API_KEY });
+    expect(result.envelopes).toHaveLength(2);
     expect(result.consumedCount).toBe(3);
   });
-});
 
-describe('TelemetryBatcher — partitioning caps', () => {
-  it('splits into multiple batches when maxEventsPerBatch is exceeded', () => {
-    const events = Array.from({ length: 7 }, () => ev());
-    const result = partitionEvents(events, {
-      apiKey: API_KEY, maxEventsPerBatch: 3, maxBatchesPerRun: 10,
-    });
-    expect(result.batches).toHaveLength(3);
-    expect(result.batches[0].batch).toHaveLength(3);
-    expect(result.batches[1].batch).toHaveLength(3);
-    expect(result.batches[2].batch).toHaveLength(1);
-    expect(result.consumedCount).toBe(7);
+  it('produces N envelopes for N events (one per event, FIFO order)', () => {
+    const events = [
+      ev({ event: 'prompt_received',   promptCount: 1 }),
+      ev({ event: 'prompt_classified', promptCount: 2 }),
+      ev({ event: 'profile_computed',  promptCount: 3 }),
+    ];
+    const result = buildEnvelopes(events, { apiKey: API_KEY, hashProjectRoot: false });
+    expect(result.envelopes).toHaveLength(3);
+    expect(result.envelopes.map(e => e.event)).toEqual(['prompt_received', 'prompt_classified', 'profile_computed']);
+    expect(result.envelopes.map(e => e.properties.promptCount)).toEqual([1, 2, 3]);
   });
 
-  it('splits into multiple batches when maxBytesPerBatch is exceeded', () => {
-    const events = Array.from({ length: 10 }, (_, i) => ev({ pinchLabel: 'x'.repeat(100), promptCount: i }));
-    const result = partitionEvents(events, {
-      apiKey: API_KEY, maxBytesPerBatch: 500, maxBatchesPerRun: 10,
-    });
-    expect(result.batches.length).toBeGreaterThan(1);
-    expect(result.consumedCount).toBe(10);
-  });
-
-  it('caps at maxBatchesPerRun — overflow events are NOT consumed', () => {
+  it('caps at maxEventsPerRun — overflow events are NOT consumed', () => {
     const events = Array.from({ length: 10 }, () => ev());
-    const result = partitionEvents(events, {
-      apiKey: API_KEY, maxEventsPerBatch: 2, maxBatchesPerRun: 2,
-    });
-    expect(result.batches).toHaveLength(2);
-    expect(result.batches[0].batch).toHaveLength(2);
-    expect(result.batches[1].batch).toHaveLength(2);
+    const result = buildEnvelopes(events, { apiKey: API_KEY, maxEventsPerRun: 4 });
+    expect(result.envelopes).toHaveLength(4);
     expect(result.consumedCount).toBe(4);
   });
-
-  it('uses production caps when no override is provided', () => {
-    const result = partitionEvents([ev()], { apiKey: API_KEY });
-    expect(result.batches[0].batch).toHaveLength(1);
-  });
 });
 
-describe('TelemetryBatcher — nested types and ordering', () => {
+describe('TelemetryBatcher — nested types and defaults', () => {
   it('passes recentPrompts metadata array through untouched (PII-safe shape)', () => {
     const recentPrompts = [
       { index: 1, classifiedStage: 'planning',       confidence: 0.9, capturedAt: 1715000000 },
       { index: 2, classifiedStage: 'implementation', confidence: 0.8, capturedAt: 1715000100 },
     ];
-    const result = partitionEvents([ev({ event: 'decision_session_started', recentPrompts })], {
+    const result = buildEnvelopes([ev({ event: 'decision_session_started', recentPrompts })], {
       apiKey: API_KEY, hashProjectRoot: false,
     });
-    expect(result.batches[0].batch[0].properties.recentPrompts).toEqual(recentPrompts);
+    expect(result.envelopes[0].properties.recentPrompts).toEqual(recentPrompts);
   });
 
   it('with an empty allowedKeys, properties contain only $lib and $lib_version', () => {
-    const result = partitionEvents([ev({ stage: 'planning', confidence: 0.9 })], {
+    const result = buildEnvelopes([ev({ stage: 'planning', confidence: 0.9 })], {
       apiKey: API_KEY, allowedKeys: [], hashProjectRoot: false,
     });
-    expect(Object.keys(result.batches[0].batch[0].properties).sort()).toEqual(['$lib', '$lib_version']);
+    expect(Object.keys(result.envelopes[0].properties).sort()).toEqual(['$lib', '$lib_version']);
   });
 
-  it('preserves input order across batch splits (FIFO)', () => {
-    const events = [
-      ev({ event: 'prompt_received',   promptCount: 1 }),
-      ev({ event: 'prompt_classified', promptCount: 2 }),
-      ev({ event: 'profile_computed',  promptCount: 3 }),
-      ev({ event: 'absence_flags_detected', promptCount: 4 }),
-    ];
-    const result = partitionEvents(events, {
-      apiKey: API_KEY, maxEventsPerBatch: 2, maxBatchesPerRun: 10, hashProjectRoot: false,
-    });
-    const ordered = result.batches.flatMap(b => b.batch).map(e => e.properties.promptCount);
-    expect(ordered).toEqual([1, 2, 3, 4]);
-  });
-});
-
-describe('TelemetryBatcher — defaults & integration', () => {
   it('defaults libVersion to POSTHOG_LIB_VERSION constant', () => {
-    const result = partitionEvents([ev()], { apiKey: API_KEY });
-    expect(result.batches[0].batch[0].properties.$lib_version).toBe(POSTHOG_LIB_VERSION);
+    const result = buildEnvelopes([ev()], { apiKey: API_KEY });
+    expect(result.envelopes[0].properties.$lib_version).toBe(POSTHOG_LIB_VERSION);
   });
 
   it('defaults hashProjectRoot to true', () => {
-    const result = partitionEvents([ev({ projectRoot: '/some/path' })], { apiKey: API_KEY });
-    expect(String(result.batches[0].batch[0].properties.projectRoot)).toMatch(/^sha256:/);
-  });
-
-  it('end-to-end: 3 events → 1 batch with 3 PostHog events, all shaped correctly', () => {
-    const events = [
-      ev({ event: 'prompt_received',   promptCount: 1 }),
-      ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.9 }),
-      ev({ event: 'profile_computed',  profile: 'cool_geek' }),
-    ];
-    const result = partitionEvents(events, { apiKey: API_KEY, hashProjectRoot: false });
-    expect(result.batches[0].batch.map(e => e.event)).toEqual([
-      'prompt_received', 'prompt_classified', 'profile_computed',
-    ]);
-    expect(result.batches[0].batch.every(e => e.distinct_id === '550e8400-e29b-41d4-a716-446655440000')).toBe(true);
-    expect(result.batches[0].batch.every(e => e.properties.$lib === 'nexpath')).toBe(true);
+    const result = buildEnvelopes([ev({ projectRoot: '/some/path' })], { apiKey: API_KEY });
+    expect(String(result.envelopes[0].properties.projectRoot)).toMatch(/^sha256:/);
   });
 });
 
-describe('TelemetryBatcher — batchEndIndices', () => {
-  it('empty events: batchEndIndices is empty', () => {
-    const result = partitionEvents([], { apiKey: API_KEY });
-    expect(result.batchEndIndices).toEqual([]);
-  });
-
-  it('single batch covering all events: one entry equal to consumedCount', () => {
-    const result = partitionEvents([ev(), ev(), ev()], { apiKey: API_KEY });
-    expect(result.batchEndIndices).toEqual([3]);
-    expect(result.consumedCount).toBe(3);
-  });
-
-  it('multiple batches: indices are monotonically increasing', () => {
-    const events = Array.from({ length: 7 }, () => ev());
-    const result = partitionEvents(events, {
-      apiKey: API_KEY, maxEventsPerBatch: 3, maxBatchesPerRun: 10,
-    });
-    expect(result.batchEndIndices).toEqual([3, 6, 7]);
-  });
-
-  it('skipped events (no installationId) count toward indices', () => {
-    const noId = ev(); delete noId.installationId;
-    const result = partitionEvents([ev(), noId, ev()], {
-      apiKey: API_KEY, maxEventsPerBatch: 10, maxBatchesPerRun: 10,
-    });
-    expect(result.batchEndIndices).toEqual([3]);
-    expect(result.consumedCount).toBe(3);
-  });
-});
-
-describe('TelemetryBatcher → TelemetryClient integration', () => {
-  it('partitioned envelope reaches fetch with valid PostHog shape and returns ok=true', async () => {
-    const events = [
-      ev({ event: 'prompt_received',   promptCount: 1 }),
-      ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.9 }),
-    ];
-    const { batches } = partitionEvents(events, { apiKey: API_KEY, hashProjectRoot: true });
+describe('TelemetryBatcher → TelemetryClient integration (single-event POST)', () => {
+  it('built envelope reaches fetch with valid PostHog single-event shape and returns ok=true', async () => {
+    const events = [ev({ event: 'prompt_received', promptCount: 1 })];
+    const { envelopes } = buildEnvelopes(events, { apiKey: API_KEY, hashProjectRoot: true });
 
     const fetchMock = vi.fn<FetchLike>(async () => ({
       ok:      true,
@@ -283,16 +214,16 @@ describe('TelemetryBatcher → TelemetryClient integration', () => {
       headers: { get: () => null },
     }));
 
-    const result = await postBatch('https://us.i.posthog.com/capture/', batches[0], { fetch: fetchMock });
-    expect(result).toEqual({ ok: true, status: 200, acceptedCount: 2 });
+    const result = await postEvent('https://us.i.posthog.com/capture/', envelopes[0], { fetch: fetchMock });
+    expect(result).toEqual({ ok: true, status: 200, acceptedCount: 1 });
 
     const init     = fetchMock.mock.calls[0][1];
     const body     = JSON.parse(init.body);
     expect(body.api_key).toBe(API_KEY);
-    expect(body.batch).toHaveLength(2);
-    expect(body.batch[0].event).toBe('prompt_received');
-    expect(body.batch[0].distinct_id).toBe('550e8400-e29b-41d4-a716-446655440000');
-    expect(body.batch[0].properties.$lib).toBe('nexpath');
-    expect(String(body.batch[0].properties.projectRoot)).toMatch(/^sha256:/);
+    expect(body.event).toBe('prompt_received');
+    expect(body.distinct_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(body.properties.$lib).toBe('nexpath');
+    expect(String(body.properties.projectRoot)).toMatch(/^sha256:/);
+    expect(body.batch).toBeUndefined();
   });
 });

--- a/src/telemetry/TelemetryBatcher.test.ts
+++ b/src/telemetry/TelemetryBatcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createHash } from 'node:crypto';
 import {
   partitionEvents,
@@ -8,6 +8,7 @@ import {
   POSTHOG_LIB_NAME,
   POSTHOG_LIB_VERSION,
 } from './TelemetryBatcher.js';
+import { postBatch, type FetchLike } from './TelemetryClient.js';
 import type { TelemetryEvent } from './types.js';
 
 const API_KEY = 'phc_test_key';
@@ -178,6 +179,40 @@ describe('TelemetryBatcher — partitioning caps', () => {
   });
 });
 
+describe('TelemetryBatcher — nested types and ordering', () => {
+  it('passes recentPrompts metadata array through untouched (PII-safe shape)', () => {
+    const recentPrompts = [
+      { index: 1, classifiedStage: 'planning',       confidence: 0.9, capturedAt: 1715000000 },
+      { index: 2, classifiedStage: 'implementation', confidence: 0.8, capturedAt: 1715000100 },
+    ];
+    const result = partitionEvents([ev({ event: 'decision_session_started', recentPrompts })], {
+      apiKey: API_KEY, hashProjectRoot: false,
+    });
+    expect(result.batches[0].batch[0].properties.recentPrompts).toEqual(recentPrompts);
+  });
+
+  it('with an empty allowedKeys, properties contain only $lib and $lib_version', () => {
+    const result = partitionEvents([ev({ stage: 'planning', confidence: 0.9 })], {
+      apiKey: API_KEY, allowedKeys: [], hashProjectRoot: false,
+    });
+    expect(Object.keys(result.batches[0].batch[0].properties).sort()).toEqual(['$lib', '$lib_version']);
+  });
+
+  it('preserves input order across batch splits (FIFO)', () => {
+    const events = [
+      ev({ event: 'prompt_received',   promptCount: 1 }),
+      ev({ event: 'prompt_classified', promptCount: 2 }),
+      ev({ event: 'profile_computed',  promptCount: 3 }),
+      ev({ event: 'absence_flags_detected', promptCount: 4 }),
+    ];
+    const result = partitionEvents(events, {
+      apiKey: API_KEY, maxEventsPerBatch: 2, maxBatchesPerRun: 10, hashProjectRoot: false,
+    });
+    const ordered = result.batches.flatMap(b => b.batch).map(e => e.properties.promptCount);
+    expect(ordered).toEqual([1, 2, 3, 4]);
+  });
+});
+
 describe('TelemetryBatcher — defaults & integration', () => {
   it('defaults libVersion to POSTHOG_LIB_VERSION constant', () => {
     const result = partitionEvents([ev()], { apiKey: API_KEY });
@@ -201,5 +236,33 @@ describe('TelemetryBatcher — defaults & integration', () => {
     ]);
     expect(result.batches[0].batch.every(e => e.distinct_id === '550e8400-e29b-41d4-a716-446655440000')).toBe(true);
     expect(result.batches[0].batch.every(e => e.properties.$lib === 'nexpath')).toBe(true);
+  });
+});
+
+describe('TelemetryBatcher → TelemetryClient integration', () => {
+  it('partitioned envelope reaches fetch with valid PostHog shape and returns ok=true', async () => {
+    const events = [
+      ev({ event: 'prompt_received',   promptCount: 1 }),
+      ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.9 }),
+    ];
+    const { batches } = partitionEvents(events, { apiKey: API_KEY, hashProjectRoot: true });
+
+    const fetchMock = vi.fn<FetchLike>(async () => ({
+      ok:      true,
+      status:  200,
+      headers: { get: () => null },
+    }));
+
+    const result = await postBatch('https://us.i.posthog.com/capture/', batches[0], { fetch: fetchMock });
+    expect(result).toEqual({ ok: true, status: 200, acceptedCount: 2 });
+
+    const init     = fetchMock.mock.calls[0][1];
+    const body     = JSON.parse(init.body);
+    expect(body.api_key).toBe(API_KEY);
+    expect(body.batch).toHaveLength(2);
+    expect(body.batch[0].event).toBe('prompt_received');
+    expect(body.batch[0].distinct_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(body.batch[0].properties.$lib).toBe('nexpath');
+    expect(String(body.batch[0].properties.projectRoot)).toMatch(/^sha256:/);
   });
 });

--- a/src/telemetry/TelemetryBatcher.test.ts
+++ b/src/telemetry/TelemetryBatcher.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  partitionEvents,
+  toPostHogEvent,
+  hashProjectRootValue,
+  ALLOWED_PROPERTY_KEYS,
+  POSTHOG_LIB_NAME,
+  POSTHOG_LIB_VERSION,
+} from './TelemetryBatcher.js';
+import type { TelemetryEvent } from './types.js';
+
+const API_KEY = 'phc_test_key';
+
+function ev(overrides: Partial<TelemetryEvent> = {}): TelemetryEvent {
+  return {
+    ts:             '2026-05-19T10:00:00.000Z',
+    v:              1,
+    installationId: '550e8400-e29b-41d4-a716-446655440000',
+    userId:         '8a3f1c2e-5b6d-4e7f-9a2c-1d3e5f7b9c0d',
+    teamId:         'team-stub-2c8e4f6a-1b3d-5e7f-9a2c-4d6e8f0b2c1d',
+    projectRoot:    '/home/jemi/projects/demo',
+    event:          'prompt_received',
+    ...overrides,
+  };
+}
+
+describe('TelemetryBatcher — toPostHogEvent', () => {
+  it('maps installationId → distinct_id', () => {
+    const out = toPostHogEvent(ev(), { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    expect(out?.distinct_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('maps ts → timestamp', () => {
+    const out = toPostHogEvent(ev({ ts: '2026-05-19T11:22:33.444Z' }), {
+      hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
+    });
+    expect(out?.timestamp).toBe('2026-05-19T11:22:33.444Z');
+  });
+
+  it('moves remaining whitelisted fields into properties', () => {
+    const out = toPostHogEvent(
+      ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.92 }),
+      { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS },
+    );
+    expect(out?.properties.userId).toBe('8a3f1c2e-5b6d-4e7f-9a2c-1d3e5f7b9c0d');
+    expect(out?.properties.teamId).toBe('team-stub-2c8e4f6a-1b3d-5e7f-9a2c-4d6e8f0b2c1d');
+    expect(out?.properties.stage).toBe('planning');
+    expect(out?.properties.confidence).toBe(0.92);
+  });
+
+  it('injects $lib and $lib_version properties', () => {
+    const out = toPostHogEvent(ev(), { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    expect(out?.properties.$lib).toBe(POSTHOG_LIB_NAME);
+    expect(out?.properties.$lib_version).toBe('0.1.1');
+  });
+
+  it('hashes projectRoot when hashProjectRoot=true (sha256: prefix)', () => {
+    const out = toPostHogEvent(ev({ projectRoot: '/home/jemi/x' }), {
+      hashProjectRoot: true, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
+    });
+    const expected = `sha256:${createHash('sha256').update('/home/jemi/x').digest('hex')}`;
+    expect(out?.properties.projectRoot).toBe(expected);
+  });
+
+  it('passes projectRoot raw when hashProjectRoot=false', () => {
+    const out = toPostHogEvent(ev({ projectRoot: '/home/jemi/x' }), {
+      hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS,
+    });
+    expect(out?.properties.projectRoot).toBe('/home/jemi/x');
+  });
+
+  it('returns null when installationId is missing', () => {
+    const raw = ev();
+    delete raw.installationId;
+    const out = toPostHogEvent(raw, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    expect(out).toBeNull();
+  });
+
+  it('drops keys not on the whitelist (security)', () => {
+    const raw = ev({ secretApiKey: 'sk-leaked-key', somethingElse: 'wat' }) as TelemetryEvent;
+    const out = toPostHogEvent(raw, { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ALLOWED_PROPERTY_KEYS });
+    expect(out?.properties.secretApiKey).toBeUndefined();
+    expect(out?.properties.somethingElse).toBeUndefined();
+  });
+
+  it('honours custom allowedKeys parameter', () => {
+    const out = toPostHogEvent(
+      ev({ stage: 'planning', confidence: 0.92 }),
+      { hashProjectRoot: false, libVersion: '0.1.1', allowedKeys: ['stage'] },
+    );
+    expect(out?.properties.stage).toBe('planning');
+    expect(out?.properties.confidence).toBeUndefined();
+    expect(out?.properties.userId).toBeUndefined();
+  });
+});
+
+describe('TelemetryBatcher — hashProjectRootValue', () => {
+  it('produces deterministic SHA-256 hash with sha256: prefix', () => {
+    const a = hashProjectRootValue('/home/x');
+    const b = hashProjectRootValue('/home/x');
+    expect(a).toBe(b);
+    expect(a.startsWith('sha256:')).toBe(true);
+    expect(a.length).toBe('sha256:'.length + 64);
+  });
+
+  it('produces different hashes for different paths', () => {
+    expect(hashProjectRootValue('/home/a')).not.toBe(hashProjectRootValue('/home/b'));
+  });
+});
+
+describe('TelemetryBatcher — partitionEvents envelope shape', () => {
+  it('empty events produce empty batches', () => {
+    const result = partitionEvents([], { apiKey: API_KEY });
+    expect(result.batches).toHaveLength(0);
+    expect(result.consumedCount).toBe(0);
+  });
+
+  it('single event produces one batch with one PostHogEvent', () => {
+    const result = partitionEvents([ev()], { apiKey: API_KEY, hashProjectRoot: false });
+    expect(result.batches).toHaveLength(1);
+    expect(result.batches[0].api_key).toBe(API_KEY);
+    expect(result.batches[0].batch).toHaveLength(1);
+    expect(result.consumedCount).toBe(1);
+  });
+
+  it('envelope wraps with api_key + batch keys (PostHog shape)', () => {
+    const result = partitionEvents([ev()], { apiKey: API_KEY });
+    expect(Object.keys(result.batches[0]).sort()).toEqual(['api_key', 'batch']);
+  });
+
+  it('events without installationId are skipped but consumedCount advances', () => {
+    const valid   = ev();
+    const noId    = ev();
+    delete noId.installationId;
+    const result = partitionEvents([valid, noId, valid], { apiKey: API_KEY });
+    expect(result.batches[0].batch).toHaveLength(2);
+    expect(result.consumedCount).toBe(3);
+  });
+});
+
+describe('TelemetryBatcher — partitioning caps', () => {
+  it('splits into multiple batches when maxEventsPerBatch is exceeded', () => {
+    const events = Array.from({ length: 7 }, () => ev());
+    const result = partitionEvents(events, {
+      apiKey: API_KEY, maxEventsPerBatch: 3, maxBatchesPerRun: 10,
+    });
+    expect(result.batches).toHaveLength(3);
+    expect(result.batches[0].batch).toHaveLength(3);
+    expect(result.batches[1].batch).toHaveLength(3);
+    expect(result.batches[2].batch).toHaveLength(1);
+    expect(result.consumedCount).toBe(7);
+  });
+
+  it('splits into multiple batches when maxBytesPerBatch is exceeded', () => {
+    const events = Array.from({ length: 10 }, (_, i) => ev({ pinchLabel: 'x'.repeat(100), promptCount: i }));
+    const result = partitionEvents(events, {
+      apiKey: API_KEY, maxBytesPerBatch: 500, maxBatchesPerRun: 10,
+    });
+    expect(result.batches.length).toBeGreaterThan(1);
+    expect(result.consumedCount).toBe(10);
+  });
+
+  it('caps at maxBatchesPerRun — overflow events are NOT consumed', () => {
+    const events = Array.from({ length: 10 }, () => ev());
+    const result = partitionEvents(events, {
+      apiKey: API_KEY, maxEventsPerBatch: 2, maxBatchesPerRun: 2,
+    });
+    expect(result.batches).toHaveLength(2);
+    expect(result.batches[0].batch).toHaveLength(2);
+    expect(result.batches[1].batch).toHaveLength(2);
+    expect(result.consumedCount).toBe(4);
+  });
+
+  it('uses production caps when no override is provided', () => {
+    const result = partitionEvents([ev()], { apiKey: API_KEY });
+    expect(result.batches[0].batch).toHaveLength(1);
+  });
+});
+
+describe('TelemetryBatcher — defaults & integration', () => {
+  it('defaults libVersion to POSTHOG_LIB_VERSION constant', () => {
+    const result = partitionEvents([ev()], { apiKey: API_KEY });
+    expect(result.batches[0].batch[0].properties.$lib_version).toBe(POSTHOG_LIB_VERSION);
+  });
+
+  it('defaults hashProjectRoot to true', () => {
+    const result = partitionEvents([ev({ projectRoot: '/some/path' })], { apiKey: API_KEY });
+    expect(String(result.batches[0].batch[0].properties.projectRoot)).toMatch(/^sha256:/);
+  });
+
+  it('end-to-end: 3 events → 1 batch with 3 PostHog events, all shaped correctly', () => {
+    const events = [
+      ev({ event: 'prompt_received',   promptCount: 1 }),
+      ev({ event: 'prompt_classified', stage: 'planning', confidence: 0.9 }),
+      ev({ event: 'profile_computed',  profile: 'cool_geek' }),
+    ];
+    const result = partitionEvents(events, { apiKey: API_KEY, hashProjectRoot: false });
+    expect(result.batches[0].batch.map(e => e.event)).toEqual([
+      'prompt_received', 'prompt_classified', 'profile_computed',
+    ]);
+    expect(result.batches[0].batch.every(e => e.distinct_id === '550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(result.batches[0].batch.every(e => e.properties.$lib === 'nexpath')).toBe(true);
+  });
+});

--- a/src/telemetry/TelemetryBatcher.ts
+++ b/src/telemetry/TelemetryBatcher.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto';
+import type { PostHogBatchEnvelope, PostHogEvent, TelemetryEvent } from './types.js';
+
+export const POSTHOG_LIB_NAME    = 'nexpath';
+export const POSTHOG_LIB_VERSION = '0.1.1';
+
+export const MAX_EVENTS_PER_BATCH = 500;
+export const MAX_BYTES_PER_BATCH  = 256 * 1024;
+export const MAX_BATCHES_PER_RUN  = 4;
+
+export const ALLOWED_PROPERTY_KEYS: ReadonlyArray<string> = [
+  '$lib', '$lib_version',
+  'userId', 'teamId',
+  'projectRoot', 'schema_version', 'v',
+  'promptCount', 'stage', 'confidence', 'classifier',
+  'profile',
+  'flagType', 'pinchLabel', 'sessionId',
+  'level', 'reason',
+  'cooldownSecondsRemaining', 'currentCap',
+  'advisoryCountInSession', 'decisionSessionCountInProject',
+  'optionId', 'optionLabel',
+  'recentPrompts', 'skipCountInProject',
+  'language',
+  'confirmed',
+  'event_count', 'latency_ms', 'http_status',
+];
+
+export interface BatchOptions {
+  apiKey:           string;
+  hashProjectRoot?: boolean;
+  libVersion?:      string;
+  allowedKeys?:     ReadonlyArray<string>;
+  maxEventsPerBatch?: number;
+  maxBytesPerBatch?:  number;
+  maxBatchesPerRun?:  number;
+}
+
+export interface BatchPartitions {
+  batches:       PostHogBatchEnvelope[];
+  consumedCount: number;
+}
+
+export function hashProjectRootValue(raw: string): string {
+  return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
+}
+
+export function toPostHogEvent(
+  raw:  TelemetryEvent,
+  opts: { hashProjectRoot: boolean; libVersion: string; allowedKeys: ReadonlyArray<string> },
+): PostHogEvent | null {
+  if (typeof raw.installationId !== 'string' || raw.installationId === '') return null;
+
+  const properties: Record<string, unknown> = {
+    $lib:         POSTHOG_LIB_NAME,
+    $lib_version: opts.libVersion,
+  };
+
+  for (const key of opts.allowedKeys) {
+    if (key === '$lib' || key === '$lib_version') continue;
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) continue;
+
+    let value: unknown = (raw as Record<string, unknown>)[key];
+    if (key === 'projectRoot' && opts.hashProjectRoot && typeof value === 'string') {
+      value = hashProjectRootValue(value);
+    }
+    properties[key] = value;
+  }
+
+  return {
+    event:       raw.event,
+    distinct_id: raw.installationId,
+    timestamp:   raw.ts,
+    properties,
+  };
+}
+
+export function partitionEvents(events: TelemetryEvent[], opts: BatchOptions): BatchPartitions {
+  const libVersion      = opts.libVersion       ?? POSTHOG_LIB_VERSION;
+  const allowedKeys     = opts.allowedKeys      ?? ALLOWED_PROPERTY_KEYS;
+  const hashProjectRoot = opts.hashProjectRoot  ?? true;
+  const maxEvents       = opts.maxEventsPerBatch ?? MAX_EVENTS_PER_BATCH;
+  const maxBytes        = opts.maxBytesPerBatch  ?? MAX_BYTES_PER_BATCH;
+  const maxBatches      = opts.maxBatchesPerRun  ?? MAX_BATCHES_PER_RUN;
+
+  const batches: PostHogBatchEnvelope[] = [];
+  let current: PostHogEvent[] = [];
+  let currentBytes = 0;
+  let consumedCount = 0;
+
+  const flush = () => {
+    if (current.length > 0) {
+      batches.push({ api_key: opts.apiKey, batch: current });
+      current = [];
+      currentBytes = 0;
+    }
+  };
+
+  for (const raw of events) {
+    if (batches.length >= maxBatches) break;
+
+    const phEvent = toPostHogEvent(raw, { hashProjectRoot, libVersion, allowedKeys });
+    if (phEvent === null) {
+      consumedCount++;
+      continue;
+    }
+
+    const phBytes = Buffer.byteLength(JSON.stringify(phEvent), 'utf8');
+    const wouldOverflow =
+      current.length > 0 &&
+      (current.length >= maxEvents || currentBytes + phBytes > maxBytes);
+
+    if (wouldOverflow) {
+      flush();
+      if (batches.length >= maxBatches) break;
+    }
+
+    current.push(phEvent);
+    currentBytes += phBytes;
+    consumedCount++;
+  }
+
+  if (batches.length < maxBatches) flush();
+
+  return { batches, consumedCount };
+}

--- a/src/telemetry/TelemetryBatcher.ts
+++ b/src/telemetry/TelemetryBatcher.ts
@@ -1,12 +1,10 @@
 import { createHash } from 'node:crypto';
-import type { PostHogBatchEnvelope, PostHogEvent, TelemetryEvent } from './types.js';
+import type { PostHogSingleEnvelope, TelemetryEvent } from './types.js';
 
 export const POSTHOG_LIB_NAME    = 'nexpath';
 export const POSTHOG_LIB_VERSION = '0.1.1';
 
-export const MAX_EVENTS_PER_BATCH = 500;
-export const MAX_BYTES_PER_BATCH  = 256 * 1024;
-export const MAX_BATCHES_PER_RUN  = 4;
+export const MAX_EVENTS_PER_RUN = 2000;
 
 export const ALLOWED_PROPERTY_KEYS: ReadonlyArray<string> = [
   '$lib', '$lib_version',
@@ -25,30 +23,28 @@ export const ALLOWED_PROPERTY_KEYS: ReadonlyArray<string> = [
   'event_count', 'latency_ms', 'http_status',
 ];
 
-export interface BatchOptions {
+export interface BuildOptions {
   apiKey:           string;
   hashProjectRoot?: boolean;
   libVersion?:      string;
   allowedKeys?:     ReadonlyArray<string>;
-  maxEventsPerBatch?: number;
-  maxBytesPerBatch?:  number;
-  maxBatchesPerRun?:  number;
+  maxEventsPerRun?: number;
 }
 
-export interface BatchPartitions {
-  batches:          PostHogBatchEnvelope[];
-  batchEndIndices:  number[];
-  consumedCount:    number;
+export interface BuildResult {
+  envelopes:     PostHogSingleEnvelope[];
+  consumedCount: number;
 }
 
 export function hashProjectRootValue(raw: string): string {
   return `sha256:${createHash('sha256').update(raw).digest('hex')}`;
 }
 
-export function toPostHogEvent(
-  raw:  TelemetryEvent,
-  opts: { hashProjectRoot: boolean; libVersion: string; allowedKeys: ReadonlyArray<string> },
-): PostHogEvent | null {
+export function toPostHogEnvelope(
+  raw:    TelemetryEvent,
+  apiKey: string,
+  opts:   { hashProjectRoot: boolean; libVersion: string; allowedKeys: ReadonlyArray<string> },
+): PostHogSingleEnvelope | null {
   if (typeof raw.installationId !== 'string' || raw.installationId === '') return null;
 
   const properties: Record<string, unknown> = {
@@ -68,6 +64,7 @@ export function toPostHogEvent(
   }
 
   return {
+    api_key:     apiKey,
     event:       raw.event,
     distinct_id: raw.installationId,
     timestamp:   raw.ts,
@@ -75,54 +72,27 @@ export function toPostHogEvent(
   };
 }
 
-export function partitionEvents(events: TelemetryEvent[], opts: BatchOptions): BatchPartitions {
-  const libVersion      = opts.libVersion       ?? POSTHOG_LIB_VERSION;
-  const allowedKeys     = opts.allowedKeys      ?? ALLOWED_PROPERTY_KEYS;
-  const hashProjectRoot = opts.hashProjectRoot  ?? true;
-  const maxEvents       = opts.maxEventsPerBatch ?? MAX_EVENTS_PER_BATCH;
-  const maxBytes        = opts.maxBytesPerBatch  ?? MAX_BYTES_PER_BATCH;
-  const maxBatches      = opts.maxBatchesPerRun  ?? MAX_BATCHES_PER_RUN;
+export function buildEnvelopes(events: TelemetryEvent[], opts: BuildOptions): BuildResult {
+  const libVersion       = opts.libVersion       ?? POSTHOG_LIB_VERSION;
+  const allowedKeys      = opts.allowedKeys      ?? ALLOWED_PROPERTY_KEYS;
+  const hashProjectRoot  = opts.hashProjectRoot  ?? true;
+  const maxEventsPerRun  = opts.maxEventsPerRun  ?? MAX_EVENTS_PER_RUN;
 
-  const batches:         PostHogBatchEnvelope[] = [];
-  const batchEndIndices: number[]               = [];
-  let current:           PostHogEvent[]         = [];
-  let currentBytes     = 0;
-  let consumedCount    = 0;
-
-  const flush = () => {
-    if (current.length > 0) {
-      batches.push({ api_key: opts.apiKey, batch: current });
-      batchEndIndices.push(consumedCount);
-      current = [];
-      currentBytes = 0;
-    }
-  };
+  const envelopes:     PostHogSingleEnvelope[] = [];
+  let consumedCount = 0;
 
   for (const raw of events) {
-    if (batches.length >= maxBatches) break;
+    if (envelopes.length >= maxEventsPerRun) break;
 
-    const phEvent = toPostHogEvent(raw, { hashProjectRoot, libVersion, allowedKeys });
-    if (phEvent === null) {
+    const envelope = toPostHogEnvelope(raw, opts.apiKey, { hashProjectRoot, libVersion, allowedKeys });
+    if (envelope === null) {
       consumedCount++;
       continue;
     }
 
-    const phBytes = Buffer.byteLength(JSON.stringify(phEvent), 'utf8');
-    const wouldOverflow =
-      current.length > 0 &&
-      (current.length >= maxEvents || currentBytes + phBytes > maxBytes);
-
-    if (wouldOverflow) {
-      flush();
-      if (batches.length >= maxBatches) break;
-    }
-
-    current.push(phEvent);
-    currentBytes += phBytes;
+    envelopes.push(envelope);
     consumedCount++;
   }
 
-  if (batches.length < maxBatches) flush();
-
-  return { batches, batchEndIndices, consumedCount };
+  return { envelopes, consumedCount };
 }

--- a/src/telemetry/TelemetryBatcher.ts
+++ b/src/telemetry/TelemetryBatcher.ts
@@ -36,8 +36,9 @@ export interface BatchOptions {
 }
 
 export interface BatchPartitions {
-  batches:       PostHogBatchEnvelope[];
-  consumedCount: number;
+  batches:          PostHogBatchEnvelope[];
+  batchEndIndices:  number[];
+  consumedCount:    number;
 }
 
 export function hashProjectRootValue(raw: string): string {
@@ -82,14 +83,16 @@ export function partitionEvents(events: TelemetryEvent[], opts: BatchOptions): B
   const maxBytes        = opts.maxBytesPerBatch  ?? MAX_BYTES_PER_BATCH;
   const maxBatches      = opts.maxBatchesPerRun  ?? MAX_BATCHES_PER_RUN;
 
-  const batches: PostHogBatchEnvelope[] = [];
-  let current: PostHogEvent[] = [];
-  let currentBytes = 0;
-  let consumedCount = 0;
+  const batches:         PostHogBatchEnvelope[] = [];
+  const batchEndIndices: number[]               = [];
+  let current:           PostHogEvent[]         = [];
+  let currentBytes     = 0;
+  let consumedCount    = 0;
 
   const flush = () => {
     if (current.length > 0) {
       batches.push({ api_key: opts.apiKey, batch: current });
+      batchEndIndices.push(consumedCount);
       current = [];
       currentBytes = 0;
     }
@@ -121,5 +124,5 @@ export function partitionEvents(events: TelemetryEvent[], opts: BatchOptions): B
 
   if (batches.length < maxBatches) flush();
 
-  return { batches, consumedCount };
+  return { batches, batchEndIndices, consumedCount };
 }

--- a/src/telemetry/TelemetryClient.test.ts
+++ b/src/telemetry/TelemetryClient.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  postBatch,
+  parseRetryAfter,
+  DEFAULT_POSTHOG_ENDPOINT,
+  DEFAULT_TIMEOUT_MS,
+  type FetchLike,
+} from './TelemetryClient.js';
+import type { PostHogBatchEnvelope } from './types.js';
+
+const ENDPOINT = DEFAULT_POSTHOG_ENDPOINT;
+const ENVELOPE: PostHogBatchEnvelope = {
+  api_key: 'phc_test',
+  batch: [
+    {
+      event:       'prompt_received',
+      distinct_id: 'install-uuid',
+      timestamp:   '2026-05-19T10:00:00.000Z',
+      properties:  { $lib: 'nexpath', $lib_version: '0.1.1' },
+    },
+  ],
+};
+
+function mockResponse(opts: { ok: boolean; status: number; headers?: Record<string, string> }): Parameters<FetchLike>[1] extends never ? never : ReturnType<FetchLike> extends Promise<infer R> ? R : never {
+  return {
+    ok:      opts.ok,
+    status:  opts.status,
+    headers: { get: (name: string) => opts.headers?.[name] ?? null },
+  } as ReturnType<FetchLike> extends Promise<infer R> ? R : never;
+}
+
+describe('TelemetryClient — successful POST', () => {
+  it('returns ok=true and acceptedCount=batch length on 200', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: true, status: 200, acceptedCount: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends POST method and Content-Type: application/json', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('sends User-Agent header with nexpath version', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers['User-Agent']).toMatch(/^nexpath\/\d/);
+  });
+
+  it('does NOT send Authorization header (PostHog uses api_key in body)', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers['Authorization']).toBeUndefined();
+  });
+
+  it('body is valid JSON containing api_key and batch', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const init   = fetchMock.mock.calls[0][1];
+    const parsed = JSON.parse(init.body);
+    expect(parsed.api_key).toBe('phc_test');
+    expect(parsed.batch).toHaveLength(1);
+    expect(parsed.batch[0].event).toBe('prompt_received');
+  });
+});
+
+describe('TelemetryClient — error responses', () => {
+  it('4xx (non-429) returns kind=http with status', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 400 }));
+    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: false, kind: 'http', status: 400 });
+  });
+
+  it('5xx returns kind=http with status', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 503 }));
+    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: false, kind: 'http', status: 503 });
+  });
+
+  it('429 returns retryAfterSeconds parsed from numeric Retry-After header', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({
+      ok: false, status: 429, headers: { 'Retry-After': '120' },
+    }));
+    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: false, kind: 'http', status: 429, retryAfterSeconds: 120 });
+  });
+
+  it('429 with no Retry-After header omits retryAfterSeconds', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 429 }));
+    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: false, kind: 'http', status: 429 });
+  });
+});
+
+describe('TelemetryClient — network and timeout', () => {
+  it('network error returns kind=network', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => { throw new Error('ECONNREFUSED'); });
+    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    expect(result).toEqual({ ok: false, kind: 'network' });
+  });
+
+  it('does not throw when fetch rejects', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => { throw new Error('boom'); });
+    await expect(postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock })).resolves.toBeDefined();
+  });
+
+  it('aborts the request after timeoutMs and returns network error', async () => {
+    const fetchMock = vi.fn<FetchLike>(async (_url, init) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    });
+    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 50 });
+    expect(result).toEqual({ ok: false, kind: 'network' });
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('parses positive integer seconds', () => {
+    expect(parseRetryAfter('120')).toBe(120);
+  });
+
+  it('parses zero', () => {
+    expect(parseRetryAfter('0')).toBe(0);
+  });
+
+  it('floors fractional seconds', () => {
+    expect(parseRetryAfter('1.9')).toBe(1);
+  });
+
+  it('returns undefined for null header', () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+  });
+
+  it('returns undefined for empty header', () => {
+    expect(parseRetryAfter('  ')).toBeUndefined();
+  });
+
+  it('returns undefined for unparseable header', () => {
+    expect(parseRetryAfter('not-a-time')).toBeUndefined();
+  });
+
+  it('parses HTTP-date header and returns seconds until that date', () => {
+    const now      = new Date('2026-05-19T10:00:00.000Z').getTime();
+    const target   = new Date(now + 90_000).toUTCString();
+    const seconds  = parseRetryAfter(target, () => now);
+    expect(seconds).toBe(90);
+  });
+
+  it('clamps past HTTP-date to 0 (no negative seconds)', () => {
+    const now    = new Date('2026-05-19T10:00:00.000Z').getTime();
+    const past   = new Date(now - 60_000).toUTCString();
+    expect(parseRetryAfter(past, () => now)).toBe(0);
+  });
+});
+
+describe('TelemetryClient — constants', () => {
+  it('DEFAULT_POSTHOG_ENDPOINT points at PostHog US cloud /capture/', () => {
+    expect(DEFAULT_POSTHOG_ENDPOINT).toBe('https://us.i.posthog.com/capture/');
+  });
+
+  it('DEFAULT_TIMEOUT_MS is 10 seconds', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(10_000);
+  });
+});

--- a/src/telemetry/TelemetryClient.test.ts
+++ b/src/telemetry/TelemetryClient.test.ts
@@ -160,6 +160,37 @@ describe('parseRetryAfter', () => {
   });
 });
 
+describe('TelemetryClient — options', () => {
+  it('passes the supplied URL to fetch', async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
+    const url       = 'https://eu.posthog.example/capture/';
+    await postBatch(url, ENVELOPE, { fetch: fetchMock });
+    expect(fetchMock.mock.calls[0][0]).toBe(url);
+  });
+
+  it('honours custom timeoutMs option', async () => {
+    let signalRef: AbortSignal | null = null;
+    const fetchMock = vi.fn<FetchLike>(async (_url, init) => {
+      signalRef = init.signal;
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    });
+    const start  = Date.now();
+    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 30 });
+    const elapsed = Date.now() - start;
+    expect(result).toEqual({ ok: false, kind: 'network' });
+    expect(elapsed).toBeLessThan(500);
+    expect(signalRef).not.toBeNull();
+  });
+});
+
+describe('parseRetryAfter — negative inputs rejected', () => {
+  it('returns undefined for negative numeric seconds', () => {
+    expect(parseRetryAfter('-30')).toBeUndefined();
+  });
+});
+
 describe('TelemetryClient — constants', () => {
   it('DEFAULT_POSTHOG_ENDPOINT points at PostHog US cloud /capture/', () => {
     expect(DEFAULT_POSTHOG_ENDPOINT).toBe('https://us.i.posthog.com/capture/');

--- a/src/telemetry/TelemetryClient.test.ts
+++ b/src/telemetry/TelemetryClient.test.ts
@@ -1,24 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
-  postBatch,
+  postEvent,
   parseRetryAfter,
   DEFAULT_POSTHOG_ENDPOINT,
   DEFAULT_TIMEOUT_MS,
   type FetchLike,
 } from './TelemetryClient.js';
-import type { PostHogBatchEnvelope } from './types.js';
+import type { PostHogSingleEnvelope } from './types.js';
 
 const ENDPOINT = DEFAULT_POSTHOG_ENDPOINT;
-const ENVELOPE: PostHogBatchEnvelope = {
-  api_key: 'phc_test',
-  batch: [
-    {
-      event:       'prompt_received',
-      distinct_id: 'install-uuid',
-      timestamp:   '2026-05-19T10:00:00.000Z',
-      properties:  { $lib: 'nexpath', $lib_version: '0.1.1' },
-    },
-  ],
+const ENVELOPE: PostHogSingleEnvelope = {
+  api_key:     'phc_test',
+  event:       'prompt_received',
+  distinct_id: 'install-uuid',
+  timestamp:   '2026-05-19T10:00:00.000Z',
+  properties:  { $lib: 'nexpath', $lib_version: '0.1.1' },
 };
 
 function mockResponse(opts: { ok: boolean; status: number; headers?: Record<string, string> }): Parameters<FetchLike>[1] extends never ? never : ReturnType<FetchLike> extends Promise<infer R> ? R : never {
@@ -30,16 +26,16 @@ function mockResponse(opts: { ok: boolean; status: number; headers?: Record<stri
 }
 
 describe('TelemetryClient — successful POST', () => {
-  it('returns ok=true and acceptedCount=batch length on 200', async () => {
+  it('returns ok=true and acceptedCount=1 on 200', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
-    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result    = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: true, status: 200, acceptedCount: 1 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('sends POST method and Content-Type: application/json', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
-    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     const init = fetchMock.mock.calls[0][1];
     expect(init.method).toBe('POST');
     expect(init.headers['Content-Type']).toBe('application/json');
@@ -47,39 +43,40 @@ describe('TelemetryClient — successful POST', () => {
 
   it('sends User-Agent header with nexpath version', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
-    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     const init = fetchMock.mock.calls[0][1];
     expect(init.headers['User-Agent']).toMatch(/^nexpath\/\d/);
   });
 
   it('does NOT send Authorization header (PostHog uses api_key in body)', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
-    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     const init = fetchMock.mock.calls[0][1];
     expect(init.headers['Authorization']).toBeUndefined();
   });
 
-  it('body is valid JSON containing api_key and batch', async () => {
+  it('body is valid JSON with flat PostHog single-event shape (api_key, event, distinct_id, timestamp, properties)', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
-    await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     const init   = fetchMock.mock.calls[0][1];
     const parsed = JSON.parse(init.body);
     expect(parsed.api_key).toBe('phc_test');
-    expect(parsed.batch).toHaveLength(1);
-    expect(parsed.batch[0].event).toBe('prompt_received');
+    expect(parsed.event).toBe('prompt_received');
+    expect(parsed.distinct_id).toBe('install-uuid');
+    expect(parsed.batch).toBeUndefined();
   });
 });
 
 describe('TelemetryClient — error responses', () => {
   it('4xx (non-429) returns kind=http with status', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 400 }));
-    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result    = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: false, kind: 'http', status: 400 });
   });
 
   it('5xx returns kind=http with status', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 503 }));
-    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result    = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: false, kind: 'http', status: 503 });
   });
 
@@ -87,13 +84,13 @@ describe('TelemetryClient — error responses', () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({
       ok: false, status: 429, headers: { 'Retry-After': '120' },
     }));
-    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: false, kind: 'http', status: 429, retryAfterSeconds: 120 });
   });
 
   it('429 with no Retry-After header omits retryAfterSeconds', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: false, status: 429 }));
-    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result    = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: false, kind: 'http', status: 429 });
   });
 });
@@ -101,13 +98,13 @@ describe('TelemetryClient — error responses', () => {
 describe('TelemetryClient — network and timeout', () => {
   it('network error returns kind=network', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => { throw new Error('ECONNREFUSED'); });
-    const result    = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock });
+    const result    = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock });
     expect(result).toEqual({ ok: false, kind: 'network' });
   });
 
   it('does not throw when fetch rejects', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => { throw new Error('boom'); });
-    await expect(postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock })).resolves.toBeDefined();
+    await expect(postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock })).resolves.toBeDefined();
   });
 
   it('aborts the request after timeoutMs and returns network error', async () => {
@@ -116,7 +113,7 @@ describe('TelemetryClient — network and timeout', () => {
         init.signal.addEventListener('abort', () => reject(new Error('aborted')));
       });
     });
-    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 50 });
+    const result = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 50 });
     expect(result).toEqual({ ok: false, kind: 'network' });
   });
 });
@@ -164,7 +161,7 @@ describe('TelemetryClient — options', () => {
   it('passes the supplied URL to fetch', async () => {
     const fetchMock = vi.fn<FetchLike>(async () => mockResponse({ ok: true, status: 200 }));
     const url       = 'https://eu.posthog.example/capture/';
-    await postBatch(url, ENVELOPE, { fetch: fetchMock });
+    await postEvent(url, ENVELOPE, { fetch: fetchMock });
     expect(fetchMock.mock.calls[0][0]).toBe(url);
   });
 
@@ -177,7 +174,7 @@ describe('TelemetryClient — options', () => {
       });
     });
     const start  = Date.now();
-    const result = await postBatch(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 30 });
+    const result = await postEvent(ENDPOINT, ENVELOPE, { fetch: fetchMock, timeoutMs: 30 });
     const elapsed = Date.now() - start;
     expect(result).toEqual({ ok: false, kind: 'network' });
     expect(elapsed).toBeLessThan(500);

--- a/src/telemetry/TelemetryClient.ts
+++ b/src/telemetry/TelemetryClient.ts
@@ -1,0 +1,97 @@
+import { POSTHOG_LIB_VERSION } from './TelemetryBatcher.js';
+import type { PostHogBatchEnvelope } from './types.js';
+
+export const DEFAULT_POSTHOG_ENDPOINT = 'https://us.i.posthog.com/capture/';
+export const DEFAULT_TIMEOUT_MS       = 10_000;
+
+export type FetchLike = (input: string, init: {
+  method:  string;
+  headers: Record<string, string>;
+  body:    string;
+  signal:  AbortSignal;
+}) => Promise<{
+  ok:      boolean;
+  status:  number;
+  headers: { get(name: string): string | null };
+}>;
+
+export interface ClientOptions {
+  fetch?:     FetchLike;
+  timeoutMs?: number;
+}
+
+export interface SuccessResult {
+  ok:            true;
+  status:        number;
+  acceptedCount: number;
+}
+
+export interface NetworkErrorResult {
+  ok:   false;
+  kind: 'network';
+}
+
+export interface HttpErrorResult {
+  ok:                 false;
+  kind:               'http';
+  status:             number;
+  retryAfterSeconds?: number;
+}
+
+export type SendResult = SuccessResult | NetworkErrorResult | HttpErrorResult;
+
+export async function postBatch(
+  url:      string,
+  envelope: PostHogBatchEnvelope,
+  opts:     ClientOptions = {},
+): Promise<SendResult> {
+  const fetchImpl = opts.fetch     ?? (globalThis.fetch as unknown as FetchLike);
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  const timer      = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(url, {
+      method:  'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent':   `nexpath/${POSTHOG_LIB_VERSION}`,
+      },
+      body:    JSON.stringify(envelope),
+      signal:  controller.signal,
+    });
+
+    if (res.ok) {
+      return { ok: true, status: res.status, acceptedCount: envelope.batch.length };
+    }
+
+    if (res.status === 429) {
+      const retryAfterSeconds = parseRetryAfter(res.headers.get('Retry-After'));
+      const out: HttpErrorResult = { ok: false, kind: 'http', status: 429 };
+      if (retryAfterSeconds !== undefined) out.retryAfterSeconds = retryAfterSeconds;
+      return out;
+    }
+
+    return { ok: false, kind: 'http', status: res.status };
+  } catch {
+    return { ok: false, kind: 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function parseRetryAfter(header: string | null, now: () => number = Date.now): number | undefined {
+  if (header === null || header.trim() === '') return undefined;
+  const trimmed = header.trim();
+
+  const asNumber = Number(trimmed);
+  if (Number.isFinite(asNumber) && asNumber >= 0) return Math.floor(asNumber);
+
+  const asDate = new Date(trimmed).getTime();
+  if (Number.isFinite(asDate)) {
+    return Math.max(0, Math.floor((asDate - now()) / 1000));
+  }
+
+  return undefined;
+}

--- a/src/telemetry/TelemetryClient.ts
+++ b/src/telemetry/TelemetryClient.ts
@@ -1,5 +1,5 @@
 import { POSTHOG_LIB_VERSION } from './TelemetryBatcher.js';
-import type { PostHogBatchEnvelope } from './types.js';
+import type { PostHogSingleEnvelope } from './types.js';
 
 export const DEFAULT_POSTHOG_ENDPOINT = 'https://us.i.posthog.com/capture/';
 export const DEFAULT_TIMEOUT_MS       = 10_000;
@@ -23,7 +23,7 @@ export interface ClientOptions {
 export interface SuccessResult {
   ok:            true;
   status:        number;
-  acceptedCount: number;
+  acceptedCount: 1;
 }
 
 export interface NetworkErrorResult {
@@ -40,9 +40,9 @@ export interface HttpErrorResult {
 
 export type SendResult = SuccessResult | NetworkErrorResult | HttpErrorResult;
 
-export async function postBatch(
+export async function postEvent(
   url:      string,
-  envelope: PostHogBatchEnvelope,
+  envelope: PostHogSingleEnvelope,
   opts:     ClientOptions = {},
 ): Promise<SendResult> {
   const fetchImpl = opts.fetch     ?? (globalThis.fetch as unknown as FetchLike);
@@ -63,7 +63,7 @@ export async function postBatch(
     });
 
     if (res.ok) {
-      return { ok: true, status: res.status, acceptedCount: envelope.batch.length };
+      return { ok: true, status: res.status, acceptedCount: 1 };
     }
 
     if (res.status === 429) {

--- a/src/telemetry/TelemetryCursor.test.ts
+++ b/src/telemetry/TelemetryCursor.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadCursor, saveCursor, clearCursor } from './TelemetryCursor.js';
+import type { CursorState } from './types.js';
+
+let tmpDir: string;
+let cursorPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'nexpath-cursor-'));
+  cursorPath = join(tmpDir, 'cursor.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('TelemetryCursor — loadCursor', () => {
+  it('returns null when cursor file does not exist (clean state)', () => {
+    expect(loadCursor(cursorPath)).toBeNull();
+  });
+
+  it('returns cursor state when valid file exists', () => {
+    const state: CursorState = { inode: 12345, offset: 67890, last_synced_ts: '2026-05-19T10:00:00.000Z' };
+    writeFileSync(cursorPath, JSON.stringify(state), 'utf8');
+    expect(loadCursor(cursorPath)).toEqual(state);
+  });
+
+  it('returns null when cursor file is corrupt JSON', () => {
+    writeFileSync(cursorPath, 'not-json-{}{', 'utf8');
+    expect(loadCursor(cursorPath)).toBeNull();
+  });
+
+  it('returns null when cursor file is missing required fields', () => {
+    writeFileSync(cursorPath, JSON.stringify({ last_synced_ts: null }), 'utf8');
+    expect(loadCursor(cursorPath)).toBeNull();
+  });
+
+  it('normalises missing last_synced_ts to null', () => {
+    writeFileSync(cursorPath, JSON.stringify({ inode: 1, offset: 2 }), 'utf8');
+    expect(loadCursor(cursorPath)).toEqual({ inode: 1, offset: 2, last_synced_ts: null });
+  });
+});
+
+describe('TelemetryCursor — saveCursor', () => {
+  it('writes valid cursor state to disk', () => {
+    const state: CursorState = { inode: 1, offset: 2, last_synced_ts: '2026-05-19T10:00:00.000Z' };
+    saveCursor(state, cursorPath);
+    expect(existsSync(cursorPath)).toBe(true);
+    const reloaded = JSON.parse(readFileSync(cursorPath, 'utf8'));
+    expect(reloaded).toEqual(state);
+  });
+
+  it('creates parent directory if missing', () => {
+    const nestedPath = join(tmpDir, 'sub', 'dir', 'cursor.json');
+    saveCursor({ inode: 1, offset: 0, last_synced_ts: null }, nestedPath);
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+
+  it('persists across simulated restart — save → load returns identical state', () => {
+    const state: CursorState = { inode: 99, offset: 1024, last_synced_ts: '2026-05-19T11:30:00.000Z' };
+    saveCursor(state, cursorPath);
+    expect(loadCursor(cursorPath)).toEqual(state);
+  });
+
+  it('does not throw when write fails (read-only dir)', () => {
+    const bogusPath = '/nonexistent/readonly/cursor.json';
+    expect(() => saveCursor({ inode: 1, offset: 0, last_synced_ts: null }, bogusPath)).not.toThrow();
+  });
+});
+
+describe('TelemetryCursor — clearCursor', () => {
+  it('removes existing cursor file', () => {
+    writeFileSync(cursorPath, JSON.stringify({ inode: 1, offset: 2, last_synced_ts: null }), 'utf8');
+    clearCursor(cursorPath);
+    expect(existsSync(cursorPath)).toBe(false);
+  });
+
+  it('is silent when cursor file does not exist', () => {
+    expect(() => clearCursor(cursorPath)).not.toThrow();
+  });
+});

--- a/src/telemetry/TelemetryCursor.test.ts
+++ b/src/telemetry/TelemetryCursor.test.ts
@@ -38,6 +38,11 @@ describe('TelemetryCursor — loadCursor', () => {
     expect(loadCursor(cursorPath)).toBeNull();
   });
 
+  it('returns null when inode is a non-numeric type', () => {
+    writeFileSync(cursorPath, JSON.stringify({ inode: 'abc', offset: 0, last_synced_ts: null }), 'utf8');
+    expect(loadCursor(cursorPath)).toBeNull();
+  });
+
   it('normalises missing last_synced_ts to null', () => {
     writeFileSync(cursorPath, JSON.stringify({ inode: 1, offset: 2 }), 'utf8');
     expect(loadCursor(cursorPath)).toEqual({ inode: 1, offset: 2, last_synced_ts: null });

--- a/src/telemetry/TelemetryCursor.ts
+++ b/src/telemetry/TelemetryCursor.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { TELEMETRY_SYNC_CURSOR_PATH } from './paths.js';
+import type { CursorState } from './types.js';
+
+export function loadCursor(cursorPath: string = TELEMETRY_SYNC_CURSOR_PATH): CursorState | null {
+  try {
+    if (!existsSync(cursorPath)) return null;
+    const raw = readFileSync(cursorPath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<CursorState>;
+    if (typeof parsed.inode !== 'number' || typeof parsed.offset !== 'number') return null;
+    return {
+      inode:          parsed.inode,
+      offset:         parsed.offset,
+      last_synced_ts: typeof parsed.last_synced_ts === 'string' ? parsed.last_synced_ts : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveCursor(state: CursorState, cursorPath: string = TELEMETRY_SYNC_CURSOR_PATH): void {
+  try {
+    mkdirSync(dirname(cursorPath), { recursive: true });
+    writeFileSync(cursorPath, JSON.stringify(state, null, 2), 'utf8');
+  } catch {
+    // Never throw — sync must not crash the host process.
+  }
+}
+
+export function clearCursor(cursorPath: string = TELEMETRY_SYNC_CURSOR_PATH): void {
+  try {
+    if (existsSync(cursorPath)) rmSync(cursorPath);
+  } catch {
+    // silent
+  }
+}

--- a/src/telemetry/TelemetryReader.test.ts
+++ b/src/telemetry/TelemetryReader.test.ts
@@ -174,12 +174,42 @@ describe('TelemetryReader — defensive behavior', () => {
     expect(result.events.map(e => e.event)).toEqual(['prompt_received', 'prompt_classified']);
   });
 
+  it('skips blank and whitespace-only lines between valid events', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    appendFileSync(livePath, '\n   \n\t\n', 'utf8');
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events.map(e => e.event)).toEqual(['prompt_received', 'prompt_classified']);
+  });
+
   it('returns empty events when there is no complete line yet (only a partial)', () => {
     appendFileSync(livePath, '{"ts":"2026-05-19T10:00:00.000Z","v":1', 'utf8');
 
     const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
     expect(result.events).toEqual([]);
     expect(result.newOffset).toBe(0);
+  });
+});
+
+describe('TelemetryReader — documented limitations', () => {
+  it('first run does NOT drain pre-existing .1 (no cursor anchor to scope the range)', () => {
+    writeLine(rotPath, sampleEvent('prompt_received', { source: 'rotated_file' }));
+    writeLine(livePath, sampleEvent('prompt_classified', { source: 'live_file' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].source).toBe('live_file');
+  });
+
+  it('cursor with inode 0 (uninitialised) is treated as rotation', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    saveCursor({ inode: 0, offset: 0, last_synced_ts: null }, cursorPath);
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.rotated).toBe(true);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].event).toBe('prompt_received');
   });
 });
 

--- a/src/telemetry/TelemetryReader.test.ts
+++ b/src/telemetry/TelemetryReader.test.ts
@@ -213,6 +213,29 @@ describe('TelemetryReader — documented limitations', () => {
   });
 });
 
+describe('TelemetryReader — rotation stress (200 events across .jsonl.1 + live)', () => {
+  it('reads all 200 events in order across a rotation boundary; cursor advances to end of new live file', () => {
+    for (let i = 0; i < 80; i++) writeLine(rotPath, sampleEvent('prompt_received', { source: 'rotated', i }));
+    const rotInode = statSync(rotPath).ino;
+
+    for (let i = 0; i < 120; i++) writeLine(livePath, sampleEvent('prompt_received', { source: 'live', i }));
+
+    saveCursor({ inode: rotInode, offset: 0, last_synced_ts: null }, cursorPath);
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+
+    expect(result.rotated).toBe(true);
+    expect(result.events).toHaveLength(200);
+    expect(result.events.slice(0, 80).every(e => e.source === 'rotated')).toBe(true);
+    expect(result.events.slice(80).every(e => e.source === 'live')).toBe(true);
+    expect(result.events[79].i).toBe(79);
+    expect(result.events[80].i).toBe(0);
+    expect(result.events[199].i).toBe(119);
+    expect(result.newOffset).toBe(statSync(livePath).size);
+    expect(result.newInode).toBe(statSync(livePath).ino);
+  });
+});
+
 describe('TelemetryReader — eventByteEnds field', () => {
   it('returns empty eventByteEnds when no events read', () => {
     const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });

--- a/src/telemetry/TelemetryReader.test.ts
+++ b/src/telemetry/TelemetryReader.test.ts
@@ -213,6 +213,38 @@ describe('TelemetryReader — documented limitations', () => {
   });
 });
 
+describe('TelemetryReader — eventByteEnds field', () => {
+  it('returns empty eventByteEnds when no events read', () => {
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.eventByteEnds).toEqual([]);
+  });
+
+  it('eventByteEnds[i] points to the byte right after the i-th event (including trailing newline)', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.eventByteEnds).toHaveLength(2);
+    expect(result.eventByteEnds[0]).toBeGreaterThan(0);
+    expect(result.eventByteEnds[1]).toBe(statSync(livePath).size);
+    expect(result.eventByteEnds[0]).toBeLessThan(result.eventByteEnds[1]);
+  });
+
+  it('rotation: drained events have eventByteEnds=0 (start of new live file)', () => {
+    writeLine(rotPath, sampleEvent('prompt_received',   { source: 'rotated' }));
+    const drainedInode = statSync(rotPath).ino;
+    writeLine(livePath, sampleEvent('prompt_classified', { source: 'live' }));
+
+    saveCursor({ inode: drainedInode, offset: 0, last_synced_ts: null }, cursorPath);
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.rotated).toBe(true);
+    expect(result.events.map(e => e.source)).toEqual(['rotated', 'live']);
+    expect(result.eventByteEnds[0]).toBe(0);
+    expect(result.eventByteEnds[1]).toBe(statSync(livePath).size);
+  });
+});
+
 describe('TelemetryReader — round-trip with cursor save', () => {
   it('after advancing cursor, second read returns only newly-appended events', () => {
     writeLine(livePath, sampleEvent('prompt_received', { promptCount: 1 }));

--- a/src/telemetry/TelemetryReader.test.ts
+++ b/src/telemetry/TelemetryReader.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, statSync, renameSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readNewEvents } from './TelemetryReader.js';
+import { saveCursor } from './TelemetryCursor.js';
+
+let tmpDir: string;
+let livePath: string;
+let rotPath: string;
+let cursorPath: string;
+
+function writeLine(path: string, obj: Record<string, unknown>): void {
+  appendFileSync(path, JSON.stringify(obj) + '\n', 'utf8');
+}
+
+function sampleEvent(name: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ts: '2026-05-19T10:00:00.000Z',
+    v: 1,
+    projectRoot: '/tmp/proj',
+    event: name,
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'nexpath-reader-'));
+  livePath = join(tmpDir, 'telemetry.jsonl');
+  rotPath = `${livePath}.1`;
+  cursorPath = join(tmpDir, 'cursor.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('TelemetryReader — file does not exist', () => {
+  it('returns empty result when telemetry file is missing', () => {
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toEqual([]);
+    expect(result.newOffset).toBe(0);
+    expect(result.rotated).toBe(false);
+  });
+});
+
+describe('TelemetryReader — first run (no cursor)', () => {
+  it('reads all events from the start when cursor is missing', () => {
+    writeLine(livePath, sampleEvent('prompt_received', { promptCount: 1 }));
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0].event).toBe('prompt_received');
+    expect(result.events[1].event).toBe('prompt_classified');
+    expect(result.newOffset).toBe(statSync(livePath).size);
+    expect(result.rotated).toBe(false);
+  });
+
+  it('returns empty events when file exists but is empty', () => {
+    writeFileSync(livePath, '', 'utf8');
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toEqual([]);
+    expect(result.newOffset).toBe(0);
+  });
+});
+
+describe('TelemetryReader — cursor advances incrementally', () => {
+  it('reads only new events appended after the previous offset', () => {
+    writeLine(livePath, sampleEvent('prompt_received', { promptCount: 1 }));
+    const firstSize = statSync(livePath).size;
+    const inode = statSync(livePath).ino;
+
+    saveCursor({ inode, offset: firstSize, last_synced_ts: null }, cursorPath);
+
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+    writeLine(livePath, sampleEvent('profile_computed', { profile: 'cool_geek' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toHaveLength(2);
+    expect(result.events.map(e => e.event)).toEqual(['prompt_classified', 'profile_computed']);
+    expect(result.newOffset).toBe(statSync(livePath).size);
+    expect(result.rotated).toBe(false);
+  });
+
+  it('returns empty events when no new bytes since last cursor', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    const size = statSync(livePath).size;
+    const inode = statSync(livePath).ino;
+    saveCursor({ inode, offset: size, last_synced_ts: null }, cursorPath);
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toEqual([]);
+    expect(result.newOffset).toBe(size);
+  });
+});
+
+describe('TelemetryReader — rotation handling', () => {
+  it('drains .1 first then reads new live file when inode differs', () => {
+    writeLine(livePath, sampleEvent('prompt_received', { promptCount: 1 }));
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+    const oldStat = statSync(livePath);
+
+    saveCursor(
+      { inode: oldStat.ino, offset: oldStat.size, last_synced_ts: null },
+      cursorPath,
+    );
+
+    writeLine(livePath, sampleEvent('profile_computed', { profile: 'hardcore_pro' }));
+    const afterRotSize = statSync(livePath).size;
+    renameSync(livePath, rotPath);
+
+    writeLine(livePath, sampleEvent('absence_flags_detected', { flagType: 'missing_tests' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+
+    expect(result.rotated).toBe(true);
+    expect(result.events.map(e => e.event)).toEqual([
+      'profile_computed',
+      'absence_flags_detected',
+    ]);
+    expect(result.newOffset).toBe(statSync(livePath).size);
+    expect(result.newInode).toBe(statSync(livePath).ino);
+    expect(afterRotSize).toBeGreaterThan(oldStat.size);
+  });
+
+  it('handles rotation when .1 does not exist (only reads new live file)', () => {
+    saveCursor(
+      { inode: 999999, offset: 100, last_synced_ts: null },
+      cursorPath,
+    );
+
+    writeLine(livePath, sampleEvent('prompt_received'));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.rotated).toBe(true);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].event).toBe('prompt_received');
+  });
+});
+
+describe('TelemetryReader — defensive behavior', () => {
+  it('handles truncation: live size < cursor offset → reads from 0', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    const inode = statSync(livePath).ino;
+
+    saveCursor(
+      { inode, offset: 1_000_000, last_synced_ts: null },
+      cursorPath,
+    );
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].event).toBe('prompt_received');
+  });
+
+  it('does not advance past a partial (mid-write) trailing line', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    appendFileSync(livePath, '{"ts":"2026-05-19T10:00:00.000Z","v":1,"projectRoot":"/tmp","event":"prompt_class', 'utf8');
+    const truncatedSize = statSync(livePath).size;
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].event).toBe('prompt_received');
+    expect(result.newOffset).toBeLessThan(truncatedSize);
+  });
+
+  it('drops malformed JSON lines but keeps valid ones', () => {
+    writeLine(livePath, sampleEvent('prompt_received'));
+    appendFileSync(livePath, 'this-is-not-json{}{\n', 'utf8');
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events.map(e => e.event)).toEqual(['prompt_received', 'prompt_classified']);
+  });
+
+  it('returns empty events when there is no complete line yet (only a partial)', () => {
+    appendFileSync(livePath, '{"ts":"2026-05-19T10:00:00.000Z","v":1', 'utf8');
+
+    const result = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(result.events).toEqual([]);
+    expect(result.newOffset).toBe(0);
+  });
+});
+
+describe('TelemetryReader — round-trip with cursor save', () => {
+  it('after advancing cursor, second read returns only newly-appended events', () => {
+    writeLine(livePath, sampleEvent('prompt_received', { promptCount: 1 }));
+    writeLine(livePath, sampleEvent('prompt_classified', { stage: 'planning' }));
+
+    const first = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(first.events).toHaveLength(2);
+
+    saveCursor(
+      { inode: first.newInode, offset: first.newOffset, last_synced_ts: '2026-05-19T10:00:00.000Z' },
+      cursorPath,
+    );
+
+    writeLine(livePath, sampleEvent('profile_computed', { profile: 'cool_geek' }));
+
+    const second = readNewEvents({ liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath });
+    expect(second.events).toHaveLength(1);
+    expect(second.events[0].event).toBe('profile_computed');
+  });
+});

--- a/src/telemetry/TelemetryReader.ts
+++ b/src/telemetry/TelemetryReader.ts
@@ -11,13 +11,14 @@ export interface ReadOptions {
 }
 
 export interface ReadResult {
-  events:    TelemetryEvent[];
-  newOffset: number;
-  newInode:  number;
-  rotated:   boolean;
+  events:        TelemetryEvent[];
+  eventByteEnds: number[];
+  newOffset:     number;
+  newInode:      number;
+  rotated:       boolean;
 }
 
-const EMPTY_RESULT: ReadResult = { events: [], newOffset: 0, newInode: 0, rotated: false };
+const EMPTY_RESULT: ReadResult = { events: [], eventByteEnds: [], newOffset: 0, newInode: 0, rotated: false };
 
 export function readNewEvents(opts: ReadOptions = {}): ReadResult {
   const livePath = opts.liveLogPath ?? TELEMETRY_PATH;
@@ -51,19 +52,23 @@ function readAcrossRotation(
   liveInode: number,
   liveSize:  number,
 ): ReadResult {
-  const events: TelemetryEvent[] = [];
+  const events:        TelemetryEvent[] = [];
+  const eventByteEnds: number[]         = [];
 
   const rotStat = safeStat(rotPath);
   if (rotStat && rotStat.ino === cursor.inode && rotStat.size > cursor.offset) {
     const drained = readAndParse(rotPath, cursor.offset, rotStat.size);
     events.push(...drained.events);
+    for (let i = 0; i < drained.events.length; i++) eventByteEnds.push(0);
   }
 
   const liveTail = readAndParse(livePath, 0, liveSize);
   events.push(...liveTail.events);
+  eventByteEnds.push(...liveTail.eventByteEnds);
 
   return {
     events,
+    eventByteEnds,
     newOffset: liveTail.consumedTo,
     newInode:  liveInode,
     rotated:   true,
@@ -78,13 +83,14 @@ function readForward(
   rotated: boolean,
 ): ReadResult {
   if (end <= start) {
-    return { events: [], newOffset: start, newInode: inode, rotated };
+    return { events: [], eventByteEnds: [], newOffset: start, newInode: inode, rotated };
   }
   const result = readAndParse(path, start, end);
   return {
-    events:    result.events,
-    newOffset: result.consumedTo,
-    newInode:  inode,
+    events:        result.events,
+    eventByteEnds: result.eventByteEnds,
+    newOffset:     result.consumedTo,
+    newInode:      inode,
     rotated,
   };
 }
@@ -99,12 +105,13 @@ function safeStat(path: string): { ino: number; size: number } | null {
 }
 
 interface ParseResult {
-  events:     TelemetryEvent[];
-  consumedTo: number;
+  events:        TelemetryEvent[];
+  eventByteEnds: number[];
+  consumedTo:    number;
 }
 
 function readAndParse(path: string, start: number, end: number): ParseResult {
-  if (end <= start) return { events: [], consumedTo: start };
+  if (end <= start) return { events: [], eventByteEnds: [], consumedTo: start };
 
   let data = '';
   try {
@@ -117,23 +124,33 @@ function readAndParse(path: string, start: number, end: number): ParseResult {
       closeSync(fd);
     }
   } catch {
-    return { events: [], consumedTo: start };
+    return { events: [], eventByteEnds: [], consumedTo: start };
   }
 
   const lastNewline = data.lastIndexOf('\n');
   if (lastNewline === -1) {
-    return { events: [], consumedTo: start };
+    return { events: [], eventByteEnds: [], consumedTo: start };
   }
 
   const completeData = data.slice(0, lastNewline + 1);
   const consumedBytes = Buffer.byteLength(completeData, 'utf8');
 
-  const events: TelemetryEvent[] = [];
-  for (const line of completeData.split('\n')) {
+  const events:        TelemetryEvent[] = [];
+  const eventByteEnds: number[]         = [];
+
+  let cumulativeBytes = 0;
+  const lines = completeData.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line     = lines[i];
+    const isLast   = i === lines.length - 1;
+    const lineBytes = Buffer.byteLength(line, 'utf8') + (isLast ? 0 : 1);
+    cumulativeBytes += lineBytes;
+
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
       events.push(JSON.parse(trimmed) as TelemetryEvent);
+      eventByteEnds.push(start + cumulativeBytes);
     } catch {
       try {
         logger.debug('telemetry_reader_malformed_line', { sample: trimmed.slice(0, 80) });
@@ -143,5 +160,5 @@ function readAndParse(path: string, start: number, end: number): ParseResult {
     }
   }
 
-  return { events, consumedTo: start + consumedBytes };
+  return { events, eventByteEnds, consumedTo: start + consumedBytes };
 }

--- a/src/telemetry/TelemetryReader.ts
+++ b/src/telemetry/TelemetryReader.ts
@@ -1,0 +1,147 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs';
+import { logger } from '../logger.js';
+import { TELEMETRY_PATH, TELEMETRY_ROTATED_PATH } from './paths.js';
+import { loadCursor } from './TelemetryCursor.js';
+import type { CursorState, TelemetryEvent } from './types.js';
+
+export interface ReadOptions {
+  liveLogPath?:    string;
+  rotatedLogPath?: string;
+  cursorPath?:     string;
+}
+
+export interface ReadResult {
+  events:    TelemetryEvent[];
+  newOffset: number;
+  newInode:  number;
+  rotated:   boolean;
+}
+
+const EMPTY_RESULT: ReadResult = { events: [], newOffset: 0, newInode: 0, rotated: false };
+
+export function readNewEvents(opts: ReadOptions = {}): ReadResult {
+  const livePath = opts.liveLogPath ?? TELEMETRY_PATH;
+  const rotPath  = opts.rotatedLogPath ?? TELEMETRY_ROTATED_PATH;
+
+  const liveStat = safeStat(livePath);
+  if (!liveStat) return EMPTY_RESULT;
+
+  const cursor = loadCursor(opts.cursorPath);
+
+  if (cursor === null) {
+    return readWholeFile(livePath, liveStat.ino, liveStat.size);
+  }
+
+  if (cursor.inode !== liveStat.ino) {
+    return readAcrossRotation(cursor, rotPath, livePath, liveStat.ino, liveStat.size);
+  }
+
+  const startOffset = liveStat.size < cursor.offset ? 0 : cursor.offset;
+  return readForward(livePath, startOffset, liveStat.size, liveStat.ino, false);
+}
+
+function readWholeFile(path: string, inode: number, size: number): ReadResult {
+  return readForward(path, 0, size, inode, false);
+}
+
+function readAcrossRotation(
+  cursor:   CursorState,
+  rotPath:  string,
+  livePath: string,
+  liveInode: number,
+  liveSize:  number,
+): ReadResult {
+  const events: TelemetryEvent[] = [];
+
+  const rotStat = safeStat(rotPath);
+  if (rotStat && rotStat.ino === cursor.inode && rotStat.size > cursor.offset) {
+    const drained = readAndParse(rotPath, cursor.offset, rotStat.size);
+    events.push(...drained.events);
+  }
+
+  const liveTail = readAndParse(livePath, 0, liveSize);
+  events.push(...liveTail.events);
+
+  return {
+    events,
+    newOffset: liveTail.consumedTo,
+    newInode:  liveInode,
+    rotated:   true,
+  };
+}
+
+function readForward(
+  path:    string,
+  start:   number,
+  end:     number,
+  inode:   number,
+  rotated: boolean,
+): ReadResult {
+  if (end <= start) {
+    return { events: [], newOffset: start, newInode: inode, rotated };
+  }
+  const result = readAndParse(path, start, end);
+  return {
+    events:    result.events,
+    newOffset: result.consumedTo,
+    newInode:  inode,
+    rotated,
+  };
+}
+
+function safeStat(path: string): { ino: number; size: number } | null {
+  try {
+    const s = statSync(path);
+    return { ino: s.ino, size: s.size };
+  } catch {
+    return null;
+  }
+}
+
+interface ParseResult {
+  events:     TelemetryEvent[];
+  consumedTo: number;
+}
+
+function readAndParse(path: string, start: number, end: number): ParseResult {
+  if (end <= start) return { events: [], consumedTo: start };
+
+  let data = '';
+  try {
+    const fd = openSync(path, 'r');
+    try {
+      const buf = Buffer.alloc(end - start);
+      readSync(fd, buf, 0, end - start, start);
+      data = buf.toString('utf8');
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return { events: [], consumedTo: start };
+  }
+
+  const lastNewline = data.lastIndexOf('\n');
+  if (lastNewline === -1) {
+    return { events: [], consumedTo: start };
+  }
+
+  const completeData = data.slice(0, lastNewline + 1);
+  const consumedBytes = Buffer.byteLength(completeData, 'utf8');
+
+  const events: TelemetryEvent[] = [];
+  for (const line of completeData.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as TelemetryEvent);
+    } catch {
+      try {
+        logger.debug('telemetry_reader_malformed_line', { sample: trimmed.slice(0, 80) });
+      } catch {
+        // logger may be uninitialised in some contexts — never crash
+      }
+    }
+  }
+
+  return { events, consumedTo: start + consumedBytes };
+}

--- a/src/telemetry/TelemetrySync.e2e.test.ts
+++ b/src/telemetry/TelemetrySync.e2e.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { postBatch, DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
+import { partitionEvents, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION } from './TelemetryBatcher.js';
+import type { PostHogBatchEnvelope, TelemetryEvent } from './types.js';
+
+const E2E_TOKEN    = process.env.E2E_POSTHOG_TOKEN;
+const E2E_ENDPOINT = process.env.E2E_POSTHOG_ENDPOINT ?? DEFAULT_POSTHOG_ENDPOINT;
+
+const runE2E = E2E_TOKEN !== undefined && E2E_TOKEN.length > 0;
+
+describe.skipIf(!runE2E)('end-to-end against live PostHog /capture/ (gated by E2E_POSTHOG_TOKEN)', () => {
+  it('sends a minimal ping envelope and receives 200', async () => {
+    const envelope: PostHogBatchEnvelope = {
+      api_key: E2E_TOKEN!,
+      batch: [{
+        event:       'nexpath_e2e_ping',
+        distinct_id: `nexpath-e2e-${Date.now()}`,
+        timestamp:   new Date().toISOString(),
+        properties:  {
+          $lib:         POSTHOG_LIB_NAME,
+          $lib_version: POSTHOG_LIB_VERSION,
+          test_run:     true,
+        },
+      }],
+    };
+    const result = await postBatch(E2E_ENDPOINT, envelope);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.acceptedCount).toBe(1);
+  }, 15_000);
+
+  it('sends a real partitioned batch produced by partitionEvents and receives 200', async () => {
+    const events: TelemetryEvent[] = Array.from({ length: 3 }, (_, i) => ({
+      ts:             new Date().toISOString(),
+      v:              1,
+      installationId: `e2e-install-${Date.now()}`,
+      userId:         `e2e-user-${Date.now()}`,
+      teamId:         `e2e-team-${Date.now()}`,
+      projectRoot:    `/tmp/nexpath-e2e/${i}`,
+      event:          'prompt_received',
+      promptCount:    i + 1,
+    }));
+
+    const { batches, consumedCount } = partitionEvents(events, {
+      apiKey:           E2E_TOKEN!,
+      hashProjectRoot:  true,
+    });
+    expect(batches).toHaveLength(1);
+    expect(consumedCount).toBe(3);
+
+    const result = await postBatch(E2E_ENDPOINT, batches[0]);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.acceptedCount).toBe(3);
+  }, 15_000);
+});

--- a/src/telemetry/TelemetrySync.e2e.test.ts
+++ b/src/telemetry/TelemetrySync.e2e.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { postBatch, DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
-import { partitionEvents, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION } from './TelemetryBatcher.js';
-import type { PostHogBatchEnvelope, TelemetryEvent } from './types.js';
+import { postEvent, DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
+import { buildEnvelopes, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION } from './TelemetryBatcher.js';
+import type { PostHogSingleEnvelope, TelemetryEvent } from './types.js';
 
 const E2E_TOKEN    = process.env.E2E_POSTHOG_TOKEN;
 const E2E_ENDPOINT = process.env.E2E_POSTHOG_ENDPOINT ?? DEFAULT_POSTHOG_ENDPOINT;
@@ -9,26 +9,24 @@ const E2E_ENDPOINT = process.env.E2E_POSTHOG_ENDPOINT ?? DEFAULT_POSTHOG_ENDPOIN
 const runE2E = E2E_TOKEN !== undefined && E2E_TOKEN.length > 0;
 
 describe.skipIf(!runE2E)('end-to-end against live PostHog /capture/ (gated by E2E_POSTHOG_TOKEN)', () => {
-  it('sends a minimal ping envelope and receives 200', async () => {
-    const envelope: PostHogBatchEnvelope = {
-      api_key: E2E_TOKEN!,
-      batch: [{
-        event:       'nexpath_e2e_ping',
-        distinct_id: `nexpath-e2e-${Date.now()}`,
-        timestamp:   new Date().toISOString(),
-        properties:  {
-          $lib:         POSTHOG_LIB_NAME,
-          $lib_version: POSTHOG_LIB_VERSION,
-          test_run:     true,
-        },
-      }],
+  it('sends a minimal single-event ping envelope and receives 200', async () => {
+    const envelope: PostHogSingleEnvelope = {
+      api_key:     E2E_TOKEN!,
+      event:       'nexpath_e2e_ping',
+      distinct_id: `nexpath-e2e-${Date.now()}`,
+      timestamp:   new Date().toISOString(),
+      properties:  {
+        $lib:         POSTHOG_LIB_NAME,
+        $lib_version: POSTHOG_LIB_VERSION,
+        test_run:     true,
+      },
     };
-    const result = await postBatch(E2E_ENDPOINT, envelope);
+    const result = await postEvent(E2E_ENDPOINT, envelope);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.acceptedCount).toBe(1);
   }, 15_000);
 
-  it('sends a real partitioned batch produced by partitionEvents and receives 200', async () => {
+  it('sends 3 single-event envelopes built by buildEnvelopes and each receives 200', async () => {
     const events: TelemetryEvent[] = Array.from({ length: 3 }, (_, i) => ({
       ts:             new Date().toISOString(),
       v:              1,
@@ -40,15 +38,17 @@ describe.skipIf(!runE2E)('end-to-end against live PostHog /capture/ (gated by E2
       promptCount:    i + 1,
     }));
 
-    const { batches, consumedCount } = partitionEvents(events, {
+    const { envelopes, consumedCount } = buildEnvelopes(events, {
       apiKey:           E2E_TOKEN!,
       hashProjectRoot:  true,
     });
-    expect(batches).toHaveLength(1);
+    expect(envelopes).toHaveLength(3);
     expect(consumedCount).toBe(3);
 
-    const result = await postBatch(E2E_ENDPOINT, batches[0]);
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.acceptedCount).toBe(3);
-  }, 15_000);
+    for (const env of envelopes) {
+      const result = await postEvent(E2E_ENDPOINT, env);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.acceptedCount).toBe(1);
+    }
+  }, 30_000);
 });

--- a/src/telemetry/TelemetrySyncRunner.test.ts
+++ b/src/telemetry/TelemetrySyncRunner.test.ts
@@ -302,6 +302,86 @@ describe('TelemetrySyncRunner — endpoint and auth', () => {
   });
 });
 
+describe('TelemetrySyncRunner — empty-batches edge case (all events lack installationId)', () => {
+  it('returns noop, advances cursor past all events, and does not call fetch', async () => {
+    const noIdEvent = {
+      ts: '2026-05-19T10:00:00.000Z',
+      v: 1,
+      projectRoot: '/tmp/p',
+      event: 'prompt_received',
+    };
+    appendFileSync(livePath, JSON.stringify(noIdEvent) + '\n', 'utf8');
+    appendFileSync(livePath, JSON.stringify(noIdEvent) + '\n', 'utf8');
+
+    const fetch = vi.fn<FetchLike>(async () => ({ ok: true, status: 200, headers: { get: () => null } }));
+    const emit  = vi.fn();
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+    });
+    expect(result.status).toBe('noop');
+    expect(result.sentEvents).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+    expect(loadCursor(cursorPath)?.offset).toBe(statSync(livePath).size);
+  });
+});
+
+describe('TelemetrySyncRunner — emitTelemetry payload shape', () => {
+  it('latency_ms is a finite non-negative number on success', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const emit = vi.fn();
+    await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:         mockOkFetch(),
+      emitTelemetry: emit,
+    });
+    const successCall = emit.mock.calls.find(c => c[0] === 'telemetry_sync_success');
+    expect(successCall).toBeDefined();
+    const latency = (successCall![1] as { latency_ms?: number }).latency_ms;
+    expect(typeof latency).toBe('number');
+    expect(Number.isFinite(latency)).toBe(true);
+    expect(latency).toBeGreaterThanOrEqual(0);
+  });
+
+  it('http_status is included on failure self-event matching the response status', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({ ok: false, status: 503, headers: { get: () => null } }));
+    const emit  = vi.fn();
+    await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+    });
+    const failedCall = emit.mock.calls.find(c => c[0] === 'telemetry_sync_failed');
+    expect(failedCall).toBeDefined();
+    expect((failedCall![1] as { http_status?: number }).http_status).toBe(503);
+  });
+});
+
+describe('TelemetrySyncRunner — error log format', () => {
+  it('appends one valid JSON object per line on 4xx', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({ ok: false, status: 422, headers: { get: () => null } }));
+    await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    const raw = readFileSync(errorLogPath, 'utf8').trim();
+    expect(raw.endsWith('\n') || raw.length > 0).toBe(true);
+    const lines = raw.split('\n').filter(l => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.status).toBe(422);
+    expect(typeof parsed.ts).toBe('string');
+    expect(typeof parsed.batchIndex).toBe('number');
+    expect(typeof parsed.batchSize).toBe('number');
+  });
+});
+
 describe('TelemetrySyncRunner — constants', () => {
   it('DEFAULT_FAILURE_DISABLE_THRESHOLD is 10', () => {
     expect(DEFAULT_FAILURE_DISABLE_THRESHOLD).toBe(10);

--- a/src/telemetry/TelemetrySyncRunner.test.ts
+++ b/src/telemetry/TelemetrySyncRunner.test.ts
@@ -382,6 +382,33 @@ describe('TelemetrySyncRunner — error log format', () => {
   });
 });
 
+describe('TelemetrySyncRunner — high-volume scenario (50-event scale)', () => {
+  it('sends 50 events across multiple batches, advances cursor to EOF, emits success', async () => {
+    for (let i = 0; i < 50; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
+
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+    const emit  = vi.fn();
+    const result = await runSyncAttempt({
+      apiKey:             API_KEY,
+      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+      maxEventsPerBatch:  20,
+      maxBatchesPerRun:   10,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.sentEvents).toBe(50);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(loadCursor(cursorPath)?.offset).toBe(statSync(livePath).size);
+    const attempt = emit.mock.calls.find(c => c[0] === 'telemetry_sync_attempt');
+    expect((attempt![1] as { event_count: number }).event_count).toBe(50);
+    const success = emit.mock.calls.find(c => c[0] === 'telemetry_sync_success');
+    expect((success![1] as { event_count: number }).event_count).toBe(50);
+  });
+});
+
 describe('TelemetrySyncRunner — constants', () => {
   it('DEFAULT_FAILURE_DISABLE_THRESHOLD is 10', () => {
     expect(DEFAULT_FAILURE_DISABLE_THRESHOLD).toBe(10);

--- a/src/telemetry/TelemetrySyncRunner.test.ts
+++ b/src/telemetry/TelemetrySyncRunner.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSyncAttempt, DEFAULT_FAILURE_DISABLE_THRESHOLD } from './TelemetrySyncRunner.js';
+import { saveCursor, loadCursor } from './TelemetryCursor.js';
+import type { FetchLike } from './TelemetryClient.js';
+import type { TelemetryEvent, TelemetryEventName } from './types.js';
+
+let tmpDir:       string;
+let livePath:     string;
+let rotPath:      string;
+let cursorPath:   string;
+let errorLogPath: string;
+
+beforeEach(() => {
+  tmpDir       = mkdtempSync(join(tmpdir(), 'nexpath-runner-'));
+  livePath     = join(tmpDir, 'telemetry.jsonl');
+  rotPath      = `${livePath}.1`;
+  cursorPath   = join(tmpDir, 'cursor.json');
+  errorLogPath = join(tmpDir, 'sync-errors.log');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+function writeEvent(path: string, event: TelemetryEventName, props: Record<string, unknown> = {}): void {
+  const record = {
+    ts:             '2026-05-19T10:00:00.000Z',
+    v:              1,
+    installationId: '550e8400-e29b-41d4-a716-446655440000',
+    userId:         '8a3f1c2e-5b6d-4e7f-9a2c-1d3e5f7b9c0d',
+    teamId:         'team-stub-uuid',
+    projectRoot:    '/tmp/proj',
+    event,
+    ...props,
+  };
+  appendFileSync(path, JSON.stringify(record) + '\n', 'utf8');
+}
+
+function mockOkFetch(): FetchLike {
+  return vi.fn<FetchLike>(async () => ({
+    ok:      true,
+    status:  200,
+    headers: { get: () => null },
+  }));
+}
+
+const API_KEY = 'phc_test';
+
+describe('TelemetrySyncRunner — noop paths', () => {
+  it('returns noop when no telemetry file exists', async () => {
+    const result = await runSyncAttempt({
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:       mockOkFetch(),
+    });
+    expect(result.status).toBe('noop');
+    expect(result.sentEvents).toBe(0);
+  });
+
+  it('returns noop when telemetry file has only sync self-events (feedback-loop filter)', async () => {
+    writeEvent(livePath, 'telemetry_sync_attempt');
+    writeEvent(livePath, 'telemetry_sync_success', { event_count: 5, latency_ms: 42 });
+    const result = await runSyncAttempt({
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:       mockOkFetch(),
+    });
+    expect(result.status).toBe('noop');
+    expect(result.sentEvents).toBe(0);
+    expect(loadCursor(cursorPath)?.offset).toBe(statSync(livePath).size);
+  });
+});
+
+describe('TelemetrySyncRunner — success path', () => {
+  it('sends all events, advances cursor to newOffset, emits success self-event', async () => {
+    writeEvent(livePath, 'prompt_received',   { promptCount: 1 });
+    writeEvent(livePath, 'prompt_classified', { stage: 'planning', confidence: 0.9 });
+
+    const emit  = vi.fn();
+    const fetch = mockOkFetch();
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+    });
+    expect(result.status).toBe('ok');
+    expect(result.sentEvents).toBe(2);
+    expect(loadCursor(cursorPath)?.offset).toBe(statSync(livePath).size);
+    expect(emit).toHaveBeenCalledWith('telemetry_sync_attempt',  expect.objectContaining({ event_count: 2 }));
+    expect(emit).toHaveBeenCalledWith('telemetry_sync_success',  expect.objectContaining({ event_count: 2 }));
+  });
+
+  it('resets consecutive_failures to 0 on success', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const result = await runSyncAttempt({
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:       mockOkFetch(),
+    }, 7);
+    expect(result.consecutiveFailuresAfter).toBe(0);
+  });
+
+  it('filters out sync self-events but still sends the real ones', async () => {
+    writeEvent(livePath, 'prompt_received');
+    writeEvent(livePath, 'telemetry_sync_attempt');
+    writeEvent(livePath, 'prompt_classified', { stage: 'planning' });
+
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok:      true, status: 200, headers: { get: () => null },
+    }));
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    expect(result.sentEvents).toBe(2);
+    const body = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
+    expect(body.batch).toHaveLength(2);
+    expect(body.batch.map((e: { event: string }) => e.event)).toEqual(['prompt_received', 'prompt_classified']);
+  });
+});
+
+describe('TelemetrySyncRunner — network error', () => {
+  it('returns network status, does not advance cursor, increments failures', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => { throw new Error('ECONNREFUSED'); });
+    const emit  = vi.fn();
+
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+    }, 2);
+
+    expect(result.status).toBe('network');
+    expect(result.consecutiveFailuresAfter).toBe(3);
+    expect(result.shouldDisableSync).toBe(false);
+    expect(loadCursor(cursorPath)).toBeNull();
+    expect(emit).toHaveBeenCalledWith('telemetry_sync_failed', expect.objectContaining({ reason: 'network' }));
+  });
+});
+
+describe('TelemetrySyncRunner — HTTP errors', () => {
+  it('4xx (non-429): writes to error log, sets shouldDisableSync after threshold', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 400, headers: { get: () => null },
+    }));
+
+    const result = await runSyncAttempt({
+      apiKey:                 API_KEY,
+      liveLogPath:            livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+      failureDisableThreshold: 3,
+    }, 2);
+
+    expect(result.status).toBe('http_4xx');
+    expect(result.httpStatus).toBe(400);
+    expect(result.consecutiveFailuresAfter).toBe(3);
+    expect(result.shouldDisableSync).toBe(true);
+    expect(existsSync(errorLogPath)).toBe(true);
+    expect(readFileSync(errorLogPath, 'utf8')).toContain('"status":400');
+  });
+
+  it('4xx below threshold: does NOT set shouldDisableSync', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 400, headers: { get: () => null },
+    }));
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    }, 0);
+    expect(result.consecutiveFailuresAfter).toBe(1);
+    expect(result.shouldDisableSync).toBe(false);
+  });
+
+  it('429: returns rate_limited with retryAfterSeconds', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 429, headers: { get: (h: string) => h === 'Retry-After' ? '120' : null },
+    }));
+    const emit  = vi.fn();
+    const result = await runSyncAttempt({
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch, emitTelemetry: emit,
+    });
+    expect(result.status).toBe('rate_limited');
+    expect(result.httpStatus).toBe(429);
+    expect(result.retryAfterSeconds).toBe(120);
+    expect(emit).toHaveBeenCalledWith('telemetry_sync_failed', expect.objectContaining({ reason: 'rate_limited' }));
+  });
+
+  it('5xx: returns http_5xx with status, does not write error log', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: false, status: 503, headers: { get: () => null },
+    }));
+    const result = await runSyncAttempt({
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    expect(result.status).toBe('http_5xx');
+    expect(result.httpStatus).toBe(503);
+    expect(existsSync(errorLogPath)).toBe(false);
+  });
+});
+
+describe('TelemetrySyncRunner — partial-credit cursor advance', () => {
+  it('after first batch succeeds and second fails, cursor advances by first batch only', async () => {
+    for (let i = 0; i < 5; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
+
+    let callCount = 0;
+    const fetch = vi.fn<FetchLike>(async () => {
+      callCount++;
+      if (callCount === 1) return { ok: true, status: 200, headers: { get: () => null } };
+      throw new Error('network down');
+    });
+
+    const result = await runSyncAttempt({
+      apiKey:             API_KEY,
+      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+      maxEventsPerBatch:  2,
+      maxBatchesPerRun:   10,
+    });
+
+    expect(result.status).toBe('network');
+    expect(result.sentEvents).toBe(2);
+    const cursor = loadCursor(cursorPath);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.offset).toBeGreaterThan(0);
+    expect(cursor!.offset).toBeLessThan(statSync(livePath).size);
+  });
+
+  it('cap-hit (consumedCount < events.length): cursor advances only through consumed events', async () => {
+    for (let i = 0; i < 8; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
+
+    const result = await runSyncAttempt({
+      apiKey:             API_KEY,
+      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:              mockOkFetch(),
+      maxEventsPerBatch:  2,
+      maxBatchesPerRun:   2,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.sentEvents).toBe(4);
+    const cursor = loadCursor(cursorPath);
+    expect(cursor!.offset).toBeGreaterThan(0);
+    expect(cursor!.offset).toBeLessThan(statSync(livePath).size);
+  });
+});
+
+describe('TelemetrySyncRunner — endpoint and auth', () => {
+  it('uses default PostHog endpoint when none provided', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+    await runSyncAttempt({
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    expect(fetch.mock.calls[0][0]).toBe('https://us.i.posthog.com/capture/');
+  });
+
+  it('uses custom endpoint when provided', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+    await runSyncAttempt({
+      endpoint:    'https://eu.example.com/capture/',
+      apiKey:      API_KEY,
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    expect(fetch.mock.calls[0][0]).toBe('https://eu.example.com/capture/');
+  });
+
+  it('apiKey is propagated to the request body', async () => {
+    writeEvent(livePath, 'prompt_received');
+    const fetch = vi.fn<FetchLike>(async () => ({
+      ok: true, status: 200, headers: { get: () => null },
+    }));
+    await runSyncAttempt({
+      apiKey:      'phc_xyz',
+      liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch,
+    });
+    const body = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
+    expect(body.api_key).toBe('phc_xyz');
+  });
+});
+
+describe('TelemetrySyncRunner — constants', () => {
+  it('DEFAULT_FAILURE_DISABLE_THRESHOLD is 10', () => {
+    expect(DEFAULT_FAILURE_DISABLE_THRESHOLD).toBe(10);
+  });
+});

--- a/src/telemetry/TelemetrySyncRunner.test.ts
+++ b/src/telemetry/TelemetrySyncRunner.test.ts
@@ -118,9 +118,9 @@ describe('TelemetrySyncRunner — success path', () => {
       fetch,
     });
     expect(result.sentEvents).toBe(2);
-    const body = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
-    expect(body.batch).toHaveLength(2);
-    expect(body.batch.map((e: { event: string }) => e.event)).toEqual(['prompt_received', 'prompt_classified']);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const events = fetch.mock.calls.map(c => JSON.parse((c[1] as { body: string }).body).event);
+    expect(events).toEqual(['prompt_received', 'prompt_classified']);
   });
 });
 
@@ -214,7 +214,7 @@ describe('TelemetrySyncRunner — HTTP errors', () => {
 });
 
 describe('TelemetrySyncRunner — partial-credit cursor advance', () => {
-  it('after first batch succeeds and second fails, cursor advances by first batch only', async () => {
+  it('after first event POST succeeds and second fails, cursor advances by one event only', async () => {
     for (let i = 0; i < 5; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
 
     let callCount = 0;
@@ -225,30 +225,27 @@ describe('TelemetrySyncRunner — partial-credit cursor advance', () => {
     });
 
     const result = await runSyncAttempt({
-      apiKey:             API_KEY,
-      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
       fetch,
-      maxEventsPerBatch:  2,
-      maxBatchesPerRun:   10,
     });
 
     expect(result.status).toBe('network');
-    expect(result.sentEvents).toBe(2);
+    expect(result.sentEvents).toBe(1);
     const cursor = loadCursor(cursorPath);
     expect(cursor).not.toBeNull();
     expect(cursor!.offset).toBeGreaterThan(0);
     expect(cursor!.offset).toBeLessThan(statSync(livePath).size);
   });
 
-  it('cap-hit (consumedCount < events.length): cursor advances only through consumed events', async () => {
+  it('cap-hit (maxEventsPerRun): cursor advances only through consumed events', async () => {
     for (let i = 0; i < 8; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
 
     const result = await runSyncAttempt({
-      apiKey:             API_KEY,
-      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
-      fetch:              mockOkFetch(),
-      maxEventsPerBatch:  2,
-      maxBatchesPerRun:   2,
+      apiKey:           API_KEY,
+      liveLogPath:      livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      fetch:            mockOkFetch(),
+      maxEventsPerRun:  4,
     });
 
     expect(result.status).toBe('ok');
@@ -377,13 +374,12 @@ describe('TelemetrySyncRunner — error log format', () => {
     const parsed = JSON.parse(lines[0]);
     expect(parsed.status).toBe(422);
     expect(typeof parsed.ts).toBe('string');
-    expect(typeof parsed.batchIndex).toBe('number');
-    expect(typeof parsed.batchSize).toBe('number');
+    expect(typeof parsed.eventIndex).toBe('number');
   });
 });
 
 describe('TelemetrySyncRunner — high-volume scenario (50-event scale)', () => {
-  it('sends 50 events across multiple batches, advances cursor to EOF, emits success', async () => {
+  it('sends 50 events as 50 individual POSTs, advances cursor to EOF, emits success', async () => {
     for (let i = 0; i < 50; i++) writeEvent(livePath, 'prompt_received', { promptCount: i });
 
     const fetch = vi.fn<FetchLike>(async () => ({
@@ -391,16 +387,14 @@ describe('TelemetrySyncRunner — high-volume scenario (50-event scale)', () => 
     }));
     const emit  = vi.fn();
     const result = await runSyncAttempt({
-      apiKey:             API_KEY,
-      liveLogPath:        livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
+      apiKey:        API_KEY,
+      liveLogPath:   livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath,
       fetch, emitTelemetry: emit,
-      maxEventsPerBatch:  20,
-      maxBatchesPerRun:   10,
     });
 
     expect(result.status).toBe('ok');
     expect(result.sentEvents).toBe(50);
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(50);
     expect(loadCursor(cursorPath)?.offset).toBe(statSync(livePath).size);
     const attempt = emit.mock.calls.find(c => c[0] === 'telemetry_sync_attempt');
     expect((attempt![1] as { event_count: number }).event_count).toBe(50);

--- a/src/telemetry/TelemetrySyncRunner.ts
+++ b/src/telemetry/TelemetrySyncRunner.ts
@@ -1,0 +1,229 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { readNewEvents, type ReadResult } from './TelemetryReader.js';
+import { saveCursor } from './TelemetryCursor.js';
+import { partitionEvents } from './TelemetryBatcher.js';
+import { postBatch, DEFAULT_POSTHOG_ENDPOINT, DEFAULT_TIMEOUT_MS, type FetchLike, type SendResult } from './TelemetryClient.js';
+import { TELEMETRY_SYNC_ERROR_LOG_PATH } from './paths.js';
+import type { TelemetryEvent, TelemetryEventName } from './types.js';
+
+export const DEFAULT_FAILURE_DISABLE_THRESHOLD = 10;
+
+const SYNC_SELF_EVENT_NAMES: ReadonlySet<TelemetryEventName> = new Set<TelemetryEventName>([
+  'telemetry_sync_attempt',
+  'telemetry_sync_success',
+  'telemetry_sync_failed',
+]);
+
+export type RunnerStatus =
+  | 'ok'
+  | 'noop'
+  | 'network'
+  | 'http_4xx'
+  | 'http_5xx'
+  | 'rate_limited';
+
+export interface RunnerResult {
+  status:                   RunnerStatus;
+  sentEvents:               number;
+  httpStatus?:              number;
+  retryAfterSeconds?:       number;
+  consecutiveFailuresAfter: number;
+  shouldDisableSync:        boolean;
+}
+
+export interface RunnerOptions {
+  endpoint?:                  string;
+  apiKey:                     string;
+  hashProjectRoot?:           boolean;
+  timeoutMs?:                 number;
+  maxEventsPerBatch?:         number;
+  maxBytesPerBatch?:          number;
+  maxBatchesPerRun?:          number;
+  failureDisableThreshold?:   number;
+  liveLogPath?:               string;
+  rotatedLogPath?:            string;
+  cursorPath?:                string;
+  errorLogPath?:              string;
+  fetch?:                     FetchLike;
+  now?:                       () => Date;
+  emitTelemetry?:             (event: TelemetryEventName, props: Record<string, unknown>) => void;
+  readNewEvents?:             () => ReadResult;
+}
+
+export async function runSyncAttempt(
+  opts:                       RunnerOptions,
+  consecutiveFailuresBefore:  number = 0,
+): Promise<RunnerResult> {
+  const endpoint            = opts.endpoint     ?? DEFAULT_POSTHOG_ENDPOINT;
+  const timeoutMs           = opts.timeoutMs    ?? DEFAULT_TIMEOUT_MS;
+  const errorLogPath        = opts.errorLogPath ?? TELEMETRY_SYNC_ERROR_LOG_PATH;
+  const failureThreshold    = opts.failureDisableThreshold ?? DEFAULT_FAILURE_DISABLE_THRESHOLD;
+  const now                 = opts.now ?? (() => new Date());
+  const emit                = opts.emitTelemetry ?? (() => {});
+  const reader              = opts.readNewEvents ?? (() => readNewEvents({
+    liveLogPath:    opts.liveLogPath,
+    rotatedLogPath: opts.rotatedLogPath,
+    cursorPath:     opts.cursorPath,
+  }));
+
+  const startTime = now().getTime();
+  const read      = reader();
+
+  const filteredIndices: number[] = [];
+  const filteredEvents:  TelemetryEvent[] = [];
+  for (let i = 0; i < read.events.length; i++) {
+    if (!SYNC_SELF_EVENT_NAMES.has(read.events[i].event)) {
+      filteredEvents.push(read.events[i]);
+      filteredIndices.push(i);
+    }
+  }
+
+  if (filteredEvents.length === 0) {
+    if (read.events.length > 0) {
+      saveCursor({
+        inode:          read.newInode,
+        offset:         read.newOffset,
+        last_synced_ts: new Date(startTime).toISOString(),
+      }, opts.cursorPath);
+    }
+    return {
+      status:                   'noop',
+      sentEvents:               0,
+      consecutiveFailuresAfter: consecutiveFailuresBefore,
+      shouldDisableSync:        false,
+    };
+  }
+
+  const { batches, batchEndIndices, consumedCount } = partitionEvents(filteredEvents, {
+    apiKey:             opts.apiKey,
+    hashProjectRoot:    opts.hashProjectRoot,
+    maxEventsPerBatch:  opts.maxEventsPerBatch,
+    maxBytesPerBatch:   opts.maxBytesPerBatch,
+    maxBatchesPerRun:   opts.maxBatchesPerRun,
+  });
+
+  emit('telemetry_sync_attempt', { event_count: consumedCount });
+
+  let sentEvents               = 0;
+  let lastSuccessfulBatchIndex = -1;
+
+  for (let i = 0; i < batches.length; i++) {
+    const sendResult: SendResult = await postBatch(endpoint, batches[i], {
+      fetch:     opts.fetch,
+      timeoutMs,
+    });
+
+    if (sendResult.ok) {
+      sentEvents += sendResult.acceptedCount;
+      lastSuccessfulBatchIndex = i;
+      continue;
+    }
+
+    const latencyMs = now().getTime() - startTime;
+
+    if (lastSuccessfulBatchIndex >= 0) {
+      advanceCursorAfter(read, filteredIndices, batchEndIndices[lastSuccessfulBatchIndex], opts.cursorPath, startTime);
+    }
+
+    if (sendResult.kind === 'network') {
+      emit('telemetry_sync_failed', { reason: 'network', latency_ms: latencyMs });
+      return {
+        status:                   'network',
+        sentEvents,
+        consecutiveFailuresAfter: consecutiveFailuresBefore + 1,
+        shouldDisableSync:        false,
+      };
+    }
+
+    if (sendResult.status === 429) {
+      emit('telemetry_sync_failed', { reason: 'rate_limited', http_status: 429, latency_ms: latencyMs });
+      const out: RunnerResult = {
+        status:                   'rate_limited',
+        sentEvents,
+        httpStatus:               429,
+        consecutiveFailuresAfter: consecutiveFailuresBefore + 1,
+        shouldDisableSync:        false,
+      };
+      if (sendResult.retryAfterSeconds !== undefined) out.retryAfterSeconds = sendResult.retryAfterSeconds;
+      return out;
+    }
+
+    if (sendResult.status >= 400 && sendResult.status < 500) {
+      logErrorLine(errorLogPath, {
+        ts:          new Date(startTime).toISOString(),
+        status:      sendResult.status,
+        batchIndex:  i,
+        batchSize:   batches[i].batch.length,
+      });
+      const newFailures   = consecutiveFailuresBefore + 1;
+      const shouldDisable = newFailures >= failureThreshold;
+      emit('telemetry_sync_failed', { reason: 'http_4xx', http_status: sendResult.status, latency_ms: latencyMs });
+      return {
+        status:                   'http_4xx',
+        sentEvents,
+        httpStatus:               sendResult.status,
+        consecutiveFailuresAfter: newFailures,
+        shouldDisableSync:        shouldDisable,
+      };
+    }
+
+    emit('telemetry_sync_failed', { reason: 'http_5xx', http_status: sendResult.status, latency_ms: latencyMs });
+    return {
+      status:                   'http_5xx',
+      sentEvents,
+      httpStatus:               sendResult.status,
+      consecutiveFailuresAfter: consecutiveFailuresBefore + 1,
+      shouldDisableSync:        false,
+    };
+  }
+
+  advanceCursorAfter(read, filteredIndices, batchEndIndices[batches.length - 1], opts.cursorPath, startTime);
+
+  const latencyMs = now().getTime() - startTime;
+  emit('telemetry_sync_success', { event_count: sentEvents, latency_ms: latencyMs });
+
+  return {
+    status:                   'ok',
+    sentEvents,
+    consecutiveFailuresAfter: 0,
+    shouldDisableSync:        false,
+  };
+}
+
+function advanceCursorAfter(
+  read:               ReadResult,
+  filteredIndices:    number[],
+  filteredCount:      number,
+  cursorPath:         string | undefined,
+  startTimeMs:        number,
+): void {
+  if (filteredCount === 0) return;
+
+  const lastFilteredIdx = filteredCount - 1;
+  const originalIdx     = filteredIndices[lastFilteredIdx];
+
+  let offset: number;
+  if (originalIdx === read.events.length - 1) {
+    offset = read.newOffset;
+  } else {
+    const nextSelfEventIdx = filteredIndices[lastFilteredIdx + 1] ?? read.events.length;
+    const advanceThrough   = nextSelfEventIdx - 1;
+    offset = read.eventByteEnds[advanceThrough] ?? read.newOffset;
+  }
+
+  saveCursor({
+    inode:          read.newInode,
+    offset,
+    last_synced_ts: new Date(startTimeMs).toISOString(),
+  }, cursorPath);
+}
+
+function logErrorLine(errorLogPath: string, line: Record<string, unknown>): void {
+  try {
+    mkdirSync(dirname(errorLogPath), { recursive: true });
+    appendFileSync(errorLogPath, JSON.stringify(line) + '\n', 'utf8');
+  } catch {
+    // error log failure must not propagate
+  }
+}

--- a/src/telemetry/TelemetrySyncRunner.ts
+++ b/src/telemetry/TelemetrySyncRunner.ts
@@ -2,8 +2,8 @@ import { appendFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { readNewEvents, type ReadResult } from './TelemetryReader.js';
 import { saveCursor } from './TelemetryCursor.js';
-import { partitionEvents } from './TelemetryBatcher.js';
-import { postBatch, DEFAULT_POSTHOG_ENDPOINT, DEFAULT_TIMEOUT_MS, type FetchLike, type SendResult } from './TelemetryClient.js';
+import { buildEnvelopes } from './TelemetryBatcher.js';
+import { postEvent, DEFAULT_POSTHOG_ENDPOINT, DEFAULT_TIMEOUT_MS, type FetchLike, type SendResult } from './TelemetryClient.js';
 import { TELEMETRY_SYNC_ERROR_LOG_PATH } from './paths.js';
 import type { TelemetryEvent, TelemetryEventName } from './types.js';
 
@@ -40,6 +40,7 @@ export interface RunnerOptions {
   maxEventsPerBatch?:         number;
   maxBytesPerBatch?:          number;
   maxBatchesPerRun?:          number;
+  maxEventsPerRun?:           number;
   failureDisableThreshold?:   number;
   liveLogPath?:               string;
   rotatedLogPath?:            string;
@@ -95,15 +96,12 @@ export async function runSyncAttempt(
     };
   }
 
-  const { batches, batchEndIndices, consumedCount } = partitionEvents(filteredEvents, {
-    apiKey:             opts.apiKey,
-    hashProjectRoot:    opts.hashProjectRoot,
-    maxEventsPerBatch:  opts.maxEventsPerBatch,
-    maxBytesPerBatch:   opts.maxBytesPerBatch,
-    maxBatchesPerRun:   opts.maxBatchesPerRun,
-  });
+  const buildOptions: Parameters<typeof buildEnvelopes>[1] = { apiKey: opts.apiKey };
+  if (opts.hashProjectRoot !== undefined) buildOptions.hashProjectRoot = opts.hashProjectRoot;
+  if (opts.maxEventsPerRun !== undefined) buildOptions.maxEventsPerRun = opts.maxEventsPerRun;
+  const { envelopes, consumedCount } = buildEnvelopes(filteredEvents, buildOptions);
 
-  if (batches.length === 0) {
+  if (envelopes.length === 0) {
     saveCursor({
       inode:          read.newInode,
       offset:         read.newOffset,
@@ -119,25 +117,25 @@ export async function runSyncAttempt(
 
   emit('telemetry_sync_attempt', { event_count: consumedCount });
 
-  let sentEvents               = 0;
-  let lastSuccessfulBatchIndex = -1;
+  let sentEvents              = 0;
+  let lastSuccessfulFilteredIdx = -1;
 
-  for (let i = 0; i < batches.length; i++) {
-    const sendResult: SendResult = await postBatch(endpoint, batches[i], {
+  for (let i = 0; i < envelopes.length; i++) {
+    const sendResult: SendResult = await postEvent(endpoint, envelopes[i], {
       fetch:     opts.fetch,
       timeoutMs,
     });
 
     if (sendResult.ok) {
-      sentEvents += sendResult.acceptedCount;
-      lastSuccessfulBatchIndex = i;
+      sentEvents += 1;
+      lastSuccessfulFilteredIdx = i;
       continue;
     }
 
     const latencyMs = now().getTime() - startTime;
 
-    if (lastSuccessfulBatchIndex >= 0) {
-      advanceCursorAfter(read, filteredIndices, batchEndIndices[lastSuccessfulBatchIndex], opts.cursorPath, startTime);
+    if (lastSuccessfulFilteredIdx >= 0) {
+      advanceCursorAfter(read, filteredIndices, lastSuccessfulFilteredIdx + 1, opts.cursorPath, startTime);
     }
 
     if (sendResult.kind === 'network') {
@@ -167,8 +165,7 @@ export async function runSyncAttempt(
       logErrorLine(errorLogPath, {
         ts:          new Date(startTime).toISOString(),
         status:      sendResult.status,
-        batchIndex:  i,
-        batchSize:   batches[i].batch.length,
+        eventIndex:  i,
       });
       const newFailures   = consecutiveFailuresBefore + 1;
       const shouldDisable = newFailures >= failureThreshold;
@@ -192,7 +189,7 @@ export async function runSyncAttempt(
     };
   }
 
-  advanceCursorAfter(read, filteredIndices, batchEndIndices[batches.length - 1], opts.cursorPath, startTime);
+  advanceCursorAfter(read, filteredIndices, envelopes.length, opts.cursorPath, startTime);
 
   const latencyMs = now().getTime() - startTime;
   emit('telemetry_sync_success', { event_count: sentEvents, latency_ms: latencyMs });
@@ -213,6 +210,15 @@ function advanceCursorAfter(
   startTimeMs:        number,
 ): void {
   if (filteredCount === 0) return;
+
+  if (filteredCount === filteredIndices.length) {
+    saveCursor({
+      inode:          read.newInode,
+      offset:         read.newOffset,
+      last_synced_ts: new Date(startTimeMs).toISOString(),
+    }, cursorPath);
+    return;
+  }
 
   const lastFilteredIdx = filteredCount - 1;
   const originalIdx     = filteredIndices[lastFilteredIdx];

--- a/src/telemetry/TelemetrySyncRunner.ts
+++ b/src/telemetry/TelemetrySyncRunner.ts
@@ -103,6 +103,20 @@ export async function runSyncAttempt(
     maxBatchesPerRun:   opts.maxBatchesPerRun,
   });
 
+  if (batches.length === 0) {
+    saveCursor({
+      inode:          read.newInode,
+      offset:         read.newOffset,
+      last_synced_ts: new Date(startTime).toISOString(),
+    }, opts.cursorPath);
+    return {
+      status:                   'noop',
+      sentEvents:               0,
+      consecutiveFailuresAfter: consecutiveFailuresBefore,
+      shouldDisableSync:        false,
+    };
+  }
+
   emit('telemetry_sync_attempt', { event_count: consumedCount });
 
   let sentEvents               = 0;

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -60,6 +60,17 @@ describe('loadSyncState', () => {
       consecutive_failures: 0,
     });
   });
+
+  it('normalises non-numeric consecutive_failures to 0', () => {
+    writeFileSync(statePath, JSON.stringify({
+      next_sync_at:         null,
+      last_attempt_at:      null,
+      last_success_at:      null,
+      last_error:           null,
+      consecutive_failures: 'not-a-number',
+    }), 'utf8');
+    expect(loadSyncState(statePath)?.consecutive_failures).toBe(0);
+  });
 });
 
 describe('saveSyncState', () => {
@@ -114,6 +125,15 @@ describe('TelemetrySyncScheduler — constructor', () => {
     saveSyncState(state, statePath);
     const s = new TelemetrySyncScheduler({ statePath, now: fixedNow });
     expect(s.getState()).toEqual(state);
+  });
+
+  it('getState returns a defensive copy (callers cannot mutate internal state)', () => {
+    const s        = new TelemetrySyncScheduler({ statePath, now: fixedNow });
+    const snapshot = s.getState();
+    snapshot.consecutive_failures = 999;
+    snapshot.last_error           = 'mutated';
+    expect(s.getState().consecutive_failures).toBe(0);
+    expect(s.getState().last_error).toBeNull();
   });
 });
 
@@ -285,6 +305,76 @@ describe('TelemetrySyncScheduler — start/stop with fake timers', () => {
     s.start();
     expect(s.getState().next_sync_at).toBe(firstNext);
     s.stop();
+  });
+
+  it('reschedules after each tick — multiple ticks fire in sequence', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const onSync = vi.fn(async () => {});
+    const s      = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+      minMinutes: 10, maxMinutes: 30,
+    });
+
+    s.start();
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(3);
+
+    s.stop();
+  });
+
+  it('advances next_sync_at forward after a tick fires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const s = new TelemetrySyncScheduler({
+      onSync: async () => {}, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+      minMinutes: 10, maxMinutes: 30,
+    });
+
+    s.start();
+    const initialNext = new Date(s.getState().next_sync_at!).getTime();
+
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+
+    const afterNext = new Date(s.getState().next_sync_at!).getTime();
+    expect(afterNext).toBeGreaterThan(initialNext);
+    expect(afterNext).toBe(initialNext + 20 * 60 * 1000);
+
+    s.stop();
+  });
+
+  it('stop() called mid-runner prevents re-scheduling of the next tick', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    let resolveRunner!: () => void;
+    const onSync = vi.fn(() => new Promise<void>(r => { resolveRunner = r; }));
+
+    const s = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+    });
+
+    s.start();
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(1);
+
+    s.stop();
+    resolveRunner();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -380,19 +380,23 @@ describe('TelemetrySyncScheduler — start/stop with fake timers', () => {
 });
 
 describe('createDefaultScheduler — isEnabled wired through config', () => {
-  it('returns false when telemetry_sync_enabled config key is unset (default disabled)', async () => {
+  it('falls back to telemetry.enabled when telemetry_sync_enabled is unset (default enabled)', async () => {
+    // When telemetry_sync_enabled is not explicitly set, sync is gated by
+    // telemetry.enabled, which defaults to 'true'. This keeps legacy installs
+    // (set before install.ts started writing telemetry_sync_enabled) working
+    // without a migration script.
     const store = await openStore(':memory:');
     try {
       const onSync = vi.fn(async () => {});
       const s     = createDefaultScheduler(store, onSync);
       await s.syncNow();
-      expect(onSync).not.toHaveBeenCalled();
+      expect(onSync).toHaveBeenCalledTimes(1);
     } finally {
       closeStore(store);
     }
   });
 
-  it('returns true only when telemetry_sync_enabled config key is set to "true"', async () => {
+  it('returns true when telemetry_sync_enabled config key is set to "true"', async () => {
     const store = await openStore(':memory:');
     try {
       setConfig(store, 'telemetry_sync_enabled', 'true');
@@ -405,14 +409,55 @@ describe('createDefaultScheduler — isEnabled wired through config', () => {
     }
   });
 
-  it('treats any value other than "true" as disabled', async () => {
+  it('explicit telemetry_sync_enabled="false" disables sync regardless of telemetry.enabled', async () => {
     const store = await openStore(':memory:');
     try {
       setConfig(store, 'telemetry_sync_enabled', 'false');
+      // telemetry.enabled defaults to 'true' here — explicit sync flag wins.
       const onSync = vi.fn(async () => {});
       const s     = createDefaultScheduler(store, onSync);
       await s.syncNow();
       expect(onSync).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('fallback path: sync_enabled unset + telemetry.enabled="false" → disabled', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry.enabled', 'false');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('fallback path: sync_enabled unset + telemetry.enabled explicit "true" → enabled', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry.enabled', 'true');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).toHaveBeenCalledTimes(1);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('explicit sync_enabled="true" wins even if telemetry.enabled="false"', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry.enabled',      'false');
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).toHaveBeenCalledTimes(1);
     } finally {
       closeStore(store);
     }

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -416,6 +416,57 @@ describe('createDefaultScheduler — isEnabled wired through config', () => {
       closeStore(store);
     }
   });
+
+  it('reads telemetry_sync_min_minutes and telemetry_sync_max_minutes from config', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled',      'true');
+      setConfig(store, 'telemetry_sync_min_minutes',  '5');
+      setConfig(store, 'telemetry_sync_max_minutes',  '7');
+      const s = createDefaultScheduler(store, async () => {});
+      s.start();
+      const nextMs   = new Date(s.getState().next_sync_at!).getTime();
+      const fromNow  = nextMs - Date.now();
+      expect(fromNow).toBeGreaterThanOrEqual(5 * 60 * 1000 - 100);
+      expect(fromNow).toBeLessThanOrEqual(7 * 60 * 1000 + 100);
+      s.stop();
+    } finally {
+      closeStore(store);
+    }
+  });
+});
+
+describe('TelemetrySyncScheduler — setNextSyncAt and setConsecutiveFailures', () => {
+  it('setNextSyncAt persists next_sync_at to disk', () => {
+    const s    = new TelemetrySyncScheduler({ statePath });
+    const when = new Date('2026-05-19T15:00:00.000Z');
+    s.setNextSyncAt(when);
+    expect(loadSyncState(statePath)?.next_sync_at).toBe(when.toISOString());
+  });
+
+  it('setConsecutiveFailures persists count to disk', () => {
+    const s = new TelemetrySyncScheduler({ statePath });
+    s.setConsecutiveFailures(5);
+    expect(loadSyncState(statePath)?.consecutive_failures).toBe(5);
+  });
+
+  it('setNextSyncAt re-schedules the pending timer to the new time', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const onSync = vi.fn(async () => {});
+    const s      = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+    });
+    s.start();
+
+    s.setNextSyncAt(new Date(FROZEN_NOW.getTime() + 5 * 60 * 1000));
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(1);
+
+    s.stop();
+  });
 });
 
 describe('TelemetrySyncScheduler — restart survival', () => {

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -463,6 +463,20 @@ describe('createDefaultScheduler — isEnabled wired through config', () => {
     }
   });
 
+  it('both flags explicitly "false" → disabled (lower bound)', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry.enabled',      'false');
+      setConfig(store, 'telemetry_sync_enabled', 'false');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+
   it('reads telemetry_sync_min_minutes and telemetry_sync_max_minutes from config', async () => {
     const store = await openStore(':memory:');
     try {

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -464,10 +464,11 @@ describe('createDefaultScheduler → runner integration', () => {
     appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
   }
 
-  it('bails silently when telemetry_sync_api_key is unset (no fetch call)', async () => {
+  it('bails silently when telemetry_sync_api_key is cleared (no fetch call)', async () => {
     const store = await openStore(':memory:');
     try {
       setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry_sync_api_key', '');
       writeSampleEvent();
       const fetch = vi.fn();
       const s     = createDefaultScheduler(store, undefined, {

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  TelemetrySyncScheduler,
+  loadSyncState,
+  saveSyncState,
+  createDefaultScheduler,
+} from './TelemetrySyncScheduler.js';
+import { openStore, closeStore } from '../store/db.js';
+import { setConfig } from '../store/config.js';
+import type { SyncState } from './types.js';
+
+let tmpDir: string;
+let statePath: string;
+
+beforeEach(() => {
+  tmpDir    = mkdtempSync(join(tmpdir(), 'nexpath-scheduler-'));
+  statePath = join(tmpDir, 'state.json');
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+const FROZEN_NOW = new Date('2026-05-19T10:00:00.000Z');
+const fixedNow = () => FROZEN_NOW;
+
+describe('loadSyncState', () => {
+  it('returns null when state file does not exist', () => {
+    expect(loadSyncState(statePath)).toBeNull();
+  });
+
+  it('returns parsed state when valid file exists', () => {
+    const state: SyncState = {
+      next_sync_at:         '2026-05-19T10:30:00.000Z',
+      last_attempt_at:      '2026-05-19T09:50:00.000Z',
+      last_success_at:      '2026-05-19T09:50:01.000Z',
+      last_error:           null,
+      consecutive_failures: 0,
+    };
+    writeFileSync(statePath, JSON.stringify(state), 'utf8');
+    expect(loadSyncState(statePath)).toEqual(state);
+  });
+
+  it('returns null when state file is corrupt JSON', () => {
+    writeFileSync(statePath, 'not-json{', 'utf8');
+    expect(loadSyncState(statePath)).toBeNull();
+  });
+
+  it('normalises missing fields to safe defaults', () => {
+    writeFileSync(statePath, JSON.stringify({ next_sync_at: '2026-05-19T10:30:00.000Z' }), 'utf8');
+    expect(loadSyncState(statePath)).toEqual({
+      next_sync_at:         '2026-05-19T10:30:00.000Z',
+      last_attempt_at:      null,
+      last_success_at:      null,
+      last_error:           null,
+      consecutive_failures: 0,
+    });
+  });
+});
+
+describe('saveSyncState', () => {
+  it('writes state to disk', () => {
+    const state: SyncState = {
+      next_sync_at:         '2026-05-19T10:30:00.000Z',
+      last_attempt_at:      null,
+      last_success_at:      null,
+      last_error:           null,
+      consecutive_failures: 0,
+    };
+    saveSyncState(state, statePath);
+    expect(existsSync(statePath)).toBe(true);
+    expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(state);
+  });
+
+  it('creates parent directory if missing', () => {
+    const nested = join(tmpDir, 'a', 'b', 'state.json');
+    saveSyncState({
+      next_sync_at: null, last_attempt_at: null, last_success_at: null, last_error: null, consecutive_failures: 0,
+    }, nested);
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it('does not throw on unwritable path', () => {
+    expect(() => saveSyncState({
+      next_sync_at: null, last_attempt_at: null, last_success_at: null, last_error: null, consecutive_failures: 0,
+    }, '/nonexistent/readonly/state.json')).not.toThrow();
+  });
+});
+
+describe('TelemetrySyncScheduler — constructor', () => {
+  it('initialises empty state when no state file exists', () => {
+    const s = new TelemetrySyncScheduler({ statePath, now: fixedNow });
+    expect(s.getState()).toEqual({
+      next_sync_at:         null,
+      last_attempt_at:      null,
+      last_success_at:      null,
+      last_error:           null,
+      consecutive_failures: 0,
+    });
+  });
+
+  it('loads existing state from disk', () => {
+    const state: SyncState = {
+      next_sync_at:         '2026-05-19T10:30:00.000Z',
+      last_attempt_at:      '2026-05-19T09:50:00.000Z',
+      last_success_at:      '2026-05-19T09:50:01.000Z',
+      last_error:           null,
+      consecutive_failures: 0,
+    };
+    saveSyncState(state, statePath);
+    const s = new TelemetrySyncScheduler({ statePath, now: fixedNow });
+    expect(s.getState()).toEqual(state);
+  });
+});
+
+describe('TelemetrySyncScheduler — randomDelayMs falls within [min, max]', () => {
+  it('over 200 samples the delay is always within [10, 30] minutes', () => {
+    const onSync = vi.fn(async () => {});
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const min = 10 * 60 * 1000;
+    const max = 30 * 60 * 1000;
+
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (let i = 0; i < 200; i++) {
+      const s = new TelemetrySyncScheduler({
+        onSync, statePath, now: () => new Date(), random: Math.random,
+      });
+      s.start();
+      const ns = new Date(s.getState().next_sync_at!).getTime() - FROZEN_NOW.getTime();
+      if (ns < lo) lo = ns;
+      if (ns > hi) hi = ns;
+      s.stop();
+      rmSync(statePath, { force: true });
+    }
+    expect(lo).toBeGreaterThanOrEqual(min);
+    expect(hi).toBeLessThanOrEqual(max);
+  });
+
+  it('honours custom minMinutes/maxMinutes', () => {
+    const s = new TelemetrySyncScheduler({
+      statePath, now: fixedNow, random: () => 0,
+      minMinutes: 1, maxMinutes: 2,
+    });
+    s.start();
+    const ns = new Date(s.getState().next_sync_at!).getTime() - FROZEN_NOW.getTime();
+    expect(ns).toBe(60 * 1000);
+    s.stop();
+  });
+});
+
+describe('TelemetrySyncScheduler — syncNow gating', () => {
+  it('short-circuits when isEnabled returns false', async () => {
+    const onSync = vi.fn(async () => {});
+    const s = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => false, statePath, now: fixedNow,
+    });
+    await s.syncNow();
+    expect(onSync).not.toHaveBeenCalled();
+    expect(s.getState().last_attempt_at).toBeNull();
+  });
+
+  it('prevents concurrent runs via in-memory flag', async () => {
+    let resolveRunner!: () => void;
+    const runnerPromise = new Promise<void>(r => { resolveRunner = r; });
+    const onSync        = vi.fn(() => runnerPromise);
+    const s             = new TelemetrySyncScheduler({ onSync, statePath, now: fixedNow });
+
+    const first  = s.syncNow();
+    const second = s.syncNow();
+
+    expect(onSync).toHaveBeenCalledTimes(1);
+    resolveRunner();
+    await Promise.all([first, second]);
+    expect(onSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TelemetrySyncScheduler — syncNow success/failure paths', () => {
+  it('on success: clears last_error, resets consecutive_failures, updates last_success_at', async () => {
+    const s = new TelemetrySyncScheduler({
+      onSync:    async () => {},
+      isEnabled: () => true,
+      statePath, now: fixedNow,
+    });
+    await s.syncNow();
+    const st = s.getState();
+    expect(st.last_attempt_at).toBe(FROZEN_NOW.toISOString());
+    expect(st.last_success_at).toBe(FROZEN_NOW.toISOString());
+    expect(st.last_error).toBeNull();
+    expect(st.consecutive_failures).toBe(0);
+  });
+
+  it('on failure: sets last_error, increments consecutive_failures, does not set last_success_at', async () => {
+    const s = new TelemetrySyncScheduler({
+      onSync:    async () => { throw new Error('boom'); },
+      isEnabled: () => true,
+      statePath, now: fixedNow,
+    });
+    await s.syncNow();
+    const st = s.getState();
+    expect(st.last_error).toBe('boom');
+    expect(st.consecutive_failures).toBe(1);
+    expect(st.last_success_at).toBeNull();
+  });
+
+  it('persists state to disk after a sync attempt', async () => {
+    const s = new TelemetrySyncScheduler({
+      onSync:    async () => {},
+      isEnabled: () => true,
+      statePath, now: fixedNow,
+    });
+    await s.syncNow();
+    expect(loadSyncState(statePath)?.last_success_at).toBe(FROZEN_NOW.toISOString());
+  });
+
+  it('consecutive_failures accumulates across failed runs', async () => {
+    const s = new TelemetrySyncScheduler({
+      onSync:    async () => { throw new Error('fail'); },
+      isEnabled: () => true,
+      statePath, now: fixedNow,
+    });
+    await s.syncNow();
+    await s.syncNow();
+    await s.syncNow();
+    expect(s.getState().consecutive_failures).toBe(3);
+  });
+});
+
+describe('TelemetrySyncScheduler — start/stop with fake timers', () => {
+  it('fires onSync after the scheduled delay', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const onSync = vi.fn(async () => {});
+    const s      = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+      minMinutes: 10, maxMinutes: 30,
+    });
+
+    s.start();
+    expect(onSync).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(20 * 60 * 1000);
+    expect(onSync).toHaveBeenCalledTimes(1);
+
+    s.stop();
+  });
+
+  it('stop() cancels the pending timer (onSync never fires)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const onSync = vi.fn(async () => {});
+    const s      = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+    });
+
+    s.start();
+    s.stop();
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(onSync).not.toHaveBeenCalled();
+  });
+
+  it('double start() is a no-op', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const s = new TelemetrySyncScheduler({
+      onSync: async () => {}, statePath,
+      now: () => new Date(), random: () => 0.5,
+    });
+
+    s.start();
+    const firstNext = s.getState().next_sync_at;
+    s.start();
+    expect(s.getState().next_sync_at).toBe(firstNext);
+    s.stop();
+  });
+});
+
+describe('createDefaultScheduler — isEnabled wired through config', () => {
+  it('returns false when telemetry_sync_enabled config key is unset (default disabled)', async () => {
+    const store = await openStore(':memory:');
+    try {
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('returns true only when telemetry_sync_enabled config key is set to "true"', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).toHaveBeenCalledTimes(1);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('treats any value other than "true" as disabled', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'false');
+      const onSync = vi.fn(async () => {});
+      const s     = createDefaultScheduler(store, onSync);
+      await s.syncNow();
+      expect(onSync).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+});
+
+describe('TelemetrySyncScheduler — restart survival', () => {
+  it('next_sync_at persists across new scheduler instance (process restart)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const first = new TelemetrySyncScheduler({
+      onSync: async () => {}, statePath,
+      now: () => new Date(), random: () => 0.25,
+    });
+    first.start();
+    const savedNext = first.getState().next_sync_at;
+    first.stop();
+    expect(savedNext).not.toBeNull();
+
+    const second = new TelemetrySyncScheduler({
+      onSync: async () => {}, statePath,
+      now: () => new Date(), random: () => 0.99,
+    });
+    expect(second.getState().next_sync_at).toBe(savedNext);
+  });
+
+  it('a past next_sync_at fires immediately on start', async () => {
+    saveSyncState({
+      next_sync_at:         '2026-05-19T09:00:00.000Z',
+      last_attempt_at:      null,
+      last_success_at:      null,
+      last_error:           null,
+      consecutive_failures: 0,
+    }, statePath);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+
+    const onSync = vi.fn(async () => {});
+    const s      = new TelemetrySyncScheduler({
+      onSync, isEnabled: () => true, statePath,
+      now: () => new Date(), random: () => 0.5,
+    });
+    s.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onSync).toHaveBeenCalledTimes(1);
+
+    s.stop();
+  });
+});

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -498,10 +498,12 @@ describe('createDefaultScheduler → runner integration', () => {
         fetch: fetch as unknown as never,
       });
       await s.syncNow();
-      expect(fetch).toHaveBeenCalledTimes(1);
-      const body = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.api_key).toBe('phc_int');
-      expect(body.batch).toHaveLength(2);
+      expect(fetch).toHaveBeenCalledTimes(2);
+      const body0 = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
+      const body1 = JSON.parse((fetch.mock.calls[1][1] as { body: string }).body);
+      expect(body0.api_key).toBe('phc_int');
+      expect(body0.event).toBe('prompt_received');
+      expect(body1.event).toBe('prompt_classified');
       expect(s.getState().consecutive_failures).toBe(0);
     } finally {
       closeStore(store);

--- a/src/telemetry/TelemetrySyncScheduler.test.ts
+++ b/src/telemetry/TelemetrySyncScheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -9,7 +9,8 @@ import {
   createDefaultScheduler,
 } from './TelemetrySyncScheduler.js';
 import { openStore, closeStore } from '../store/db.js';
-import { setConfig } from '../store/config.js';
+import { setConfig, getConfig } from '../store/config.js';
+import type { FetchLike } from './TelemetryClient.js';
 import type { SyncState } from './types.js';
 
 let tmpDir: string;
@@ -423,13 +424,135 @@ describe('createDefaultScheduler — isEnabled wired through config', () => {
       setConfig(store, 'telemetry_sync_enabled',      'true');
       setConfig(store, 'telemetry_sync_min_minutes',  '5');
       setConfig(store, 'telemetry_sync_max_minutes',  '7');
-      const s = createDefaultScheduler(store, async () => {});
+      const s = createDefaultScheduler(store, async () => {}, { statePath });
       s.start();
       const nextMs   = new Date(s.getState().next_sync_at!).getTime();
       const fromNow  = nextMs - Date.now();
       expect(fromNow).toBeGreaterThanOrEqual(5 * 60 * 1000 - 100);
       expect(fromNow).toBeLessThanOrEqual(7 * 60 * 1000 + 100);
       s.stop();
+    } finally {
+      closeStore(store);
+    }
+  });
+});
+
+describe('createDefaultScheduler → runner integration', () => {
+  let livePath:     string;
+  let rotPath:      string;
+  let cursorPath:   string;
+  let errorLogPath: string;
+
+  beforeEach(() => {
+    livePath     = join(tmpDir, 'telemetry.jsonl');
+    rotPath      = `${livePath}.1`;
+    cursorPath   = join(tmpDir, 'cursor.json');
+    errorLogPath = join(tmpDir, 'sync-errors.log');
+  });
+
+  function writeSampleEvent(extra: Record<string, unknown> = {}): void {
+    const ev = {
+      ts:             '2026-05-19T10:00:00.000Z',
+      v:              1,
+      installationId: '550e8400-e29b-41d4-a716-446655440000',
+      userId:         'user-uuid',
+      teamId:         'team-uuid',
+      projectRoot:    '/tmp/proj',
+      event:          'prompt_received',
+      ...extra,
+    };
+    appendFileSync(livePath, JSON.stringify(ev) + '\n', 'utf8');
+  }
+
+  it('bails silently when telemetry_sync_api_key is unset (no fetch call)', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      writeSampleEvent();
+      const fetch = vi.fn();
+      const s     = createDefaultScheduler(store, undefined, {
+        liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath, statePath,
+        fetch: fetch as unknown as never,
+      });
+      await s.syncNow();
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('end-to-end success: events flow through runner and reach fetch', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry_sync_api_key', 'phc_int');
+      writeSampleEvent({ event: 'prompt_received', promptCount: 1 });
+      writeSampleEvent({ event: 'prompt_classified', stage: 'planning' });
+
+      const fetch = vi.fn<FetchLike>(async () => ({
+        ok: true, status: 200, headers: { get: () => null },
+      }));
+      const s = createDefaultScheduler(store, undefined, {
+        liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath, statePath,
+        fetch: fetch as unknown as never,
+      });
+      await s.syncNow();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse((fetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.api_key).toBe('phc_int');
+      expect(body.batch).toHaveLength(2);
+      expect(s.getState().consecutive_failures).toBe(0);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('on 4xx auto-disable threshold reached: telemetry_sync_enabled config flips to "false"', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry_sync_api_key', 'phc_int');
+      writeSampleEvent();
+
+      const fetch = vi.fn<FetchLike>(async () => ({
+        ok: false, status: 400, headers: { get: () => null },
+      }));
+      const s = createDefaultScheduler(store, undefined, {
+        liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath, statePath,
+        fetch: fetch as unknown as never,
+      });
+      s.setConsecutiveFailures(9);
+      await s.syncNow();
+
+      expect(getConfig(store.db, 'telemetry_sync_enabled')).toBe('false');
+      expect(s.getState().consecutive_failures).toBe(10);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it('on 429 with Retry-After: applies max(retryAfter, 30 min) to next_sync_at', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry_sync_api_key', 'phc_int');
+      writeSampleEvent();
+
+      const fakeNow = new Date('2026-05-19T10:00:00.000Z');
+      const fetch = vi.fn<FetchLike>(async () => ({
+        ok: false, status: 429,
+        headers: { get: (h: string) => h === 'Retry-After' ? '60' : null },
+      }));
+      const s = createDefaultScheduler(store, undefined, {
+        liveLogPath: livePath, rotatedLogPath: rotPath, cursorPath, errorLogPath, statePath,
+        fetch: fetch as unknown as never,
+        now: () => fakeNow,
+      });
+      await s.syncNow();
+
+      const next   = new Date(s.getState().next_sync_at!).getTime();
+      const expected = fakeNow.getTime() + 30 * 60 * 1000;
+      expect(next).toBe(expected);
     } finally {
       closeStore(store);
     }

--- a/src/telemetry/TelemetrySyncScheduler.ts
+++ b/src/telemetry/TelemetrySyncScheduler.ts
@@ -267,7 +267,10 @@ export function createDefaultScheduler(
     onSync: onSyncOverride ?? defaultOnSync,
     isEnabled: () => {
       try {
-        return getConfig(store.db, 'telemetry_sync_enabled') === 'true';
+        const syncFlag = getConfig(store.db, 'telemetry_sync_enabled');
+        if (syncFlag !== undefined) return syncFlag === 'true';
+        // Fallback: respect top-level telemetry.enabled (defaults to 'true').
+        return getConfig(store.db, 'telemetry.enabled') !== 'false';
       } catch {
         return false;
       }

--- a/src/telemetry/TelemetrySyncScheduler.ts
+++ b/src/telemetry/TelemetrySyncScheduler.ts
@@ -6,7 +6,7 @@ import type { Store } from '../store/db.js';
 import type { SyncState } from './types.js';
 import { runSyncAttempt, type RunnerOptions } from './TelemetrySyncRunner.js';
 import { writeTelemetry } from './TelemetryWriter.js';
-import { DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
+import { DEFAULT_POSTHOG_ENDPOINT, type FetchLike } from './TelemetryClient.js';
 
 const DEFAULT_MIN_MINUTES = 10;
 const DEFAULT_MAX_MINUTES = 30;
@@ -208,9 +208,24 @@ function buildRunnerOptions(store: Store): Omit<RunnerOptions, 'apiKey'> & { api
   return out;
 }
 
-export function createDefaultScheduler(store: Store, onSyncOverride?: () => Promise<void>): TelemetrySyncScheduler {
+export interface DefaultSchedulerOverrides {
+  liveLogPath?:    string;
+  rotatedLogPath?: string;
+  cursorPath?:     string;
+  errorLogPath?:   string;
+  statePath?:      string;
+  fetch?:          FetchLike;
+  now?:            () => Date;
+}
+
+export function createDefaultScheduler(
+  store:           Store,
+  onSyncOverride?: () => Promise<void>,
+  overrides?:      DefaultSchedulerOverrides,
+): TelemetrySyncScheduler {
   const minFromConfig = readConfigNumber(store, 'telemetry_sync_min_minutes');
   const maxFromConfig = readConfigNumber(store, 'telemetry_sync_max_minutes');
+  const now           = overrides?.now ?? (() => new Date());
 
   let scheduler: TelemetrySyncScheduler;
   const defaultOnSync = async () => {
@@ -220,11 +235,15 @@ export function createDefaultScheduler(store: Store, onSyncOverride?: () => Prom
     const before = scheduler.getState().consecutive_failures;
     const result = await runSyncAttempt({
       ...runnerOpts,
-      apiKey: runnerOpts.apiKey,
+      apiKey:        runnerOpts.apiKey,
       emitTelemetry: (event, props) => writeTelemetry('<sync>', event, props, store),
+      ...(overrides?.liveLogPath    !== undefined ? { liveLogPath:    overrides.liveLogPath }    : {}),
+      ...(overrides?.rotatedLogPath !== undefined ? { rotatedLogPath: overrides.rotatedLogPath } : {}),
+      ...(overrides?.cursorPath     !== undefined ? { cursorPath:     overrides.cursorPath }     : {}),
+      ...(overrides?.errorLogPath   !== undefined ? { errorLogPath:   overrides.errorLogPath }   : {}),
+      ...(overrides?.fetch          !== undefined ? { fetch:          overrides.fetch }          : {}),
+      ...(overrides?.now            !== undefined ? { now:            overrides.now }            : {}),
     }, before);
-
-    scheduler.setConsecutiveFailures(result.consecutiveFailuresAfter);
 
     if (result.shouldDisableSync) {
       try {
@@ -236,7 +255,11 @@ export function createDefaultScheduler(store: Store, onSyncOverride?: () => Prom
 
     if (result.status === 'rate_limited' && result.retryAfterSeconds !== undefined) {
       const delaySeconds = Math.max(result.retryAfterSeconds, 30 * 60);
-      scheduler.setNextSyncAt(new Date(Date.now() + delaySeconds * 1000));
+      scheduler.setNextSyncAt(new Date(now().getTime() + delaySeconds * 1000));
+    }
+
+    if (result.status === 'network' || result.status === 'http_4xx' || result.status === 'http_5xx') {
+      throw new Error(`sync_${result.status}${result.httpStatus !== undefined ? `_${result.httpStatus}` : ''}`);
     }
   };
 
@@ -250,8 +273,10 @@ export function createDefaultScheduler(store: Store, onSyncOverride?: () => Prom
       }
     },
   };
-  if (minFromConfig !== undefined) schedulerOpts.minMinutes = minFromConfig;
-  if (maxFromConfig !== undefined) schedulerOpts.maxMinutes = maxFromConfig;
+  if (minFromConfig          !== undefined) schedulerOpts.minMinutes = minFromConfig;
+  if (maxFromConfig          !== undefined) schedulerOpts.maxMinutes = maxFromConfig;
+  if (overrides?.statePath   !== undefined) schedulerOpts.statePath  = overrides.statePath;
+  if (overrides?.now         !== undefined) schedulerOpts.now        = overrides.now;
 
   scheduler = new TelemetrySyncScheduler(schedulerOpts);
   return scheduler;

--- a/src/telemetry/TelemetrySyncScheduler.ts
+++ b/src/telemetry/TelemetrySyncScheduler.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { TELEMETRY_SYNC_STATE_PATH } from './paths.js';
+import { getConfig } from '../store/config.js';
+import type { Store } from '../store/db.js';
+import type { SyncState } from './types.js';
+
+const DEFAULT_MIN_MINUTES = 10;
+const DEFAULT_MAX_MINUTES = 30;
+const MS_PER_MINUTE = 60 * 1000;
+
+const EMPTY_STATE: SyncState = {
+  next_sync_at:         null,
+  last_attempt_at:      null,
+  last_success_at:      null,
+  last_error:           null,
+  consecutive_failures: 0,
+};
+
+export function loadSyncState(statePath: string = TELEMETRY_SYNC_STATE_PATH): SyncState | null {
+  try {
+    if (!existsSync(statePath)) return null;
+    const raw    = readFileSync(statePath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<SyncState>;
+    return {
+      next_sync_at:         typeof parsed.next_sync_at         === 'string' ? parsed.next_sync_at         : null,
+      last_attempt_at:      typeof parsed.last_attempt_at      === 'string' ? parsed.last_attempt_at      : null,
+      last_success_at:      typeof parsed.last_success_at      === 'string' ? parsed.last_success_at      : null,
+      last_error:           typeof parsed.last_error           === 'string' ? parsed.last_error           : null,
+      consecutive_failures: typeof parsed.consecutive_failures === 'number' ? parsed.consecutive_failures : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveSyncState(state: SyncState, statePath: string = TELEMETRY_SYNC_STATE_PATH): void {
+  try {
+    mkdirSync(dirname(statePath), { recursive: true });
+    writeFileSync(statePath, JSON.stringify(state, null, 2), 'utf8');
+  } catch {
+    // Never throw — sync must not crash the host process.
+  }
+}
+
+export interface SchedulerOptions {
+  onSync?:      () => Promise<void>;
+  isEnabled?:   () => boolean;
+  now?:         () => Date;
+  random?:      () => number;
+  statePath?:   string;
+  minMinutes?:  number;
+  maxMinutes?:  number;
+}
+
+export class TelemetrySyncScheduler {
+  private readonly onSync:     () => Promise<void>;
+  private readonly isEnabled:  () => boolean;
+  private readonly now:        () => Date;
+  private readonly random:     () => number;
+  private readonly statePath:  string;
+  private readonly minMs:      number;
+  private readonly maxMs:      number;
+
+  private state:      SyncState;
+  private isRunning   = false;
+  private stopped     = true;
+  private timer:      ReturnType<typeof setTimeout> | null = null;
+
+  constructor(opts: SchedulerOptions = {}) {
+    this.onSync     = opts.onSync     ?? (async () => {});
+    this.isEnabled  = opts.isEnabled  ?? (() => true);
+    this.now        = opts.now        ?? (() => new Date());
+    this.random     = opts.random     ?? Math.random;
+    this.statePath  = opts.statePath  ?? TELEMETRY_SYNC_STATE_PATH;
+    this.minMs      = (opts.minMinutes ?? DEFAULT_MIN_MINUTES) * MS_PER_MINUTE;
+    this.maxMs      = (opts.maxMinutes ?? DEFAULT_MAX_MINUTES) * MS_PER_MINUTE;
+
+    const loaded = loadSyncState(this.statePath);
+    this.state   = loaded ?? { ...EMPTY_STATE };
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+    this.stopped = false;
+
+    const nowMs = this.now().getTime();
+    let nextMs: number;
+
+    if (this.state.next_sync_at) {
+      nextMs = new Date(this.state.next_sync_at).getTime();
+    } else {
+      nextMs = nowMs + this.randomDelayMs();
+      this.state.next_sync_at = new Date(nextMs).toISOString();
+      saveSyncState(this.state, this.statePath);
+    }
+
+    const delayMs = Math.max(0, nextMs - nowMs);
+    this.timer = setTimeout(() => { void this.tick(); }, delayMs);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async syncNow(): Promise<void> {
+    if (!this.isEnabled()) return;
+    if (this.isRunning) return;
+
+    this.isRunning             = true;
+    this.state.last_attempt_at = this.now().toISOString();
+
+    try {
+      await this.onSync();
+      this.state.last_success_at      = this.now().toISOString();
+      this.state.last_error           = null;
+      this.state.consecutive_failures = 0;
+    } catch (err) {
+      this.state.last_error           = err instanceof Error ? err.message : String(err);
+      this.state.consecutive_failures = this.state.consecutive_failures + 1;
+    } finally {
+      this.isRunning = false;
+      saveSyncState(this.state, this.statePath);
+    }
+  }
+
+  getState(): SyncState {
+    return { ...this.state };
+  }
+
+  private async tick(): Promise<void> {
+    if (this.stopped) return;
+    await this.syncNow();
+    if (this.stopped) return;
+
+    const delayMs           = this.randomDelayMs();
+    const nextMs            = this.now().getTime() + delayMs;
+    this.state.next_sync_at = new Date(nextMs).toISOString();
+    saveSyncState(this.state, this.statePath);
+
+    this.timer = setTimeout(() => { void this.tick(); }, delayMs);
+  }
+
+  private randomDelayMs(): number {
+    const span = this.maxMs - this.minMs;
+    return this.minMs + this.random() * span;
+  }
+}
+
+export function createDefaultScheduler(store: Store, onSync?: () => Promise<void>): TelemetrySyncScheduler {
+  return new TelemetrySyncScheduler({
+    onSync,
+    isEnabled: () => {
+      try {
+        return getConfig(store.db, 'telemetry_sync_enabled') === 'true';
+      } catch {
+        return false;
+      }
+    },
+  });
+}

--- a/src/telemetry/TelemetrySyncScheduler.ts
+++ b/src/telemetry/TelemetrySyncScheduler.ts
@@ -1,9 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { TELEMETRY_SYNC_STATE_PATH } from './paths.js';
-import { getConfig } from '../store/config.js';
+import { getConfig, setConfig } from '../store/config.js';
 import type { Store } from '../store/db.js';
 import type { SyncState } from './types.js';
+import { runSyncAttempt, type RunnerOptions } from './TelemetrySyncRunner.js';
+import { writeTelemetry } from './TelemetryWriter.js';
+import { DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
 
 const DEFAULT_MIN_MINUTES = 10;
 const DEFAULT_MAX_MINUTES = 30;
@@ -107,6 +110,21 @@ export class TelemetrySyncScheduler {
     }
   }
 
+  setNextSyncAt(when: Date): void {
+    this.state.next_sync_at = when.toISOString();
+    saveSyncState(this.state, this.statePath);
+    if (this.timer !== null && !this.stopped) {
+      clearTimeout(this.timer);
+      const delayMs = Math.max(0, when.getTime() - this.now().getTime());
+      this.timer = setTimeout(() => { void this.tick(); }, delayMs);
+    }
+  }
+
+  setConsecutiveFailures(n: number): void {
+    this.state.consecutive_failures = n;
+    saveSyncState(this.state, this.statePath);
+  }
+
   async syncNow(): Promise<void> {
     if (!this.isEnabled()) return;
     if (this.isRunning) return;
@@ -151,9 +169,79 @@ export class TelemetrySyncScheduler {
   }
 }
 
-export function createDefaultScheduler(store: Store, onSync?: () => Promise<void>): TelemetrySyncScheduler {
-  return new TelemetrySyncScheduler({
-    onSync,
+function readConfigNumber(store: Store, key: string): number | undefined {
+  try {
+    const v = getConfig(store.db, key);
+    if (v === undefined) return undefined;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildRunnerOptions(store: Store): Omit<RunnerOptions, 'apiKey'> & { apiKey: string | undefined } {
+  let apiKey:           string | undefined;
+  let endpoint:         string | undefined;
+  let timeoutMs:        number | undefined;
+  let maxEventsPerBatch: number | undefined;
+  let maxBytesPerBatch:  number | undefined;
+  let hashProjectRoot:   boolean | undefined;
+  try {
+    apiKey            = getConfig(store.db, 'telemetry_sync_api_key');
+    endpoint          = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    timeoutMs         = readConfigNumber(store, 'telemetry_sync_timeout_ms');
+    maxEventsPerBatch = readConfigNumber(store, 'telemetry_sync_batch_max_events');
+    maxBytesPerBatch  = readConfigNumber(store, 'telemetry_sync_batch_max_bytes');
+    const hashFlag    = getConfig(store.db, 'telemetry_sync_hash_project_root');
+    hashProjectRoot   = hashFlag === undefined ? undefined : hashFlag !== 'false';
+  } catch {
+    // Use defaults if config read fails
+  }
+
+  const out: Omit<RunnerOptions, 'apiKey'> & { apiKey: string | undefined } = { apiKey };
+  if (endpoint          !== undefined) out.endpoint          = endpoint;
+  if (timeoutMs         !== undefined) out.timeoutMs         = timeoutMs;
+  if (maxEventsPerBatch !== undefined) out.maxEventsPerBatch = maxEventsPerBatch;
+  if (maxBytesPerBatch  !== undefined) out.maxBytesPerBatch  = maxBytesPerBatch;
+  if (hashProjectRoot   !== undefined) out.hashProjectRoot   = hashProjectRoot;
+  return out;
+}
+
+export function createDefaultScheduler(store: Store, onSyncOverride?: () => Promise<void>): TelemetrySyncScheduler {
+  const minFromConfig = readConfigNumber(store, 'telemetry_sync_min_minutes');
+  const maxFromConfig = readConfigNumber(store, 'telemetry_sync_max_minutes');
+
+  let scheduler: TelemetrySyncScheduler;
+  const defaultOnSync = async () => {
+    const runnerOpts = buildRunnerOptions(store);
+    if (!runnerOpts.apiKey) return;
+
+    const before = scheduler.getState().consecutive_failures;
+    const result = await runSyncAttempt({
+      ...runnerOpts,
+      apiKey: runnerOpts.apiKey,
+      emitTelemetry: (event, props) => writeTelemetry('<sync>', event, props, store),
+    }, before);
+
+    scheduler.setConsecutiveFailures(result.consecutiveFailuresAfter);
+
+    if (result.shouldDisableSync) {
+      try {
+        setConfig(store, 'telemetry_sync_enabled', 'false');
+      } catch {
+        // setConfig failure must not propagate
+      }
+    }
+
+    if (result.status === 'rate_limited' && result.retryAfterSeconds !== undefined) {
+      const delaySeconds = Math.max(result.retryAfterSeconds, 30 * 60);
+      scheduler.setNextSyncAt(new Date(Date.now() + delaySeconds * 1000));
+    }
+  };
+
+  const schedulerOpts: SchedulerOptions = {
+    onSync: onSyncOverride ?? defaultOnSync,
     isEnabled: () => {
       try {
         return getConfig(store.db, 'telemetry_sync_enabled') === 'true';
@@ -161,5 +249,10 @@ export function createDefaultScheduler(store: Store, onSync?: () => Promise<void
         return false;
       }
     },
-  });
+  };
+  if (minFromConfig !== undefined) schedulerOpts.minMinutes = minFromConfig;
+  if (maxFromConfig !== undefined) schedulerOpts.maxMinutes = maxFromConfig;
+
+  scheduler = new TelemetrySyncScheduler(schedulerOpts);
+  return scheduler;
 }

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -12,6 +12,39 @@ const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
+describe('TelemetryWriter — hook latency budget (Plan §18)', () => {
+  it('1000 writeTelemetry calls complete in under 500ms (avg <0.5ms/call)', async () => {
+    const { writeTelemetry } = await import('./TelemetryWriter.js');
+    const fs = await import('node:fs');
+    vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ size: 100 } as ReturnType<typeof fs.statSync>);
+
+    const start = Date.now();
+    for (let i = 0; i < 1000; i++) {
+      writeTelemetry('/tmp/proj', 'prompt_received', { promptCount: i });
+    }
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('writeTelemetry has no static dependency on the sync module — telemetry_sync_enabled does not alter the writer code path', async () => {
+    const { writeTelemetry } = await import('./TelemetryWriter.js');
+    const fs = await import('node:fs');
+    const appends: string[] = [];
+    vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => { appends.push(String(data)); });
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ size: 100 } as ReturnType<typeof fs.statSync>);
+
+    writeTelemetry('/tmp/proj', 'prompt_received', { promptCount: 1 });
+    expect(appends).toHaveLength(1);
+    const written = JSON.parse(appends[0].trim());
+    expect(written.event).toBe('prompt_received');
+  });
+});
+
 describe('TelemetryWriter — writeTelemetry', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -43,6 +43,30 @@ describe('TelemetryWriter — hook latency budget (Plan §18)', () => {
     const written = JSON.parse(appends[0].trim());
     expect(written.event).toBe('prompt_received');
   });
+
+  it('with a real store where telemetry_sync_enabled=true, 1000 writeTelemetry calls still complete in <500ms', async () => {
+    const { writeTelemetry } = await import('./TelemetryWriter.js');
+    const fs = await import('node:fs');
+    vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+    vi.spyOn(fs, 'statSync').mockReturnValue({ size: 100 } as ReturnType<typeof fs.statSync>);
+
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'telemetry_sync_enabled', 'true');
+      setConfig(store, 'telemetry.enabled',      'true');
+
+      const start = Date.now();
+      for (let i = 0; i < 1000; i++) {
+        writeTelemetry('/tmp/proj', 'prompt_received', { promptCount: i }, store);
+      }
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      store.db.close();
+    }
+  });
 });
 
 describe('TelemetryWriter — writeTelemetry', () => {

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -241,5 +241,57 @@ describe('TelemetryWriter — writeTelemetry', () => {
       expect(second['userId']).toBe(first['userId']);
       expect(second['teamId']).toBe(first['teamId']);
     });
+
+    it('still writes the record (without IDs) when identity-read throws', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+      const identity = await import('./identity.js');
+
+      let written = '';
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) written += String(data);
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      // Force the first identity getter to throw — exercises the
+      // try/catch fail-open path inside writeTelemetry.
+      vi.spyOn(identity, 'getInstallationId').mockImplementation(() => {
+        throw new Error('simulated config-read failure');
+      });
+
+      expect(() =>
+        writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store),
+      ).not.toThrow();
+
+      const parsed = JSON.parse(written.trim()) as Record<string, unknown>;
+      // Record still landed with core fields intact …
+      expect(parsed['event']).toBe('prompt_received');
+      expect(parsed['promptCount']).toBe(1);
+      // … but the 3 identity fields were skipped because the read failed.
+      expect(parsed).not.toHaveProperty('installationId');
+      expect(parsed).not.toHaveProperty('userId');
+      expect(parsed).not.toHaveProperty('teamId');
+    });
+
+    it('accepts undefined data plus store (stop.ts:91 stop_no_pending shape)', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      let written = '';
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) written += String(data);
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'stop_no_pending', undefined, store);
+
+      const parsed = JSON.parse(written.trim()) as Record<string, unknown>;
+      expect(parsed['event']).toBe('stop_no_pending');
+      expect(parsed['installationId']).toMatch(UUID_V4);
+      expect(parsed['userId']).toMatch(UUID_V4);
+      expect(parsed['teamId']).toMatch(UUID_V4);
+    });
   });
 });

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { openStore, type Store } from '../store/db.js';
+import { setConfig } from '../store/config.js';
 import { _resetIdentityCache } from './identity.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -292,6 +293,151 @@ describe('TelemetryWriter — writeTelemetry', () => {
       expect(parsed['installationId']).toMatch(UUID_V4);
       expect(parsed['userId']).toMatch(UUID_V4);
       expect(parsed['teamId']).toMatch(UUID_V4);
+    });
+  });
+
+  // ── telemetry.enabled gate (Phase 2) ─────────────────────────────────────────
+
+  describe('telemetry.enabled config gate', () => {
+    let store: Store;
+
+    beforeEach(async () => {
+      store = await openStore(':memory:');
+    });
+
+    afterEach(() => {
+      store.db.close();
+    });
+
+    it('writes happen by default when no config key is set (DEFAULT_CONFIG = true)', async () => {
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes happen when telemetry.enabled is explicitly set to "true"', async () => {
+      setConfig(store, 'telemetry.enabled', 'true');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes are silently skipped when telemetry.enabled is "false"', async () => {
+      setConfig(store, 'telemetry.enabled', 'false');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const mkdirSpy = vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+
+      expect(appendSpy).not.toHaveBeenCalled();
+      // Gate runs BEFORE rotate(), so mkdirSync should not run either.
+      expect(mkdirSpy).not.toHaveBeenCalled();
+    });
+
+    it('toggle false → true with cache reset resumes writes', async () => {
+      // Pull writeTelemetry AND _resetEnabledCache from the same fresh module
+      // instance — top-level imports are a different instance after resetModules.
+      const tw = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      // Step 1 — disabled, write skipped.
+      setConfig(store, 'telemetry.enabled', 'false');
+      tw.writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      expect(appendSpy).not.toHaveBeenCalled();
+
+      // Step 2 — flip to true; without cache reset the cached 'false' still wins.
+      setConfig(store, 'telemetry.enabled', 'true');
+      tw.writeTelemetry('/proj', 'prompt_received', { promptCount: 2 }, store);
+      expect(appendSpy).not.toHaveBeenCalled();
+
+      // Step 3 — reset cache; gate re-reads config and writes resume.
+      tw._resetEnabledCache();
+      tw.writeTelemetry('/proj', 'prompt_received', { promptCount: 3 }, store);
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('config read failure fails open — write still happens', async () => {
+      // Spy on the freshly-imported config module so the binding inside
+      // the freshly-imported TelemetryWriter sees the mock.
+      const config = await import('../store/config.js');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      // Make getConfig throw — isEnabled's try/catch should swallow and return true.
+      vi.spyOn(config, 'getConfig').mockImplementation(() => {
+        throw new Error('simulated config read failure');
+      });
+
+      expect(() =>
+        writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store),
+      ).not.toThrow();
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-store call bypasses the gate (fail-open — runLevel sites until Phase 3)', async () => {
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      // Even with telemetry.enabled='false' in the only known store, a writer
+      // call WITHOUT a store cannot check the gate — so it must still write.
+      setConfig(store, 'telemetry.enabled', 'false');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 });
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('cache avoids repeated config reads within the same process', async () => {
+      const config = await import('../store/config.js');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      const getConfigSpy = vi.spyOn(config, 'getConfig');
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      writeTelemetry('/proj', 'prompt_classified', { stage: 'planning' }, store);
+      writeTelemetry('/proj', 'absence_flags_detected', { newFlagsCount: 0 }, store);
+
+      // getConfig should only be called once for 'telemetry.enabled' — the cache
+      // serves subsequent isEnabled() invocations.
+      const enabledReads = getConfigSpy.mock.calls.filter(
+        (call) => call[1] === 'telemetry.enabled',
+      );
+      expect(enabledReads.length).toBe(1);
     });
   });
 });

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -1,19 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openStore, type Store } from '../store/db.js';
+import { _resetIdentityCache } from './identity.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return { ...actual };
 });
 
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('TelemetryWriter — writeTelemetry', () => {
   beforeEach(() => {
     vi.resetModules();
+    _resetIdentityCache();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    _resetIdentityCache();
   });
 
   it('creates the directory and writes on first call when file does not exist', async () => {
@@ -137,5 +143,103 @@ describe('TelemetryWriter — writeTelemetry', () => {
     const { TELEMETRY_PATH } = await import('./TelemetryWriter.js');
     expect(typeof TELEMETRY_PATH).toBe('string');
     expect(TELEMETRY_PATH).toContain('telemetry.jsonl');
+  });
+
+  // ── Identity-ID injection (Phase 1) ──────────────────────────────────────────
+
+  describe('identity-ID injection when store is provided', () => {
+    let store: Store;
+
+    beforeEach(async () => {
+      store = await openStore(':memory:');
+    });
+
+    afterEach(() => {
+      store.db.close();
+    });
+
+    it('record carries installationId, userId, teamId when store is passed', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      let written = '';
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) written += String(data);
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+
+      const parsed = JSON.parse(written.trim()) as Record<string, unknown>;
+      expect(parsed['installationId']).toMatch(UUID_V4);
+      expect(parsed['userId']).toMatch(UUID_V4);
+      expect(parsed['teamId']).toMatch(UUID_V4);
+    });
+
+    it('record omits identity IDs when store is NOT passed', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      let written = '';
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) written += String(data);
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 });
+
+      const parsed = JSON.parse(written.trim()) as Record<string, unknown>;
+      expect(parsed).not.toHaveProperty('installationId');
+      expect(parsed).not.toHaveProperty('userId');
+      expect(parsed).not.toHaveProperty('teamId');
+    });
+
+    it('IDs are stable across multiple writes within the same process', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const lines: string[] = [];
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) lines.push(String(data).trim());
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      writeTelemetry('/proj', 'prompt_classified', { stage: 'planning' }, store);
+
+      const a = JSON.parse(lines[0]) as Record<string, string>;
+      const b = JSON.parse(lines[1]) as Record<string, string>;
+      expect(a['installationId']).toBe(b['installationId']);
+      expect(a['userId']).toBe(b['userId']);
+      expect(a['teamId']).toBe(b['teamId']);
+    });
+
+    it('IDs persist across a simulated process restart (close + reopen)', async () => {
+      const { writeTelemetry, TELEMETRY_PATH } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const lines: string[] = [];
+      vi.spyOn(fs, 'appendFileSync').mockImplementation((_p, data) => {
+        if (_p === TELEMETRY_PATH) lines.push(String(data).trim());
+      });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      const first = JSON.parse(lines[0]) as Record<string, string>;
+
+      // Simulate restart: same in-memory DB, but identity cache wiped.
+      _resetIdentityCache();
+
+      writeTelemetry('/proj', 'prompt_classified', { stage: 'planning' }, store);
+      const second = JSON.parse(lines[1]) as Record<string, string>;
+
+      expect(second['installationId']).toBe(first['installationId']);
+      expect(second['userId']).toBe(first['userId']);
+      expect(second['teamId']).toBe(first['teamId']);
+    });
   });
 });

--- a/src/telemetry/TelemetryWriter.test.ts
+++ b/src/telemetry/TelemetryWriter.test.ts
@@ -496,5 +496,54 @@ describe('TelemetryWriter — writeTelemetry', () => {
       );
       expect(enabledReads.length).toBe(1);
     });
+
+    it('cache also serves disabled state — repeated writes with telemetry.enabled=false do not re-read config', async () => {
+      setConfig(store, 'telemetry.enabled', 'false');
+      const config = await import('../store/config.js');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      const getConfigSpy = vi.spyOn(config, 'getConfig');
+
+      writeTelemetry('/proj', 'prompt_received',   { promptCount: 1 }, store);
+      writeTelemetry('/proj', 'prompt_classified', { stage: 'planning' }, store);
+      writeTelemetry('/proj', 'absence_flags_detected', { newFlagsCount: 0 }, store);
+
+      expect(appendSpy).not.toHaveBeenCalled();
+      const enabledReads = getConfigSpy.mock.calls.filter(
+        (call) => call[1] === 'telemetry.enabled',
+      );
+      expect(enabledReads.length).toBe(1);
+    });
+
+    it('only the literal string "false" disables — empty string keeps writes enabled', async () => {
+      setConfig(store, 'telemetry.enabled', '');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('disable check is case-sensitive — "False" does NOT disable, only lowercase "false"', async () => {
+      setConfig(store, 'telemetry.enabled', 'False');
+      const { writeTelemetry } = await import('./TelemetryWriter.js');
+      const fs = await import('node:fs');
+
+      const appendSpy = vi.spyOn(fs, 'appendFileSync').mockImplementation(() => {});
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as never);
+
+      writeTelemetry('/proj', 'prompt_received', { promptCount: 1 }, store);
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/telemetry/TelemetryWriter.ts
+++ b/src/telemetry/TelemetryWriter.ts
@@ -2,6 +2,8 @@ import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'nod
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { TelemetryEventName } from './types.js';
+import type { Store } from '../store/db.js';
+import { getInstallationId, getUserId, getTeamId } from './identity.js';
 
 export const TELEMETRY_PATH = join(homedir(), '.nexpath', 'telemetry.jsonl');
 const MAX_BYTES = 5 * 1024 * 1024;
@@ -24,14 +26,25 @@ export function writeTelemetry(
   projectRoot: string,
   event:       TelemetryEventName,
   data?:       Record<string, unknown>,
+  store?:      Store,
 ): void {
-  const record = {
+  const record: Record<string, unknown> = {
     ts: new Date().toISOString(),
     v:  1 as const,
     projectRoot,
     event,
     ...data,
   };
+
+  if (store) {
+    try {
+      record['installationId'] = getInstallationId(store);
+      record['userId']         = getUserId(store);
+      record['teamId']         = getTeamId(store);
+    } catch {
+      // identity-read failure must never crash the hook — fall through without IDs
+    }
+  }
 
   try {
     rotate();

--- a/src/telemetry/TelemetryWriter.ts
+++ b/src/telemetry/TelemetryWriter.ts
@@ -1,12 +1,12 @@
 import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
+import { dirname } from 'node:path';
 import type { TelemetryEventName } from './types.js';
 import type { Store } from '../store/db.js';
 import { getConfig } from '../store/config.js';
 import { getInstallationId, getUserId, getTeamId } from './identity.js';
+import { TELEMETRY_PATH } from './paths.js';
 
-export const TELEMETRY_PATH = join(homedir(), '.nexpath', 'telemetry.jsonl');
+export { TELEMETRY_PATH };
 const MAX_BYTES = 5 * 1024 * 1024;
 
 // Module-level cache for the telemetry.enabled config value.

--- a/src/telemetry/TelemetryWriter.ts
+++ b/src/telemetry/TelemetryWriter.ts
@@ -3,10 +3,35 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { TelemetryEventName } from './types.js';
 import type { Store } from '../store/db.js';
+import { getConfig } from '../store/config.js';
 import { getInstallationId, getUserId, getTeamId } from './identity.js';
 
 export const TELEMETRY_PATH = join(homedir(), '.nexpath', 'telemetry.jsonl');
 const MAX_BYTES = 5 * 1024 * 1024;
+
+// Module-level cache for the telemetry.enabled config value.
+// Avoids a per-write SQL read; honours fail-open semantics if reading fails.
+let _enabledCache: string | null = null;
+
+function isEnabled(store?: Store): boolean {
+  // No store available (e.g. inner runLevel call sites until Phase 3) →
+  // fail-open: we cannot check the gate, so allow the write.
+  if (!store) return true;
+  if (_enabledCache !== null) return _enabledCache !== 'false';
+  try {
+    const v = getConfig(store.db, 'telemetry.enabled') ?? 'true';
+    _enabledCache = v;
+    return v !== 'false';
+  } catch {
+    // Config read failed — never crash the hook; default to enabled.
+    return true;
+  }
+}
+
+// Test-only — wipes the module-level cache so per-test isolation works.
+export function _resetEnabledCache(): void {
+  _enabledCache = null;
+}
 
 function rotate(): void {
   try {
@@ -28,6 +53,8 @@ export function writeTelemetry(
   data?:       Record<string, unknown>,
   store?:      Store,
 ): void {
+  if (!isEnabled(store)) return;   // silent skip when telemetry.enabled = 'false'
+
   const record: Record<string, unknown> = {
     ts: new Date().toISOString(),
     v:  1 as const,

--- a/src/telemetry/identity.test.ts
+++ b/src/telemetry/identity.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { openStore, type Store } from '../store/db.js';
+import { isConfigSet, getConfig } from '../store/config.js';
+import {
+  getInstallationId,
+  getUserId,
+  getTeamId,
+  _resetIdentityCache,
+} from './identity.js';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('telemetry — identity', () => {
+  let store: Store;
+
+  beforeEach(async () => {
+    _resetIdentityCache();
+    store = await openStore(':memory:');
+  });
+
+  afterEach(() => {
+    store.db.close();
+    _resetIdentityCache();
+  });
+
+  it('getInstallationId generates a UUID, persists it to config, and returns it', () => {
+    expect(isConfigSet(store.db, 'installation_id')).toBe(false);
+    const id = getInstallationId(store);
+    expect(id).toMatch(UUID_V4);
+    expect(isConfigSet(store.db, 'installation_id')).toBe(true);
+    expect(getConfig(store.db, 'installation_id')).toBe(id);
+  });
+
+  it('second call returns the cached value without regenerating', () => {
+    const first  = getInstallationId(store);
+    const second = getInstallationId(store);
+    expect(first).toBe(second);
+  });
+
+  it('existing config value is returned without regeneration', () => {
+    // Manually plant a known ID in config — should be picked up, not overwritten.
+    const planted = '11111111-2222-4333-8444-555555555555';
+    store.db.run(
+      'INSERT INTO config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value',
+      ['installation_id', planted],
+    );
+    expect(getInstallationId(store)).toBe(planted);
+  });
+
+  it('after cache reset, value is re-read from config (not regenerated)', () => {
+    const first = getInstallationId(store);
+    _resetIdentityCache();
+    const second = getInstallationId(store);
+    expect(second).toBe(first);
+  });
+
+  it('getUserId behaves identically — generates, persists, caches', () => {
+    expect(isConfigSet(store.db, 'user_id')).toBe(false);
+    const a = getUserId(store);
+    const b = getUserId(store);
+    expect(a).toMatch(UUID_V4);
+    expect(a).toBe(b);
+    expect(getConfig(store.db, 'user_id')).toBe(a);
+  });
+
+  it('getTeamId behaves identically — generates, persists, caches', () => {
+    expect(isConfigSet(store.db, 'team_id')).toBe(false);
+    const a = getTeamId(store);
+    const b = getTeamId(store);
+    expect(a).toMatch(UUID_V4);
+    expect(a).toBe(b);
+    expect(getConfig(store.db, 'team_id')).toBe(a);
+  });
+
+  it('installation/user/team IDs are independent values', () => {
+    const inst = getInstallationId(store);
+    const user = getUserId(store);
+    const team = getTeamId(store);
+    expect(new Set([inst, user, team]).size).toBe(3);
+  });
+
+  it('IDs persist across a simulated process restart (cache reset + same DB)', async () => {
+    const inst = getInstallationId(store);
+    const user = getUserId(store);
+    const team = getTeamId(store);
+
+    // Simulate restart — fresh cache, but config is still in :memory: store.
+    _resetIdentityCache();
+
+    expect(getInstallationId(store)).toBe(inst);
+    expect(getUserId(store)).toBe(user);
+    expect(getTeamId(store)).toBe(team);
+  });
+});

--- a/src/telemetry/identity.ts
+++ b/src/telemetry/identity.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from 'node:crypto';
+import { getConfig, setConfig } from '../store/config.js';
+import type { Store } from '../store/db.js';
+
+const KEY_INSTALLATION = 'installation_id';
+const KEY_USER         = 'user_id';
+const KEY_TEAM         = 'team_id';
+
+// Module-level cache — avoid repeated config reads per process.
+let _installCache: string | null = null;
+let _userCache:    string | null = null;
+let _teamCache:    string | null = null;
+
+function getOrCreate(
+  store: Store,
+  key:   string,
+  cache: string | null,
+): { value: string; cache: string } {
+  if (cache) return { value: cache, cache };
+  const existing = getConfig(store.db, key);
+  if (existing) return { value: existing, cache: existing };
+  const fresh = randomUUID();
+  setConfig(store, key, fresh);
+  return { value: fresh, cache: fresh };
+}
+
+export function getInstallationId(store: Store): string {
+  const r = getOrCreate(store, KEY_INSTALLATION, _installCache);
+  _installCache = r.cache;
+  return r.value;
+}
+
+export function getUserId(store: Store): string {
+  const r = getOrCreate(store, KEY_USER, _userCache);
+  _userCache = r.cache;
+  return r.value;
+}
+
+export function getTeamId(store: Store): string {
+  const r = getOrCreate(store, KEY_TEAM, _teamCache);
+  _teamCache = r.cache;
+  return r.value;
+}
+
+// Test-only — clears module-level cache so per-test isolation works.
+export function _resetIdentityCache(): void {
+  _installCache = null;
+  _userCache    = null;
+  _teamCache    = null;
+}

--- a/src/telemetry/paths.ts
+++ b/src/telemetry/paths.ts
@@ -5,4 +5,5 @@ export const TELEMETRY_DIR = join(homedir(), '.nexpath');
 export const TELEMETRY_PATH = join(TELEMETRY_DIR, 'telemetry.jsonl');
 export const TELEMETRY_ROTATED_PATH = `${TELEMETRY_PATH}.1`;
 export const TELEMETRY_SYNC_CURSOR_PATH = join(TELEMETRY_DIR, 'telemetry-sync-cursor.json');
-export const TELEMETRY_SYNC_STATE_PATH = join(TELEMETRY_DIR, 'telemetry-sync-state.json');
+export const TELEMETRY_SYNC_STATE_PATH      = join(TELEMETRY_DIR, 'telemetry-sync-state.json');
+export const TELEMETRY_SYNC_ERROR_LOG_PATH  = join(TELEMETRY_DIR, 'telemetry-sync-errors.log');

--- a/src/telemetry/paths.ts
+++ b/src/telemetry/paths.ts
@@ -5,3 +5,4 @@ export const TELEMETRY_DIR = join(homedir(), '.nexpath');
 export const TELEMETRY_PATH = join(TELEMETRY_DIR, 'telemetry.jsonl');
 export const TELEMETRY_ROTATED_PATH = `${TELEMETRY_PATH}.1`;
 export const TELEMETRY_SYNC_CURSOR_PATH = join(TELEMETRY_DIR, 'telemetry-sync-cursor.json');
+export const TELEMETRY_SYNC_STATE_PATH = join(TELEMETRY_DIR, 'telemetry-sync-state.json');

--- a/src/telemetry/paths.ts
+++ b/src/telemetry/paths.ts
@@ -1,0 +1,7 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const TELEMETRY_DIR = join(homedir(), '.nexpath');
+export const TELEMETRY_PATH = join(TELEMETRY_DIR, 'telemetry.jsonl');
+export const TELEMETRY_ROTATED_PATH = `${TELEMETRY_PATH}.1`;
+export const TELEMETRY_SYNC_CURSOR_PATH = join(TELEMETRY_DIR, 'telemetry-sync-cursor.json');

--- a/src/telemetry/recent-prompts.test.ts
+++ b/src/telemetry/recent-prompts.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import type { PromptRecord } from '../classifier/types.js';
+import type { Stage } from '../classifier/types.js';
+import { recentPromptMetadata } from './recent-prompts.js';
+
+function makePrompt(i: number, overrides: Partial<PromptRecord> = {}): PromptRecord {
+  return {
+    index:           i,
+    text:            `prompt text #${i} — should NEVER appear in telemetry`,
+    capturedAt:      1_700_000_000_000 + i * 1000,
+    classifiedStage: 'implementation' as Stage,
+    confidence:      0.85,
+    ...overrides,
+  };
+}
+
+describe('telemetry — recentPromptMetadata', () => {
+  it('returns empty array when history is empty', () => {
+    expect(recentPromptMetadata([])).toEqual([]);
+  });
+
+  it('returns all entries when history has fewer than 5', () => {
+    const history = [1, 2, 3].map((i) => makePrompt(i));
+    const result = recentPromptMetadata(history);
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => p.index)).toEqual([1, 2, 3]);
+  });
+
+  it('returns exactly the LAST 5 when history has more than 5', () => {
+    const history = Array.from({ length: 12 }, (_, i) => makePrompt(i + 1));
+    const result = recentPromptMetadata(history);
+    expect(result).toHaveLength(5);
+    expect(result.map((p) => p.index)).toEqual([8, 9, 10, 11, 12]);
+  });
+
+  it('preserves index, classifiedStage, confidence, capturedAt verbatim', () => {
+    const history = [makePrompt(7, { confidence: 0.42, classifiedStage: 'planning' as Stage })];
+    const result = recentPromptMetadata(history);
+    expect(result[0]).toEqual({
+      index:           7,
+      classifiedStage: 'planning',
+      confidence:      0.42,
+      capturedAt:      1_700_000_007_000,
+    });
+  });
+
+  it('NEVER includes the text field — PII safety guarantee', () => {
+    const history = Array.from({ length: 5 }, (_, i) => makePrompt(i + 1));
+    const result = recentPromptMetadata(history);
+    for (const entry of result) {
+      expect(entry).not.toHaveProperty('text');
+    }
+  });
+
+  it('coerces undefined classifiedStage / confidence to null (defensive)', () => {
+    // Build a record with the optional fields undefined — possible in some
+    // edge cases (e.g. partial classifier failure). The contract is
+    // "metadata is always shaped; missing fields become null on the wire".
+    const partial = {
+      index:      1,
+      text:       'x',
+      capturedAt: 1,
+    } as unknown as PromptRecord;
+    const result = recentPromptMetadata([partial]);
+    expect(result[0].classifiedStage).toBeNull();
+    expect(result[0].confidence).toBeNull();
+  });
+
+  it('does not mutate the input array', () => {
+    const history = [1, 2, 3, 4, 5, 6, 7].map((i) => makePrompt(i));
+    const before = history.length;
+    recentPromptMetadata(history);
+    expect(history.length).toBe(before);
+  });
+});

--- a/src/telemetry/recent-prompts.ts
+++ b/src/telemetry/recent-prompts.ts
@@ -1,0 +1,28 @@
+import type { PromptRecord } from '../classifier/types.js';
+
+/**
+ * Wire-format shape of a single recent-prompt entry inside a telemetry payload.
+ * Deliberately omits `text` — raw prompt content stays in `prompts` table only.
+ */
+export interface RecentPromptMetadata {
+  index:           number;
+  classifiedStage: string | null;
+  confidence:      number | null;
+  capturedAt:      number;
+}
+
+/**
+ * Returns up to the last 5 prompts from a session's promptHistory, projected
+ * to a PII-safe metadata shape. Used by `pipeline_advisory_pending` and
+ * `decision_session_started` events to give server-side aggregation enough
+ * context without exposing prompt text.
+ */
+export function recentPromptMetadata(history: PromptRecord[]): RecentPromptMetadata[] {
+  return history.slice(-5).map((p) => ({
+    index:           p.index,
+    classifiedStage: p.classifiedStage ?? null,
+    confidence:      p.confidence ?? null,
+    capturedAt:      p.capturedAt,
+    // text: INTENTIONALLY EXCLUDED — PII stays local in prompts table.
+  }));
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -45,3 +45,11 @@ export interface CursorState {
   offset:         number;
   last_synced_ts: string | null;
 }
+
+export interface SyncState {
+  next_sync_at:         string | null;
+  last_attempt_at:      string | null;
+  last_success_at:      string | null;
+  last_error:           string | null;
+  consecutive_failures: number;
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -23,7 +23,11 @@ export type TelemetryEventName =
   | 'decision_session_dismissed'
   | 'decision_session_sim_dismissed'
   // Language detection
-  | 'language_detected';
+  | 'language_detected'
+  // Sync self-events
+  | 'telemetry_sync_attempt'
+  | 'telemetry_sync_success'
+  | 'telemetry_sync_failed';
 
 export interface TelemetryEvent {
   ts:              string;
@@ -52,4 +56,16 @@ export interface SyncState {
   last_success_at:      string | null;
   last_error:           string | null;
   consecutive_failures: number;
+}
+
+export interface PostHogEvent {
+  event:       string;
+  distinct_id: string;
+  timestamp:   string;
+  properties:  Record<string, unknown>;
+}
+
+export interface PostHogBatchEnvelope {
+  api_key: string;
+  batch:   PostHogEvent[];
 }

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -39,3 +39,9 @@ export interface TelemetryEvent {
   event:           TelemetryEventName;
   [key: string]:   unknown;
 }
+
+export interface CursorState {
+  inode:          number;
+  offset:         number;
+  last_synced_ts: string | null;
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -58,14 +58,10 @@ export interface SyncState {
   consecutive_failures: number;
 }
 
-export interface PostHogEvent {
+export interface PostHogSingleEnvelope {
+  api_key:     string;
   event:       string;
   distinct_id: string;
   timestamp:   string;
   properties:  Record<string, unknown>;
-}
-
-export interface PostHogBatchEnvelope {
-  api_key: string;
-  batch:   PostHogEvent[];
 }

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -26,9 +26,16 @@ export type TelemetryEventName =
   | 'language_detected';
 
 export interface TelemetryEvent {
-  ts:          string;
-  v:           1;
-  projectRoot: string;
-  event:       TelemetryEventName;
-  [key: string]: unknown;
+  ts:              string;
+  v:               1;
+  // Identity IDs are present on every record once Phase 1 wiring lands at all
+  // call sites. They remain optional in the type because some inner call sites
+  // (e.g. DecisionSession.runLevel) do not yet receive the store handle — that
+  // wiring lands in Phase 3.
+  installationId?: string;
+  userId?:         string;
+  teamId?:         string;
+  projectRoot:     string;
+  event:           TelemetryEventName;
+  [key: string]:   unknown;
 }


### PR DESCRIPTION
 - `nexpath install` now asks a single telemetry question that flips both local capture and server sync — users no longer need to run `telemetry-sync enable`
  separately.
  - Saying "No" is a full stop: no capture, no server traffic.
  - `nexpath uninstall` clears both flags symmetrically.
  - Legacy installs (only `telemetry.enabled` set) auto-resume syncing via a scheduler fallback — no migration needed.
