### PR TITLE
test: fix the 4 pre-existing test failures (no product changes)

### DIFF
--- a/src/cli/commands/__snapshots__/install.snapshot.test.ts.snap
+++ b/src/cli/commands/__snapshots__/install.snapshot.test.ts.snap
@@ -3,7 +3,8 @@
 exports[`installAction snapshot (M1 zero-diff safety net) > writes the same settings.json bytes and stdout as the pre-refactor baseline 1`] = `
 {
   "settingsContent": null,
-  "stdout": "Not found: Claude Code
+  "stdout": "Installing for: cli
+Not found: Claude Code
 nexpath currently supports Claude Code only — support for Cursor, Windsurf, and other agents is coming in future updates.
 
 Restart your agents to activate nexpath-prompt-store.",

--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -1342,7 +1342,7 @@ describe('uninstallAction', () => {
       mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
       vi.stubEnv('HOME', dir);
       const paths = resolveAgentPaths(dir, dir, dir);
-      await uninstallAction({ paths, execFn: () => {} });
+      await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
       expect(output).toContain('Cursor');
       expect(output).toContain('cursor --uninstall-extension');
@@ -1359,7 +1359,7 @@ describe('uninstallAction', () => {
       mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
       vi.stubEnv('HOME', dir);
       const paths = resolveAgentPaths(dir, dir, dir);
-      await uninstallAction({ paths, execFn: () => {} });
+      await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
       expect(output).toContain('Windsurf');
       expect(output).toContain('windsurf --uninstall-extension');
@@ -1381,7 +1381,7 @@ describe('uninstallAction', () => {
       mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
       vi.stubEnv('HOME', dir);
       const paths = resolveAgentPaths(dir, dir, dir);
-      await uninstallAction({ paths, execFn: () => {} });
+      await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
       expect(uninstallSpy).toHaveBeenCalledOnce();
       expect(output).toMatch(/failed:.*synthetic uninstall failure/);

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -89,6 +89,7 @@ vi.mock('./host-detector.js', () => ({
 }));
 vi.mock('./chat-input-injector.js', () => ({
   chatInputInject: vi.fn(),
+  CANDIDATE_COMMANDS: { cursor: [], windsurf: [] },
 }));
 vi.mock('./path-enumerator.js', () => ({
   enumerateStateVscdbPaths: mockEnumerateStateVscdbPaths,


### PR DESCRIPTION
  - uninstallAction tests deadlocked on the interactive 'Remove stored API key?' prompt when a key is present in the keychain; inject apiKeyConfirmFn + :memory: db so they never hit the real prompt/keychain
  - refresh the install.snapshot baseline for the intended 'Installing for: cli' line (added by the --for <platform> feature)
  - add CANDIDATE_COMMANDS to the chat-input-injector mock (extension.ts imports it for the Cursor diagnostic) — clears 15 unhandled rejections