### PR TITLE
fix(ext-browser): never collapse the options band to zero on a short …

### DIFF
--- a/src/ext-browser/ui/panel.js
+++ b/src/ext-browser/ui/panel.js
@@ -60,9 +60,16 @@ const STYLES = `
   .np-root.np-busy .np-body-wrap { opacity:.4; pointer-events:none; }
 
   /* #2: fixed header (pinch/question/why-help) + scrolling options + fixed footer. */
-  .np-fixed-top { flex: 0 0 auto; }
+  /* On a very short viewport (max-height: calc(100vh - 40px)) the header must be
+     allowed to shrink and clip its own overflow (why-help drops from the bottom,
+     pinch + question stay) so it can never squeeze the options band to zero rows —
+     which would leave the panel showing no selectable option and let a blind Enter
+     jump straight to the send-confirm. */
+  .np-fixed-top { flex: 0 1 auto; min-height: 0; overflow: hidden; }
   .np-scroll {
-    flex: 1 1 auto; overflow-y: auto; min-height: 0;
+    /* min-height keeps >=1 option visible even when the header is at full size;
+       inert on normal windows (the options band is already far taller than this). */
+    flex: 1 1 auto; overflow-y: auto; min-height: 56px;
     scrollbar-width: thin; scrollbar-color: #5a3a52 transparent;
   }
   .np-scroll::-webkit-scrollbar { width: 8px; }

--- a/src/ext-browser/ui/panel.styles.test.ts
+++ b/src/ext-browser/ui/panel.styles.test.ts
@@ -1,0 +1,49 @@
+// Regression guard for the "short-viewport blank options / direct send-confirm" bug.
+//
+// On a short browser window the panel (`.np-root`, capped at calc(100vh - 40px))
+// shrinks. If the header (`.np-fixed-top`) keeps a fixed size it squeezes the
+// options band (`.np-scroll`) to zero height: no selectable option renders, and a
+// blind Enter jumps straight to the "Send to your agent" confirm. Reproduced live
+// across all 6 fixtures at viewport <= 230px.
+//
+// The fix is two CSS invariants in panel.js. jsdom cannot compute flexbox layout,
+// so this test asserts the invariants at the source level — the live layout proof
+// is the browser reproduction sweep (blank renders 19 -> 0, focused option visible
+// at every height down to vp 180px, normal-window render byte-identical).
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const panelSrc = readFileSync(fileURLToPath(new URL('./panel.js', import.meta.url)), 'utf8');
+
+/** Return the declaration block for an exact CSS selector (first match). */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = panelSrc.match(new RegExp(escaped + '\\s*\\{([^}]*)\\}'));
+  if (!m) throw new Error(`CSS rule not found for selector: ${selector}`);
+  return m[1];
+}
+
+describe('panel.js short-viewport layout invariants', () => {
+  it('.np-fixed-top can shrink and clip so it never eats the whole panel', () => {
+    const body = ruleBody('.np-fixed-top');
+    // flex-shrink must be enabled (0 1 auto), not disabled (0 0 auto).
+    expect(body).toMatch(/flex:\s*0\s+1\s+auto/);
+    expect(body).toMatch(/min-height:\s*0/);
+    expect(body).toMatch(/overflow:\s*hidden/);
+    // explicit guard against the pre-fix value.
+    expect(body).not.toMatch(/flex:\s*0\s+0\s+auto/);
+  });
+
+  it('.np-scroll reserves a non-zero minimum so >=1 option is always visible', () => {
+    const body = ruleBody('.np-scroll');
+    const m = body.match(/min-height:\s*(\d+)px/);
+    expect(m, '.np-scroll must declare a px min-height').not.toBeNull();
+    const minPx = Number(m![1]);
+    // Must be tall enough to show at least the focused option row (line-height 15px).
+    expect(minPx).toBeGreaterThanOrEqual(30);
+    // explicit guard against the pre-fix value (min-height: 0).
+    expect(body).not.toMatch(/min-height:\s*0\s*;/);
+  });
+});


### PR DESCRIPTION
…viewport

On a short browser window the fixed-size header squeezed .np-scroll to 0px, so no selectable option rendered and a blind Enter jumped straight to the send-confirm. Let the header shrink/clip (why-help drops, pinch+question stay) and floor the options band at min-height:56px. Inert on normal windows (byte-identical render). Reproduced live across 6 fixtures at vp<=230px (blank 19->0); +regression test.