### PR TITLE
fix(ext-browser): harden agent composer lookup against site DOM drift…

### DIFF
--- a/src/ext-browser/content/agents/inject-kit.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.test.ts
@@ -150,4 +150,65 @@ describe('content/agents/inject-kit.ts — injectViaSimulatedPaste', () => {
     await clipboardFallback('option text for an agent without inject-back yet');
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('option text for an agent without inject-back yet');
   });
+
+  // ── prioritised selector list + rendered-element preference (site-drift resilience) ──
+  it('accepts a prioritised selector LIST and uses the first selector that matches', async () => {
+    const input = document.createElement('div');
+    input.className = 'tiptap ProseMirror';
+    input.setAttribute('aria-label', 'Ask Lovable to create something');
+    document.body.appendChild(input);
+    input.addEventListener('paste', (ev) => {
+      input.textContent = (ev as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+
+    // The original exact-label selector matches nothing (site relabelled it); a later
+    // fallback selector does — must inject, NOT fall back to clipboard.
+    await injectViaSimulatedPaste(
+      [
+        '.tiptap.ProseMirror[aria-label="Chat input"]',
+        '.tiptap.ProseMirror[aria-label^="Ask Lovable"]',
+        '.tiptap.ProseMirror',
+      ],
+      'run all tests',
+    );
+
+    expect(input.textContent).toBe('run all tests');
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers the first RENDERED element when a selector matches several nodes', async () => {
+    const hidden = document.createElement('div');
+    hidden.className = 'tiptap ProseMirror';
+    hidden.addEventListener('paste', () => { hidden.textContent = 'WRONG (hidden)'; });
+    const visible = document.createElement('div');
+    visible.className = 'tiptap ProseMirror';
+    visible.addEventListener('paste', (ev) => {
+      visible.textContent = (ev as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+    document.body.append(hidden, visible); // hidden is first in document order
+
+    // jsdom performs no layout, so drive getClientRects explicitly: only `visible` renders.
+    hidden.getClientRects = () => [] as unknown as DOMRectList;
+    visible.getClientRects = () => [{ width: 200, height: 24 } as DOMRect] as unknown as DOMRectList;
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'ship it');
+
+    expect(visible.textContent).toBe('ship it');
+    expect(hidden.textContent).not.toBe('WRONG (hidden)');
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+  });
+
+  it('backward-compatible: a bare string selector still resolves to its first match', async () => {
+    const input = document.createElement('div');
+    input.id = 'legacy-composer';
+    document.body.appendChild(input);
+    input.addEventListener('paste', (ev) => {
+      input.textContent = (ev as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+
+    await injectViaSimulatedPaste('#legacy-composer', 'still works');
+
+    expect(input.textContent).toBe('still works');
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -118,8 +118,35 @@ function hasLanded(input: HTMLElement, text: string): boolean {
   return (input.textContent ?? '').trim().includes(text.trim().slice(0, 20));
 }
 
-export async function injectViaSimulatedPaste(inputSelector: string, text: string): Promise<void> {
-  const input = document.querySelector<HTMLElement>(inputSelector);
+/**
+ * Resolve the agent's composer from ONE selector or a PRIORITISED LIST. Purely
+ * additive over the original single-`querySelector` lookup and can never do worse:
+ *   • a bare string behaves exactly as before;
+ *   • a list is tried in order — the FIRST selector that matches wins, so the
+ *     original/most-specific selector stays authoritative and every later entry is
+ *     only a fallback for when a site renames its composer (e.g. Lovable relabelled
+ *     its input's aria-label "Chat input" → "Ask Lovable…", which silently routed
+ *     "Send to your agent" to the clipboard fallback);
+ *   • when a selector matches several nodes, the first RENDERED one is preferred
+ *     (getClientRects covers position:fixed, which offsetParent misses), hardening
+ *     every agent against duplicate/off-screen editors.
+ * If nothing is rendered it still returns the first raw match — so the existing
+ * clipboard-fallback contract (null → clipboard) is unchanged.
+ */
+function resolveComposer(selectors: string | string[]): HTMLElement | null {
+  const list = Array.isArray(selectors) ? selectors : [selectors];
+  let firstMatch: HTMLElement | null = null;
+  for (const selector of list) {
+    for (const el of document.querySelectorAll<HTMLElement>(selector)) {
+      firstMatch ??= el;
+      if (el.getClientRects().length > 0) return el;
+    }
+  }
+  return firstMatch;
+}
+
+export async function injectViaSimulatedPaste(inputSelector: string | string[], text: string): Promise<void> {
+  const input = resolveComposer(inputSelector);
   if (!input) {
     await clipboardFallback(text);
     return;

--- a/src/ext-browser/content/agents/lovable-inject.test.ts
+++ b/src/ext-browser/content/agents/lovable-inject.test.ts
@@ -62,17 +62,43 @@ describe('lovable-inject.ts — injectPromptText', () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith('add dark mode');
   });
 
-  it('ignores a TipTap editor without the "Chat input" aria-label (wrong element) and falls back', async () => {
-    const other = document.createElement('div');
-    other.className = 'tiptap ProseMirror';
-    other.setAttribute('contenteditable', 'true');
-    other.addEventListener('paste', () => { other.textContent = 'should never land here'; });
-    document.body.appendChild(other);
+  it('injects into a RELABELLED composer (aria-label "Chat input" → "Ask Lovable…") — the drift fix, no clipboard fallback', async () => {
+    // Reproduces the 2026-07-23 tester bug: Lovable renamed the composer's aria-label,
+    // so the old exact-label selector matched nothing and "Send to your agent" copied
+    // to clipboard instead of pasting. The fallback list must now find it.
+    const relabelled = document.createElement('div');
+    relabelled.className = 'tiptap ProseMirror';
+    relabelled.setAttribute('contenteditable', 'true');
+    relabelled.setAttribute('aria-label', 'Ask Lovable to create something amazing');
+    relabelled.addEventListener('paste', (ev) => {
+      relabelled.textContent = (ev as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+    document.body.appendChild(relabelled);
 
     await injectPromptText('add dark mode');
 
-    expect(other.textContent).not.toBe('should never land here');
-    expect(clipboardWriteTextMock).toHaveBeenCalledWith('add dark mode');
+    expect(relabelled.textContent).toBe('add dark mode');
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+  });
+
+  it('still prefers the exact "Chat input" composer when it is present (selector priority preserved)', async () => {
+    const other = document.createElement('div');
+    other.className = 'tiptap ProseMirror';
+    other.setAttribute('contenteditable', 'true');
+    other.setAttribute('aria-label', 'Some other editor');
+    other.addEventListener('paste', () => { other.textContent = 'WRONG'; });
+    document.body.appendChild(other); // appears first in the DOM
+
+    const chat = makeTipTapInput(); // the real composer (aria-label "Chat input")
+    chat.addEventListener('paste', (ev) => {
+      chat.textContent = (ev as ClipboardEvent).clipboardData?.getData('text/plain') ?? '';
+    });
+
+    await injectPromptText('add dark mode');
+
+    expect(chat.textContent).toBe('add dark mode');
+    expect(other.textContent).not.toBe('WRONG');
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
   });
 
   it('falls back to clipboard when the paste does not visibly land', async () => {

--- a/src/ext-browser/content/agents/lovable-inject.ts
+++ b/src/ext-browser/content/agents/lovable-inject.ts
@@ -8,14 +8,24 @@ import { injectViaSimulatedPaste } from './inject-kit.js';
  * importing from the auto-bootstrapping capture entry would duplicate its
  * observers into inject.js's bundle (the B3 duplicate-bundling bug).
  *
- * Lovable's prompt input is TipTap/ProseMirror with aria-label "Chat input"
- * (docs/capture-recon/lovable-recon.md §3) — the same editor family whose
- * simulated-paste mechanism is live-verified on Bolt. NOT yet live-verified on
- * Lovable itself (B5 E2E gate item).
+ * Lovable's prompt input is a TipTap/ProseMirror contenteditable. It historically
+ * carried aria-label "Chat input" (docs/capture-recon/lovable-recon.md §3); Lovable
+ * later relabelled it "Ask Lovable to create …" (confirmed live 2026-07-23), which
+ * silently broke the aria-label-pinned selector → "Send to your agent" fell back to
+ * clipboard-copy instead of pasting + auto-submitting.
+ *
+ * The selector is now a PRIORITISED FALLBACK LIST (resolved by resolveComposer in
+ * inject-kit.ts): the original exact label FIRST (still authoritative if Lovable
+ * reverts), then the current label prefix, then the label-independent structural
+ * class as a last resort. Nothing is removed — each entry only adds resilience.
  */
 
-const INPUT_SELECTOR = '.tiptap.ProseMirror[aria-label="Chat input"]';
+const INPUT_SELECTORS = [
+  '.tiptap.ProseMirror[aria-label="Chat input"]',   // original label — kept, still preferred
+  '.tiptap.ProseMirror[aria-label^="Ask Lovable"]', // current label (live 2026-07-23)
+  '.tiptap.ProseMirror',                            // structural fallback (label-independent)
+];
 
 export async function injectPromptText(text: string): Promise<void> {
-  await injectViaSimulatedPaste(INPUT_SELECTOR, text);
+  await injectViaSimulatedPaste(INPUT_SELECTORS, text);
 }


### PR DESCRIPTION
… (Lovable aria-label relabel)

Lovable renamed its composer aria-label 'Chat input' -> 'Ask Lovable...', so the exact-label selector matched nothing and 'Send to your agent' fell back to clipboard instead of pasting + auto-submitting. injectViaSimulatedPaste now accepts a prioritised selector list (original label kept as top priority) and prefers the first rendered match. Purely additive; no existing selector or code path removed. Live-verified on lovable.dev.