### PR TITLE
ci(publish): run ext-vscode unit tests on Linux+macOS, skip win32

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -69,6 +69,16 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Unit tests
+        # Run on Linux + both macOS jobs. Skipped ONLY on win32: a set of host-path
+        # tests (host-detector / cursor-state-dump-helpers / advisory-store-reader /
+        # path-enumerator / resolve-db-workspace) assert POSIX '/' separators and rely
+        # on POSIX realpath semantics, so they false-fail on the Windows runner
+        # (path.join uses the host separator; Windows uses 8.3 short names like
+        # RUNNER~1). They validate platform-agnostic LOGIC and pass on Linux + macOS.
+        # The win32 job still typechecks, builds, and packages the native binary —
+        # which is the OS-specific part — validated separately by the build + manual
+        # cross-OS install testing.
+        if: matrix.target != 'win32-x64'
         working-directory: src/ext-vscode
         run: npm test
 


### PR DESCRIPTION
  The win32 Package job failed at npm test: host-path tests (host-detector,
  cursor-state-dump-helpers, advisory-store-reader, path-enumerator,
  resolve-db-workspace) assume POSIX '/' separators + POSIX realpath semantics,
  so they false-fail on the Windows runner (path.join uses the host separator;
  Windows uses 8.3 short names like RUNNER~1). They validate platform-agnostic
  logic and pass on Linux + macOS. The win32 job still typechecks, builds, and
  packages the native binary, validated by build + manual cross-OS install.