### PR TITLE
fix(render-loop): never render zero selectable options on a short vie…

### DIFF
--- a/src/decision-session/render-loop.test.ts
+++ b/src/decision-session/render-loop.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { PassThrough } from 'node:stream';
 import {
   computeLayout,
+  MIN_OPTION_BAND_ROWS,
   D1_TRUNCATED_LINE_CAP,
   D2_TRUNCATION_MARKER,
   D4_PADDING_ROW_COUNT,
@@ -699,6 +700,54 @@ describe('render-loop — visual-row-aware budget (ui-bug-fix plan §5.4 Candida
     const visibleText = r.viewport.visibleStyledLines.join('\n');
     expect(visibleText).toContain('NEXPATH CLI');                   // page-header wordmark
     expect(visibleText).toContain('Service boundary established');  // pinch label
+  });
+});
+
+describe('render-loop — min option band: never render zero selectable options', () => {
+  // Reproduces the Cursor/CLI report "popup shows up with no options, just
+  // Send to your agent": a tall header (NEXPATH page-header + pinch + question +
+  // 3-line why-help) on a short popup window used to drive avail -> 0 via the
+  // Tier-2 header fill, dropping EVERY option so nothing was selectable.
+  const tallHeader = (rows: number): RenderLoopOptions => makeOpts({
+    pageHeader:   '▲  NEXPATH CLI\n────────────\n\n',
+    pinchLabel:   'Before coding.',
+    question:     'Spec ready — is the architecture decided?',
+    whyHelpBlock:
+      "You're seeing this because\n" +
+      "Your recent prompts show a shift to a new stage; the prior stage's loose ends are not tied up yet.\n" +
+      '— pick from the options below to keep moving.',
+    options: [
+      { value: 'design', label: 'Design the system architecture: components, data model, API contracts.', descBase: 'Settle the architecture before any code is written.' },
+      { value: 'review', label: 'Review the plan before building', descBase: 'Confirm scope and acceptance.' },
+    ],
+    rows,
+  });
+
+  for (const rows of [10, 12, 14]) {
+    it(`keeps the focused option visible on a short viewport (rows=${rows}) — this returned ZERO option lines before the fix`, () => {
+      const r = computeLayout(tallHeader(rows), FRESH_STATE);
+      expect(r.viewport.visibleStyledLines.join('\n')).toContain('Design the system architecture');
+    });
+  }
+
+  it('reserves MIN_OPTION_BAND_ROWS so avail never collapses to 0 while Tier 1 fits (rows=14)', () => {
+    const r = computeLayout(tallHeader(14), FRESH_STATE);
+    expect(r.budget.avail).toBeGreaterThanOrEqual(MIN_OPTION_BAND_ROWS);
+  });
+
+  it('hard floor: the option region is never empty even at a pathological tiny viewport where the header alone overflows (rows=6)', () => {
+    const r = computeLayout(tallHeader(6), FRESH_STATE);
+    // Tier 1 alone can exceed rows=6 (avail may still be 0) — the hard-floor
+    // guard guarantees at least the focused option's first line renders anyway.
+    expect(r.viewport.visibleStyledLines.join('\n')).toContain('Design the system architecture');
+  });
+
+  it('roomy viewport is byte-unchanged: rows=40 fits every option and avail stays well above the band', () => {
+    const r = computeLayout(tallHeader(40), FRESH_STATE);
+    const text = r.viewport.visibleStyledLines.join('\n');
+    expect(text).toContain('Design the system architecture');
+    expect(text).toContain('Review the plan before building');
+    expect(r.budget.avail).toBeGreaterThan(MIN_OPTION_BAND_ROWS);
   });
 });
 

--- a/src/decision-session/render-loop.ts
+++ b/src/decision-session/render-loop.ts
@@ -238,6 +238,19 @@ export const SUB_LINE_CONTINUATION_INDENT = '  ';
 export const DEFAULT_MAX_ITEMS_FLOOR = 5;
 
 /**
+ * Minimum visual rows reserved for the option region when the sticky-header
+ * priority tiers drop Tier 2 content on a short viewport. Without this reserve,
+ * droppable header rows (question + why-help + D4 padding) can consume the
+ * viewport down to `avail === 0`, leaving the popup with a full header and ZERO
+ * selectable options — the user then sees only "Send to your agent" with nothing
+ * to pick. Reserving this band makes Tier 2 drop one step earlier so at least the
+ * focused option always fits. Kept at 3 (label + gap + first desc line) so it
+ * never over-reserves on the small-header viewports the existing budget tests
+ * lock (rows 8/10/14 headers are ~3 rows and still fit every Tier 2 emission).
+ */
+export const MIN_OPTION_BAND_ROWS = 3;
+
+/**
  * Minimum effective expanded cap. If the secondary cap drops below this
  * (terminal too short to fit a meaningful expansion plus the surrounding
  * option-list context), the layout refuses to expand and silently falls
@@ -707,7 +720,10 @@ export function computeLayout(opts: RenderLoopOptions, state: LayoutState): Rend
       fixedVisualRows += cost;
       includedHeaderIdx.push(i);
     } else if (!dropRemainingTier2) {
-      if (fixedVisualRows + cost + 2 <= opts.rows) {
+      // Reserve MIN_OPTION_BAND_ROWS for the option region so a droppable Tier 2
+      // emission is dropped one step earlier than it "just fits" — otherwise the
+      // header can fill the viewport down to avail === 0 (no visible options).
+      if (fixedVisualRows + cost + 2 + MIN_OPTION_BAND_ROWS <= opts.rows) {
         fixedVisualRows += cost;
         includedHeaderIdx.push(i);
       } else {
@@ -792,7 +808,13 @@ export function computeLayout(opts: RenderLoopOptions, state: LayoutState): Rend
   const windowedChromed: string[] = [];
   for (let i = startEmissionORIdx; i < optionStyled.length; i++) {
     const cost = visualRowsByIdx[headerEnd + i];
-    if (visualUsed + cost > avail) break;
+    // Hard floor: always keep at least the first (focused) option line. On a
+    // viewport so short that avail collapses to 0 (Tier 1 alone fills it), an
+    // empty option region leaves the user a popup they cannot act on — never let
+    // `options.length > 0` render zero options. The `windowed.length > 0` guard
+    // means this only ever changes the otherwise-empty case: whenever the first
+    // line already fits (every existing budget test), behaviour is byte-identical.
+    if (windowed.length > 0 && visualUsed + cost > avail) break;
     windowed.push(optionStyled[i]);
     windowedChromed.push(optionChromed[i]);
     visualUsed += cost;


### PR DESCRIPTION
…wport

Bug #1 — the advisory popup showed with NO selectable options (only "Send to your agent") on a short terminal/popup window. computeLayout's sticky-header tiers could fill the viewport down to avail === 0, so the option window slice came out empty.

Two additive guards, no change to the avail/windowing formulas the budget tests lock: (1) reserve MIN_OPTION_BAND_ROWS (3) when dropping Tier 2 header rows so the header stops one step before it leaves zero room for options; (2) a hard floor in the option windowing loop that always keeps at least the focused option's first line, so options.length > 0 never renders zero options.

+6 regression tests (rows 6/10/12/14 tall-header repro + roomy baseline) that fail on the pre-fix code. Full suite 7472/7472; no existing render-loop test changed.