### PR TITLE
Update popup wordmark to N E X P A T H  C L I

### DIFF
--- a/src/decision-session/DecisionSession.ts
+++ b/src/decision-session/DecisionSession.ts
@@ -50,16 +50,16 @@ const BOLD         = '\x1b[1m';
 /**
  * Branded Nexpath wordmark, shown at the top of every popup window.
  *
- *   ▲  N E X P A T H
- *   ─────────────────
+ *   ▲  N E X P A T H  C L I
+ *   ────────────────────────
  *
  * Triangle bold bright cyan, wordmark bold bright white with 2-space
  * tracking, rule dim gray. Trailing blank line gives breathing room
  * before the clack prompt area starts rendering.
  */
 export const NEXPATH_HEADER =
-  `${BOLD_CYAN}▲${RESET}  ${BOLD_WHITE}N E X P A T H${RESET}\n` +
-  `${DIM_GRAY}─────────────────${RESET}\n\n`;
+  `${BOLD_CYAN}▲${RESET}  ${BOLD_WHITE}N E X P A T H  C L I${RESET}\n` +
+  `${DIM_GRAY}────────────────────────${RESET}\n\n`;
 
 /** Visible row count the header consumes — wordmark (1) + rule (1) + blank (1). */
 export const NEXPATH_HEADER_LINES = 3;

--- a/src/decision-session/TtySelectFn.test.ts
+++ b/src/decision-session/TtySelectFn.test.ts
@@ -1168,7 +1168,7 @@ describe('Regression: .mjs script content is platform-consistent', () => {
       expect(script).toContain('emitKeypressEvents');
       // Branded Nexpath wordmark header must be written to stdout before the prompt renders.
       expect(script).toContain('process.stdout.write(');
-      expect(script).toContain('N E X P A T H');
+      expect(script).toContain('N E X P A T H  C L I');
     }
 
     // Clipboard differs: Linux has xclip chain, macOS has pbcopy

--- a/src/decision-session/decision-session.test.ts
+++ b/src/decision-session/decision-session.test.ts
@@ -2261,8 +2261,8 @@ describe('NEXPATH_HEADER', () => {
     expect(NEXPATH_HEADER).toContain('▲');
   });
 
-  it('contains the tracked wordmark "N E X P A T H"', () => {
-    expect(NEXPATH_HEADER).toContain('N E X P A T H');
+  it('contains the tracked wordmark "N E X P A T H  C L I"', () => {
+    expect(NEXPATH_HEADER).toContain('N E X P A T H  C L I');
   });
 
   it('contains a dim-gray horizontal rule line', () => {


### PR DESCRIPTION
Extend the tracked wordmark in NEXPATH_HEADER from "N E X P A T H" to "N E X P A T H  C L I" and widen the dim-gray rule to span under the new wordmark. The constant is shared by all four spawned popup windows (decision session, root chooser, frequency sub-menu, role sub-menu), so the new title renders consistently everywhere via a single source.

Header line count stays at 3, so option-budget calculations in TtySelectFn need no change. JSDoc ASCII diagram updated to match.

Strengthens the wordmark substring assertions in the matching tests to the full new string so a future revert is caught.