### PR TITLE
ci(publish): cross-compile darwin-x64 on Apple Silicon (macos-14) via…

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -31,6 +31,9 @@ jobs:
   package:
     name: Package (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    # Catch a genuinely hung job (vs the queue) so it fails fast instead of
+    # running for hours. Generous: the macOS cross-compile rebuilds 8 ABIs.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +45,12 @@ jobs:
           - target: linux-x64
             runner: ubuntu-22.04
           - target: darwin-x64
-            runner: macos-13         # Intel mac for x64 prebuild
+            # Apple Silicon runner — the x64 (Intel-Mac) binary is CROSS-COMPILED
+            # here via `--arch x64` (see package-with-electron-abi.mjs). GitHub's
+            # Intel macOS (macos-13) runners are scarce/deprecated and queue for
+            # hours; Apple-Silicon runners are plentiful and the macOS toolchain
+            # is universal, so this produces a genuine Intel-Mac binary with no wait.
+            runner: macos-14
           - target: darwin-arm64
             runner: macos-14         # Apple Silicon (pinned; previously macos-latest)
           - target: win32-x64

--- a/src/ext-vscode/scripts/package-with-electron-abi.mjs
+++ b/src/ext-vscode/scripts/package-with-electron-abi.mjs
@@ -85,6 +85,24 @@ function readElectronVersions(primary) {
 const electronVersion = readTargetElectron();
 const versionsToBuild = readElectronVersions(electronVersion);
 const extraArgs = process.argv.slice(2);
+
+// ── Cross-compile support ────────────────────────────────────────────────────
+// Derive the TARGET cpu arch from the `--target <os>-<arch>` flag that the CI
+// forwards to `vsce package` (e.g. "darwin-x64" → "x64"). We pass it to
+// @electron/rebuild as `--arch`, so a build host can produce a binary for a
+// DIFFERENT arch of the same OS family. Concretely: the darwin-x64 (Intel-Mac)
+// binary is cross-compiled on the Apple-Silicon runner (macos-14) — the macOS
+// toolchain is universal, so this yields a genuine Intel-Mac binary WITHOUT a
+// (scarce, deprecated) Intel macOS runner. When the target arch already matches
+// the host it's a normal native build; with no `--target` (local `npm run
+// package`) it falls back to the host arch — unchanged behaviour.
+function readTargetArch(argv) {
+  const i = argv.indexOf('--target');
+  const target = i >= 0 ? argv[i + 1] : undefined; // e.g. "darwin-x64"
+  const arch = typeof target === 'string' ? target.split('-')[1] : undefined;
+  return arch || process.arch; // x64 | arm64 | …
+}
+const targetArch = readTargetArch(extraArgs);
 const releaseBinary = resolve(subPkgRoot, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node');
 const prebuildsDir = resolve(subPkgRoot, 'prebuilds');
 
@@ -101,9 +119,9 @@ rmSync(prebuildsDir, { recursive: true, force: true });
 for (const v of versionsToBuild) {
   const abi = String(nodeAbi.getAbi(v, 'electron'));
   const rebuildCode = run(
-    `Rebuild better-sqlite3 → Electron ${v} (ABI ${abi})`,
+    `Rebuild better-sqlite3 → Electron ${v} (ABI ${abi}, arch ${targetArch})`,
     'npx',
-    ['electron-rebuild', '--version', v, '--force', '--only', 'better-sqlite3', '--module-dir', '.'],
+    ['electron-rebuild', '--version', v, '--arch', targetArch, '--force', '--only', 'better-sqlite3', '--module-dir', '.'],
   );
   if (rebuildCode !== 0 || !existsSync(releaseBinary)) {
     console.error(`✗ electron-rebuild failed for Electron ${v} (exit ${rebuildCode}) — aborting before vsce package.`);


### PR DESCRIPTION
… --arch

  GitHub Intel-macOS (macos-13) runners are scarce/deprecated and queue for hours.
  Build the Intel-Mac (darwin-x64) better-sqlite3 binary by cross-compiling on the
  plentiful Apple-Silicon runner: derive the target arch from --target and pass
  --arch to electron-rebuild (macOS toolchain is universal → a real Intel-Mac
  binary, no Intel runner needed). Other targets pass their host arch (native,
  unchanged); local npm run package unchanged. Also adds timeout-minutes:45.