### PR TITLE
feat(telemetry): opportunistic sync from auto and stop hooks

### DIFF
--- a/src/cli/commands/auto.ts
+++ b/src/cli/commands/auto.ts
@@ -27,6 +27,7 @@ import { writeHookStats } from '../../store/hook-stats.js';
 import { upsertPendingAdvisory } from '../../store/pending-advisories.js';
 import { insertSkippedSession } from '../../store/skipped-sessions.js';
 import { writeTelemetry } from '../../telemetry/index.js';
+import { triggerOpportunisticSync } from '../../telemetry/OpportunisticSync.js';
 import { resolveFrequencyConfig, type AdvisoryFrequencyLevel } from '../../config/GlobalConfig.js';
 import { recentPromptMetadata } from '../../telemetry/recent-prompts.js';
 
@@ -509,6 +510,7 @@ export function registerAutoCommand(program: import('commander').Command): void 
         );
 
         writeHookStats(opts.project, result.outcome);
+        void triggerOpportunisticSync(store).catch(() => {});
         // 'no_action' and 'pending' → exit silently (Stop hook handles UI)
       } finally {
         closeStore(store);

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -15,6 +15,7 @@ import { logger, initLogger } from '../../logger.js';
 import type { LogLevel } from '../../logger.js';
 import { writeHookStats } from '../../store/hook-stats.js';
 import { writeTelemetry } from '../../telemetry/index.js';
+import { triggerOpportunisticSync } from '../../telemetry/OpportunisticSync.js';
 import { recentPromptMetadata } from '../../telemetry/recent-prompts.js';
 import { readStdin } from './auto.js';
 import { resolveDecisionContent } from '../../decision-session/options.js';
@@ -261,6 +262,7 @@ export function registerStopCommand(program: import('commander').Command): void 
             process.stderr.write('\n[nexpath] Copied to clipboard — paste and edit in Claude terminal\n');
           }
         }
