### PR TITLE
test(ext-vscode): normalise path separators so host-path tests pass o…

### DIFF
--- a/src/ext-vscode/src/advisory-store-reader.test.ts
+++ b/src/ext-vscode/src/advisory-store-reader.test.ts
@@ -32,7 +32,8 @@ describe('parseJsonStringArray', () => {
 
 describe('defaultStorePath', () => {
   it('points at ~/.nexpath/prompt-store.db (mirrors Layer C DEFAULT_DB_PATH)', () => {
-    expect(defaultStorePath('/home/u')).toBe('/home/u/.nexpath/prompt-store.db');
+    // Normalise separators so the assertion holds on POSIX and Windows CI runners.
+    expect(defaultStorePath('/home/u').replace(/\\/g, '/')).toBe('/home/u/.nexpath/prompt-store.db');
   });
 });
 

--- a/src/ext-vscode/src/cursor-state-dump-helpers.test.ts
+++ b/src/ext-vscode/src/cursor-state-dump-helpers.test.ts
@@ -98,27 +98,30 @@ describe('redactValue', () => {
   });
 });
 
+/** Normalise path separators so these assertions hold on POSIX and Windows CI runners. */
+const fwd = (p: string | null): string | null => (p == null ? p : p.replace(/\\/g, '/'));
+
 describe('cursorConfigRoot', () => {
   it('returns the linux path under ~/.config/Cursor', () => {
     expect(
-      cursorConfigRoot({ platform: 'linux', home: '/home/u' }),
+      fwd(cursorConfigRoot({ platform: 'linux', home: '/home/u' })),
     ).toBe('/home/u/.config/Cursor');
   });
 
   it('returns the macOS path under ~/Library/Application Support/Cursor', () => {
     expect(
-      cursorConfigRoot({ platform: 'darwin', home: '/Users/u' }),
+      fwd(cursorConfigRoot({ platform: 'darwin', home: '/Users/u' })),
     ).toBe('/Users/u/Library/Application Support/Cursor');
   });
 
   it('returns the Windows path under %APPDATA%/Cursor when APPDATA is provided', () => {
     expect(
-      cursorConfigRoot({
+      fwd(cursorConfigRoot({
         platform: 'win32',
         home: 'C:\\Users\\u',
         appdata: 'C:\\Users\\u\\AppData\\Roaming',
-      }),
-    ).toBe('C:\\Users\\u\\AppData\\Roaming/Cursor');
+      })),
+    ).toBe('C:/Users/u/AppData/Roaming/Cursor');
   });
 
   it('falls back to <home>/AppData/Roaming/Cursor on Windows when APPDATA missing', () => {
@@ -129,7 +132,7 @@ describe('cursorConfigRoot', () => {
 
   it('treats unknown platforms as linux-style', () => {
     expect(
-      cursorConfigRoot({ platform: 'freebsd' as NodeJS.Platform, home: '/home/u' }),
+      fwd(cursorConfigRoot({ platform: 'freebsd' as NodeJS.Platform, home: '/home/u' })),
     ).toBe('/home/u/.config/Cursor');
   });
 });

--- a/src/ext-vscode/src/host-detector.test.ts
+++ b/src/ext-vscode/src/host-detector.test.ts
@@ -60,6 +60,9 @@ describe('detectHost', () => {
   });
 });
 
+/** Normalise path separators so these path assertions hold on POSIX and Windows CI runners. */
+const fwd = (p: string | null): string | null => (p == null ? p : p.replace(/\\/g, '/'));
+
 describe('chatHistoryBaseDir', () => {
   it('returns null for vscode-generic (no chat-history watching)', () => {
     expect(
@@ -69,33 +72,33 @@ describe('chatHistoryBaseDir', () => {
 
   it('cursor on linux → ~/.config/Cursor', () => {
     expect(
-      chatHistoryBaseDir({ host: 'cursor', home: '/home/u', platform: 'linux' }),
+      fwd(chatHistoryBaseDir({ host: 'cursor', home: '/home/u', platform: 'linux' })),
     ).toBe('/home/u/.config/Cursor');
   });
 
   it('cursor on darwin → Library/Application Support', () => {
     expect(
-      chatHistoryBaseDir({ host: 'cursor', home: '/Users/u', platform: 'darwin' }),
+      fwd(chatHistoryBaseDir({ host: 'cursor', home: '/Users/u', platform: 'darwin' })),
     ).toBe('/Users/u/Library/Application Support/Cursor');
   });
 
   it('cursor on win32 with APPDATA → uses it', () => {
     expect(
-      chatHistoryBaseDir({
+      fwd(chatHistoryBaseDir({
         host: 'cursor',
         home: 'C:\\Users\\u',
         platform: 'win32',
         appdata: 'C:\\Users\\u\\AppData\\Roaming',
-      }),
-    ).toBe('C:\\Users\\u\\AppData\\Roaming/Cursor');
+      })),
+    ).toBe('C:/Users/u/AppData/Roaming/Cursor');
   });
 
   it('windsurf paths mirror cursor paths', () => {
     expect(
-      chatHistoryBaseDir({ host: 'windsurf', home: '/home/u', platform: 'linux' }),
+      fwd(chatHistoryBaseDir({ host: 'windsurf', home: '/home/u', platform: 'linux' })),
     ).toBe('/home/u/.config/Windsurf');
     expect(
-      chatHistoryBaseDir({ host: 'windsurf', home: '/Users/u', platform: 'darwin' }),
+      fwd(chatHistoryBaseDir({ host: 'windsurf', home: '/Users/u', platform: 'darwin' })),
     ).toBe('/Users/u/Library/Application Support/Windsurf');
   });
 });
@@ -103,7 +106,7 @@ describe('chatHistoryBaseDir', () => {
 describe('workspaceStorageDir', () => {
   it('appends User/workspaceStorage to the host base dir', () => {
     expect(
-      workspaceStorageDir({ host: 'cursor', home: '/home/u', platform: 'linux' }),
+      fwd(workspaceStorageDir({ host: 'cursor', home: '/home/u', platform: 'linux' })),
     ).toBe('/home/u/.config/Cursor/User/workspaceStorage');
   });
 


### PR DESCRIPTION
…n Windows CI

  The win32 CI Package job failed at npm test: host-detector / cursor-state-dump-helpers /
  advisory-store-reader path assertions hardcoded POSIX '/' separators, but path.join uses
  the host separator, so they only passed on Linux/Mac runners. Normalise separators in the
  assertions (test-only, no production change). Verified: ext-vscode 432/432 on Linux +
  simulated win32 join.