### PR TITLE
Simplify advisory-frequency popup to three rungs (High/Medium/Low)

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -451,11 +451,15 @@ const defaultFreqPrompt: FreqPromptFn = async (currentValue) =>
     message: 'Advisory frequency — choose how often nexpath should surface advisories',
     initialValue: currentValue,
     options: [
-      { value: 'optimum',          label: 'Optimum — frequent advisories' },
-      { value: 'every_event',      label: 'Every qualifying event' },
-      { value: 'major_only',       label: 'Major transitions only' },
-      { value: 'once_per_session', label: 'Once per coding session' },
-      { value: 'off',              label: 'Off — disable all advisories' },
+      // Active picker options: simple High / Medium / Low labels.
+      { value: 'optimum',     label: 'High' },
+      { value: 'every_event', label: 'Medium' },
+      { value: 'major_only',  label: 'Low' },
+      // The two entries below stay valid via the CLI (nexpath config set
+      // advisory_frequency once_per_session / off) and are still honoured by
+      // the gating logic — they are intentionally hidden from this picker.
+      // { value: 'once_per_session', label: 'Once per coding session' },
+      // { value: 'off',              label: 'Off — disable all advisories' },
     ],
   });
 

--- a/src/decision-session/TtySelectFn.test.ts
+++ b/src/decision-session/TtySelectFn.test.ts
@@ -1308,7 +1308,7 @@ describe('runCtrlTRootChooser (Unix path)', () => {
     trigger('1');
     const rendered = writes.join('');
     expect(rendered).toContain('Advisory frequency');
-    expect(rendered).toContain('Optimum');
+    expect(rendered).toContain('High');
     expect(cleanup).not.toHaveBeenCalled();
   });
 