+        void triggerOpportunisticSync(store).catch(() => {});
         // All other outcomes → exit 0 (Claude stops normally)
       } finally {
         closeStore(store);

--- a/src/telemetry/OpportunisticSync.test.ts
+++ b/src/telemetry/OpportunisticSync.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openStore, closeStore, setConfig } from '../store/index.js';
+import type { Store } from '../store/db.js';
+import { triggerOpportunisticSync } from './OpportunisticSync.js';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('./TelemetrySyncRunner.js', () => ({
+  runSyncAttempt: vi.fn(),
+}));
+
+vi.mock('./TelemetrySyncScheduler.js', () => ({
+  loadSyncState: vi.fn(),
+  saveSyncState: vi.fn(),
+}));
+
+import { runSyncAttempt } from './TelemetrySyncRunner.js';
+import { loadSyncState, saveSyncState } from './TelemetrySyncScheduler.js';
+
+const mockedRunSyncAttempt = vi.mocked(runSyncAttempt);
+const mockedLoadSyncState  = vi.mocked(loadSyncState);
+const mockedSaveSyncState  = vi.mocked(saveSyncState);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let store: Store;
+let tmpDir: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  store = await openStore(':memory:');
+  tmpDir   = mkdtempSync(join(tmpdir(), 'opportunistic-sync-test-'));
+  lockPath = join(tmpDir, 'sync.lock');
+  mockedRunSyncAttempt.mockReset();
+  mockedLoadSyncState.mockReset();
+  mockedSaveSyncState.mockReset();
+  mockedLoadSyncState.mockReturnValue(null);
+  mockedRunSyncAttempt.mockResolvedValue({
+    status:                   'ok',
+    sentEvents:               1,
+    consecutiveFailuresAfter: 0,
+    shouldDisableSync:        false,
+  });
+});
+
+afterEach(() => {
+  closeStore(store);
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function enableSync(): void {
+  setConfig(store, 'telemetry_sync_enabled', 'true');
+  setConfig(store, 'telemetry_sync_api_key', 'phc_test_key');
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('triggerOpportunisticSync', () => {
+  it('skips when telemetry_sync_enabled is not "true"', async () => {
+    setConfig(store, 'telemetry_sync_api_key', 'phc_test_key');
+    // sync flag intentionally NOT set
+
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(mockedRunSyncAttempt).not.toHaveBeenCalled();
+    expect(mockedSaveSyncState).not.toHaveBeenCalled();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('skips when api_key is missing', async () => {
+    setConfig(store, 'telemetry_sync_enabled', 'true');
+    // api_key intentionally NOT set — but DEFAULT_CONFIG ships one, so override empty
+    setConfig(store, 'telemetry_sync_api_key', '');
+
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(mockedRunSyncAttempt).not.toHaveBeenCalled();
+    expect(mockedSaveSyncState).not.toHaveBeenCalled();
+  });
+
+  it('fires sync on every call when guards 1+2 pass and no lock contention', async () => {
+    enableSync();
+
+    await triggerOpportunisticSync(store, { lockPath });
+    await triggerOpportunisticSync(store, { lockPath });
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(mockedRunSyncAttempt).toHaveBeenCalledTimes(3);
+    expect(mockedSaveSyncState).toHaveBeenCalledTimes(3);
+  });
+
+  it('acquires and releases the lock around the sync call', async () => {
+    enableSync();
+
+    let lockExistedDuringSync = false;
+    mockedRunSyncAttempt.mockImplementationOnce(async () => {
+      lockExistedDuringSync = existsSync(lockPath);
+      return {
+        status:                   'ok',
+        sentEvents:               1,
+        consecutiveFailuresAfter: 0,
+        shouldDisableSync:        false,
+      };
+    });
+
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(lockExistedDuringSync).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('skips when lock file is held by another process and fresh (< 60s old)', async () => {
+    enableSync();
+    writeFileSync(lockPath, '99999');  // simulate another process's lock
+
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(mockedRunSyncAttempt).not.toHaveBeenCalled();
+    // Original lock must be untouched
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, 'utf8')).toBe('99999');
+  });
+
+  it('overwrites stale lock file older than 60s and proceeds with sync', async () => {
+    enableSync();
+    writeFileSync(lockPath, '99999');
+    // Backdate lock file to 2 minutes ago
+    const twoMinAgoSec = Math.floor(Date.now() / 1000) - 120;
+    utimesSync(lockPath, twoMinAgoSec, twoMinAgoSec);
+
+    await triggerOpportunisticSync(store, { lockPath });
+
+    expect(mockedRunSyncAttempt).toHaveBeenCalledTimes(1);
+    // After successful sync, lock should be released
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('silently catches all errors — never throws', async () => {
+    enableSync();
+    mockedRunSyncAttempt.mockRejectedValueOnce(new Error('PostHog exploded'));
+
+    await expect(triggerOpportunisticSync(store, { lockPath })).resolves.toBeUndefined();
+    // Lock must still be released after error
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/src/telemetry/OpportunisticSync.ts
+++ b/src/telemetry/OpportunisticSync.ts
@@ -1,0 +1,108 @@
+import { closeSync, openSync, statSync, unlinkSync, writeSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Store } from '../store/db.js';
+import { getConfig, setConfig } from '../store/config.js';
+import { DEFAULT_POSTHOG_ENDPOINT } from './TelemetryClient.js';
+import { runSyncAttempt } from './TelemetrySyncRunner.js';
+import { loadSyncState, saveSyncState } from './TelemetrySyncScheduler.js';
+
+const SYNC_LOCK_PATH       = join(homedir(), '.nexpath', 'sync.lock');
+const DEFAULT_STALE_LOCK_MS = 60_000;
+
+export interface OpportunisticSyncOptions {
+  lockStaleMs?: number;
+  now?:         () => number;
+  lockPath?:    string;
+}
+
+/**
+ * Fire one sync attempt opportunistically from the auto/stop hooks.
+ *
+ * Guards (skip-and-return on any):
+ *   1. telemetry_sync_enabled !== 'true'
+ *   2. telemetry_sync_api_key missing
+ *   3. another process already holds the cross-process lock (and lock is fresh)
+ *
+ * Hook-safety contract: this function NEVER throws. All errors are swallowed
+ * by an outer try/catch so the caller's hook UX is never blocked by a
+ * telemetry failure.
+ *
+ * Callers should invoke as `void triggerOpportunisticSync(store).catch(() => {})`
+ * to also defend against a synchronous throw before the outer try begins.
+ */
+export async function triggerOpportunisticSync(
+  store: Store,
+  opts:  OpportunisticSyncOptions = {},
+): Promise<void> {
+  const lockPath     = opts.lockPath    ?? SYNC_LOCK_PATH;
+  const lockStaleMs  = opts.lockStaleMs ?? DEFAULT_STALE_LOCK_MS;
+  const now          = opts.now         ?? (() => Date.now());
+
+  let lockHeld = false;
+  try {
+    if (getConfig(store.db, 'telemetry_sync_enabled') !== 'true') return;
+
+    const apiKey = getConfig(store.db, 'telemetry_sync_api_key');
+    if (!apiKey) return;
+
+    if (!acquireLock(lockPath, lockStaleMs, now)) return;
+    lockHeld = true;
+
+    const endpoint = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    const state    = loadSyncState();
+    const before   = state?.consecutive_failures ?? 0;
+
+    const result = await runSyncAttempt({ apiKey, endpoint }, before);
+
+    const nowIso = new Date(now()).toISOString();
+    saveSyncState({
+      next_sync_at:         state?.next_sync_at ?? null,
+      last_attempt_at:      nowIso,
+      last_success_at:      result.status === 'ok' ? nowIso : (state?.last_success_at ?? null),
+      last_error:           result.status === 'ok' ? null : `sync_${result.status}`,
+      consecutive_failures: result.consecutiveFailuresAfter,
+    });
+
+    if (result.shouldDisableSync) {
+      try { setConfig(store, 'telemetry_sync_enabled', 'false'); } catch { /* never propagate */ }
+    }
+  } catch {
+    // Hook UX must never be blocked by a telemetry failure.
+  } finally {
+    if (lockHeld) {
+      try { unlinkSync(lockPath); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Atomic cross-process lock acquire via O_CREAT | O_EXCL ('wx' flag).
+ * Returns true on success, false if another process holds a fresh lock.
+ * Overwrites a stale lock (older than lockStaleMs) and acquires it.
+ */
+function acquireLock(lockPath: string, lockStaleMs: number, now: () => number): boolean {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(lockPath, 'wx');
+      try { writeSync(fd, String(process.pid)); } catch { /* best-effort pid write */ }
+      closeSync(fd);
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return false;
+      // EEXIST — check if the existing lock is stale
+      try {
+        const age = now() - statSync(lockPath).mtimeMs;
+        if (age > lockStaleMs) {
+          unlinkSync(lockPath);
+          continue;  // retry once
+        }
+      } catch {
+        // Lock file disappeared between EEXIST and statSync — retry
+        continue;
+      }
+      return false;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Telemetry sync currently only runs on its scheduled cadence, so events can sit
locally until the next sync window. This change adds an opportunistic sync that
piggybacks on the `auto` and `stop` Claude Code hooks, flushing pending
telemetry as part of normal hook execution. The result is fresher telemetry
with no new background process and no change in behaviour when sync is disabled.

## Changes

- Add `src/telemetry/OpportunisticSync.ts` exporting `triggerOpportunisticSync(store, opts?)`.
- Wire a fire-and-forget call into both hooks:
  - `src/cli/commands/auto.ts` - after `writeHookStats(...)`
  - `src/cli/commands/stop.ts` - after the clipboard/UI branch
- Both call sites use `void triggerOpportunisticSync(store).catch(() => {})`, so a
  synchronous throw can never bubble into the hook.

## How it works

`triggerOpportunisticSync` skips and returns early on any of three guards:

1. `telemetry_sync_enabled` is not `'true'`
2. `telemetry_sync_api_key` is missing
3. Another process already holds a fresh cross-process lock

When the guards pass it acquires an atomic cross-process lock
(`openSync(path, 'wx')`, i.e. `O_CREAT | O_EXCL`) at `~/.nexpath/sync.lock`,
runs a single `runSyncAttempt`, persists the updated sync state
(`last_attempt_at`, `last_success_at`, `last_error`, `consecutive_failures`),
and auto-disables sync if the runner reports `shouldDisableSync`. A lock older
than 60s is treated as stale, overwritten, and reacquired. The lock path, stale
threshold, and clock are injectable via `opts` for testing.

## Safety

- Hook-safety contract: the function never throws. All errors are swallowed by an
  outer try/catch, and the lock is always released in `finally`, so a telemetry
  failure can never block or slow the hook UX.
- Stale-lock recovery (60s) prevents a crashed process from permanently blocking sync.

## Testing

Adds `src/telemetry/OpportunisticSync.test.ts` (7 cases) covering:

- skip when sync is disabled
- skip when the API key is missing
- fires on every eligible call
- acquires the lock during sync and releases it afterwards
- skips when a fresh lock is held by another process
- overwrites a stale (>60s) lock and proceeds
- swallows runner errors and still releases the lock

## Notes

Purely additive - no existing lines removed, no behaviour change when telemetry
sync is off.