### PR TITLE
Preserve the help hint row when the popup option budget overflows

### DIFF
--- a/src/decision-session/TtySelectFn.ts
+++ b/src/decision-session/TtySelectFn.ts
@@ -99,6 +99,10 @@ for (const opt of opts.options) {
 const _skipNowIdx = opts.options.findIndex(o => o.value === opts.skipNow);
 if (_skipNowIdx >= 0 && _maxItems <= _skipNowIdx) _maxItems = _skipNowIdx + 1;
 _maxItems = Math.max(_maxItems, 5);
+const _helpIdx = opts.options.findIndex(o => o.value === opts.separatorPrefix + 'help');
+if (_helpIdx >= 0) {
+  _maxItems = opts.options.length;
+}
 const _selOptions = (_skipNowIdx >= 0 && _maxItems < opts.options.length)
   ? opts.options.slice(0, _skipNowIdx + 1)
   : opts.options;


### PR DESCRIPTION
### Summary

The popup select-window (`TtySelectFn`) prunes options that exceed the
terminal's vertical row budget by slicing the list after the `SKIP_NOW`
entry. On the default **80×24 terminal** — especially once the branded-header
rows are reserved — this silently dropped the trailing help hint
(`don't need nexpath here? press Ctrl+X… Ctrl+T…`), so users lost the
skip-shortcut reminder exactly when the list was tightest.

### The fix

Detect the help row via its `separatorPrefix + 'help'` value. When it's
present, expand `_maxItems` to the full options length so the slice
condition no longer triggers and the help hint always renders.

The slice still strips overflow when the help row is **absent** (i.e. after
the per-project display cap is reached), so the existing
**"Skip always visible"** guarantee stays intact.

```ts
const _helpIdx = opts.options.findIndex(o => o.value === opts.separatorPrefix + 'help');
if (_helpIdx >= 0) {
  _maxItems = opts.options.length;
}
```

### Changes

- `src/decision-session/TtySelectFn.ts` — add a help-row lookup and bump
  `_maxItems` to the full list length when the help row exists (+4 lines).

