### PR TITLE
fix(ext-browser): drop unused `scripting` permission; pin permission …

### DIFF
--- a/src/ext-browser/CHANGELOG.md
+++ b/src/ext-browser/CHANGELOG.md
@@ -34,6 +34,10 @@ First release candidate — CLI‑parity classifier and popup.
 - Space now toggles a single option's details without collapsing others (non‑exclusive, CLI parity).
 - "Copy to clipboard" now closes the popup instead of returning to the option list (CLI
   `clipboard_only` parity).
+- **Minimised permissions:** removed the unused `scripting` permission from both manifests —
+  all injection is declarative (`content_scripts` + `web_accessible_resources`), so it was
+  never used. The extension now requests only `storage` and `tabs`. A manifest guard test
+  pins this surface so an unused permission can't be reintroduced.
 
 ### Notes
 - Bring‑your‑own OpenAI key; nothing is sent anywhere except the user's own OpenAI account.

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -5,8 +5,7 @@
   "description": "Behaviour guidance for vibe coders using AI coding agents.",
   "permissions": [
     "storage",
-    "tabs",
-    "scripting"
+    "tabs"
   ],
   "host_permissions": [
     "https://*.replit.com/*",

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -5,8 +5,7 @@
   "description": "Behaviour guidance for vibe coders using AI coding agents.",
   "permissions": [
     "storage",
-    "tabs",
-    "scripting"
+    "tabs"
   ],
   "host_permissions": [
     "https://*.replit.com/*",

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Guards the shipped permission surface. The store review (Chrome Web Store + AMO)
+// rejects/penalises permissions the extension does not actually use, so the set is
+// pinned here: injection is entirely declarative (manifest `content_scripts` +
+// `web_accessible_resources`), which needs NO `scripting` permission; messaging and
+// the "reload open agent tabs on install" flow use `tabs`; settings/state use
+// `storage`. Anything added here must come with a real API use + a reviewer
+// justification — this test fails loudly if `scripting` (or any other unused
+// permission) is re-introduced.
+const load = (target: 'chrome' | 'firefox') =>
+  JSON.parse(readFileSync(new URL(`./manifest.${target}.json`, import.meta.url), 'utf8'));
+
+const EXPECTED_PERMISSIONS = ['storage', 'tabs'];
+const EXPECTED_HOSTS = [
+  'https://*.replit.com/*',
+  'https://bolt.new/*',
+  'https://*.stackblitz.com/*',
+  'https://lovable.dev/*',
+];
+
+describe('ext-browser manifests — permission surface', () => {
+  for (const target of ['chrome', 'firefox'] as const) {
+    describe(`manifest.${target}.json`, () => {
+      const manifest = load(target);
+
+      it('requests exactly the permissions it uses (no unused perms)', () => {
+        expect(manifest.permissions).toEqual(EXPECTED_PERMISSIONS);
+      });
+
+      it('does NOT declare the unused `scripting` permission', () => {
+        expect(manifest.permissions).not.toContain('scripting');
+      });
+
+      it('scopes host_permissions to the supported agents only', () => {
+        expect(manifest.host_permissions).toEqual(EXPECTED_HOSTS);
+      });
+
+      it('is MV3 and version-locked', () => {
+        expect(manifest.manifest_version).toBe(3);
+        expect(manifest.version).toMatch(/^\d+\.\d+\.\d+$/);
+      });
+    });
+  }
+
+  it('chrome and firefox agree on permissions, hosts and version', () => {
+    const chrome = load('chrome');
+    const firefox = load('firefox');
+    expect(firefox.permissions).toEqual(chrome.permissions);
+    expect(firefox.host_permissions).toEqual(chrome.host_permissions);
+    expect(firefox.version).toEqual(chrome.version);
+  });
+});


### PR DESCRIPTION
…surface

Injection is entirely declarative (content_scripts + web_accessible_resources), so the `scripting` permission was never used by any code path. Remove it from both manifests (now storage + tabs only) to minimise the store-review permission surface, and add a manifest guard test so an unused permission can't reappear.

No runtime behaviour change: the permission was inert. Full ext suite green (7464/7464).