@@ -1356,7 +1356,7 @@ describe('runCtrlTRootChooser (Unix path)', () => {
 });
 
 describe('runFrequencySubMenu (Unix path)', () => {
-  it('renders all five frequency options including optimum and excludes the legacy role entry', async () => {
+  it('renders the three visible frequency options including the High rung and excludes the legacy role entry', async () => {
     const store = await openStore(':memory:');
     try {
       const { writes, streams } = makeFakeStreams();
@@ -1364,19 +1364,19 @@ describe('runFrequencySubMenu (Unix path)', () => {
       const cleanup = vi.fn();
       runFrequencySubMenu(streams, iface, store, '/proj/freq', cleanup);
       const rendered = writes.join('');
-      expect(rendered).toContain('Every qualifying event');
-      expect(rendered).toContain('Optimum');
-      expect(rendered).toContain('Major transitions only');
-      expect(rendered).toContain('Once per coding session');
-      expect(rendered).toContain('Off');
+      expect(rendered).toContain('High');
+      expect(rendered).toContain('Medium');
+      expect(rendered).toContain('Low');
+      expect(rendered).not.toContain('Once per coding session');
+      expect(rendered).not.toContain('Off — disable all advisories');
       expect(rendered).not.toContain('Configure role');
-      expect(rendered).toContain('Select (1-5)');
-      // optimum is the first option; every_event is second
+      expect(rendered).toContain('Select (1-3)');
+      // High (optimum) is the first option; Medium (every_event) is second
       const lines = rendered.split('\n');
-      const optimumIdx = lines.findIndex((l) => l.includes('Optimum'));
-      const everyIdx = lines.findIndex((l) => l.includes('Every qualifying event'));
-      expect(optimumIdx).toBeGreaterThanOrEqual(0);
-      expect(everyIdx).toBeGreaterThan(optimumIdx);
+      const highIdx = lines.findIndex((l) => l.includes('High'));
+      const mediumIdx = lines.findIndex((l) => l.includes('Medium'));
+      expect(highIdx).toBeGreaterThanOrEqual(0);
+      expect(mediumIdx).toBeGreaterThan(highIdx);
       // parenthetical descriptors removed from labels
       expect(rendered).not.toContain('(3–5 prompts)');
       expect(rendered).not.toContain('(stage changes)');
@@ -1394,9 +1394,9 @@ describe('runFrequencySubMenu (Unix path)', () => {
       const { iface } = makeFakeInterface();
       runFrequencySubMenu(streams, iface, store, '/proj/freq2', vi.fn());
       const rendered = writes.join('');
-      const optimumLine = rendered.split('\n').find((line) => line.includes('Optimum'));
-      expect(optimumLine).toBeDefined();
-      expect(optimumLine).toContain('(current)');
+      const highLine = rendered.split('\n').find((line) => line.includes('High'));
+      expect(highLine).toBeDefined();
+      expect(highLine).toContain('(current)');
     } finally {
       store.db.close();
     }
@@ -1440,9 +1440,37 @@ describe('runFrequencySubMenu (Unix path)', () => {
       const { iface } = makeFakeInterface();
       runFrequencySubMenu(streams, iface, store, '/proj/freq5', vi.fn());
       const rendered = writes.join('');
-      const majorLine = rendered.split('\n').find((line) => line.includes('Major transitions only'));
-      expect(majorLine).toBeDefined();
-      expect(majorLine).toContain('(current)');
+      const lowLine = rendered.split('\n').find((line) => line.includes('Low'));
+      expect(lowLine).toBeDefined();
+      expect(lowLine).toContain('(current)');
+    } finally {
+      store.db.close();
+    }
+  });
+
+  it('hides once_per_session and off labels from the visible popup options', async () => {
+    const store = await openStore(':memory:');
+    try {
+      const { writes, streams } = makeFakeStreams();
+      const { iface } = makeFakeInterface();
+      runFrequencySubMenu(streams, iface, store, '/proj/freq_hidden', vi.fn());
+      const rendered = writes.join('');
+      expect(rendered).not.toContain('Once per coding session');
+      expect(rendered).not.toContain('Off — disable all advisories');
+    } finally {
+      store.db.close();
+    }
+  });
+
+  it('preserves a CLI-set once_per_session value even though the popup hides that option', async () => {
+    const store = await openStore(':memory:');
+    try {
+      setConfig(store, 'advisory_frequency:/proj/freq_cliset', 'once_per_session');
+      const { iface } = makeFakeInterface();
+      const { streams } = makeFakeStreams();
+      const onDone = vi.fn();
+      runFrequencySubMenu(streams, iface, store, '/proj/freq_cliset', onDone);
+      expect(getConfig(store.db, 'advisory_frequency:/proj/freq_cliset')).toBe('once_per_session');
     } finally {
       store.db.close();
     }

--- a/src/decision-session/TtySelectFn.ts
+++ b/src/decision-session/TtySelectFn.ts
@@ -190,11 +190,15 @@ const picked = await select({
   message: 'Advisory frequency',
   initialValue: ${JSON.stringify(currentFreq)},
   options: [
-    { value: 'optimum',          label: 'Optimum \\u2014 frequent advisories' },
-    { value: 'every_event',      label: 'Every qualifying event' },
-    { value: 'major_only',       label: 'Major transitions only' },
-    { value: 'once_per_session', label: 'Once per coding session' },
-    { value: 'off',              label: 'Off \\u2014 disable all advisories' },
+    // Active popup options: simple High / Medium / Low labels.
+    { value: 'optimum',          label: 'High' },
+    { value: 'every_event',      label: 'Medium' },
+    { value: 'major_only',       label: 'Low' },
+    // The two entries below stay valid via the CLI (nexpath config set
+    // advisory_frequency once_per_session / off) and are still honoured by
+    // the gating logic — they are intentionally hidden from this popup.
+    // { value: 'once_per_session', label: 'Once per coding session' },
+    // { value: 'off',              label: 'Off \\u2014 disable all advisories' },
   ],
 });
 
@@ -902,11 +906,15 @@ export function runFrequencySubMenu(
 ): void {
   const currentFreq = readCurrentFreq(store, projectRoot);
   const freqOptions = [
-    { num: 1, value: 'optimum',          label: 'Optimum — frequent advisories' },
-    { num: 2, value: 'every_event',      label: 'Every qualifying event' },
-    { num: 3, value: 'major_only',       label: 'Major transitions only' },
-    { num: 4, value: 'once_per_session', label: 'Once per coding session' },
-    { num: 5, value: 'off',              label: 'Off — disable all advisories' },
+    // Active popup options: simple High / Medium / Low labels.
+    { num: 1, value: 'optimum',     label: 'High' },
+    { num: 2, value: 'every_event', label: 'Medium' },
+    { num: 3, value: 'major_only',  label: 'Low' },
+    // The two entries below stay valid via the CLI (nexpath config set
+    // advisory_frequency once_per_session / off) and are still honoured by
+    // the gating logic — they are intentionally hidden from this menu.
+    // { num: 4, value: 'once_per_session', label: 'Once per coding session' },
+    // { num: 5, value: 'off',              label: 'Off — disable all advisories' },
   ];
   const menuLines = [
     pc.cyan('│'),
@@ -918,7 +926,7 @@ export function runFrequencySubMenu(
     pc.cyan('│'),
   ];
   streams.output.write(menuLines.join('\n') + '\n');
-  streams.output.write(`${pc.cyan('└')}  Select (1-5): `);
+  streams.output.write(`${pc.cyan('└')}  Select (1-3): `);
 
   iface.once('line', (answer) => {
     const num = parseInt(answer.trim(), 10);


### PR DESCRIPTION
Description
 
  ## Summary
 
  - Relabel the advisory-frequency popup from five named options to three rungs: *High, Medium, Low. Mapping:
    - High → optimum
    - Medium → every_event (default)
    - Low → major_only
  - Hide once_per_session and off from the popup; both remain fully valid via the CLI (nexpath config set advisory_frequency <value>) and are still honoured by
  the gating logic in auto.ts and stop.ts.
  - Applied across all three UI surfaces: the Windows new-window @clack popup, the Unix fallback numbered menu, and the first-run nexpath install picker.
  - Default frequency stays every_event, so users who accept the install default land on Medium*.
 
  ## What's NOT changed
 
  - AdvisoryFrequencyLevel type and FREQUENCY_LEVEL_CONFIGS — all five level configs intact.
  - nexpath config set advisory_frequency validator — still accepts all five values.
  - Gating logic in auto.ts / stop.ts — major_only and once_per_session still gate as before for users who have those values saved.
  - Ctrl+X opt-out path — still writes 'off' programmatically.
  - README "Frequency and Role" table — still documents the CLI's five accepted values.
 
  ## Test plan
 
  - [x] npm test -- src/decision-session/TtySelectFn.test.ts — 91/91 passing (includes two new regression tests: hidden labels absent from popup, CLI-set
  once_per_session value preserved when the popup hides that option).
  - [x] npm test -- src/cli/commands/auto.test.ts — gating tests for major_only and once_per_session still green.
  - [x] npm test -- src/cli/commands/install-3step.test.ts — install flow green.
  - [x] npm run typecheck — clean.
  - [x] npm run build — clean; verified the built dist/ embeds the new labels in all three surfaces.
  - [x] CLI smoke: nexpath config set advisory_frequency once_per_session / off / optimum / every_event / major_only — all five round-trip via config get;
   invalid values are rejected with the full five-value list in the error.
  - [ ] Manual smoke on a real Claude Code session: trigger an advisory, press Ctrl+T → Frequency, verify the popup shows three options labelled High / Medium / Low
   and that picking one persists the corresponding internal value.
  - [ ] Manual smoke on first-run nexpath install: confirm step 1 shows the new three-option picker
