### PR TITLE
docs(privacy): team-lead edits — Scope box to end, three sites, Repli…

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Nexpath Browser Extension — Privacy Policy</title>
-<meta name="description" content="Privacy policy for the Nexpath browser extension — an AI coding assistant for Replit, Bolt.new and Lovable. Your API key and settings stay in your browser; prompt context goes only to OpenAI using your own key. No telemetry, no tracking.">
+<meta name="description" content="Privacy policy for the Nexpath browser extension — an AI coding assistant for Replit, Lovable and Bolt.new. Your API key and settings stay in your browser; prompt context goes only to OpenAI using your own key. No telemetry, no tracking.">
 <style>
   :root{
     --bg:#ffffff; --fg:#1a1d1f; --muted:#5b6266; --rule:#e3e6e8;
@@ -57,14 +57,8 @@
 
   <header>
     <h1>Nexpath Browser Extension — Privacy Policy</h1>
-    <p class="meta">Last updated: 20 July 2026</p>
+    <p class="meta">Last updated: 3 August 2026</p>
   </header>
-
-  <div class="scope">
-    <strong>Scope.</strong> This policy covers the <strong>Nexpath browser extension</strong> for
-    Chrome and Firefox only. The Nexpath CLI and the Nexpath VS Code extension are separate products
-    with their own data practices and their own documentation.
-  </div>
 
   <p class="lede">
     Nexpath is a browser extension made by <strong>ParseOS</strong>. It is an AI coding assistant — a
@@ -73,8 +67,8 @@
   </p>
 
   <p>
-    It runs only on the supported sites: <strong>Replit</strong>, <strong>Bolt.new</strong>,
-    and <strong>Lovable</strong>. Nexpath is an independent tool and is
+    It runs only on the supported sites: <strong>Replit</strong>, <strong>Lovable</strong>,
+    and <strong>Bolt.new</strong>. Nexpath is an independent tool and is
     not affiliated with, endorsed by, or sponsored by any of them.
   </p>
 
@@ -132,7 +126,7 @@
     <li>No analytics services, advertising, or third-party trackers of any kind.</li>
     <li>No selling or transferring of your data to anyone.</li>
     <li>No use of your data for anything unrelated to generating your suggestions.</li>
-    <li>No running on websites other than the four supported AI coding sites.</li>
+    <li>No running on websites other than the three supported AI coding sites.</li>
   </ul>
 
   <h2>Data retention</h2>
@@ -154,7 +148,7 @@
     <li><strong>storage</strong> — save your API key and preferences locally.</li>
     <li><strong>tabs</strong> — show the popup on the correct agent tab when the agent finishes responding.</li>
     <li>
-      <strong>Site access</strong> (Replit, Bolt.new, Lovable) — Nexpath only works on
+      <strong>Site access</strong> (Replit, Lovable, Bolt.new) — Nexpath only works on
       these AI coding sites and runs nowhere else.
     </li>
   </ul>
@@ -170,6 +164,12 @@
 
   <h2>Contact</h2>
   <p>Questions about this policy: <a href="mailto:pyemptyops@gmail.com">pyemptyops@gmail.com</a></p>
+
+  <div class="scope">
+    <strong>Scope.</strong> This policy covers the <strong>Nexpath browser extension</strong> for
+    Chrome and Firefox only. The Nexpath CLI and the Nexpath VS Code extension are separate products
+    with their own data practices and their own documentation.
+  </div>
 
   <footer>
     Nexpath is made by ParseOS ·

--- a/src/ext-browser/CHANGELOG.md
+++ b/src/ext-browser/CHANGELOG.md
@@ -13,7 +13,7 @@ First release candidate — CLI‑parity classifier and popup.
   differential test).
 - **Natural‑language detection:** detects the language of recent prompts (tinyld) and adapts the
   suggestion wording, mirroring the CLI.
-- **Advisory popup** on Replit, Bolt, and Lovable: capture → classify → Stage‑2 → suggestion, shown
+- **Advisory popup** on Replit, Lovable, and Bolt: capture → classify → Stage‑2 → suggestion, shown
   when the agent finishes responding. Multi‑level options (L1/L2/L3), pinch/question/why‑help,
   profile‑adaptive register.
 - **Send to your agent / Copy to clipboard / Skip**, an in‑panel frequency/role chooser
@@ -35,7 +35,7 @@ First release candidate — CLI‑parity classifier and popup.
 - "Copy to clipboard" now closes the popup instead of returning to the option list (CLI
   `clipboard_only` parity).
 - **Store summary aligned to brand:** the manifest `description` (which Chrome uses as the store
-  summary) now reads "AI coding assistant for Replit, Bolt, and Lovable — a behaviour-guidance
+  summary) now reads "AI coding assistant for Replit, Lovable, and Bolt — a behaviour-guidance
   layer for vibe coders." — the same pattern the Nexpath VS Code extension uses, kept within
   Chrome's 132-char summary limit (guard-tested).
 - **Minimised permissions:** removed the unused `scripting` permission from both manifests —

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -6,14 +6,14 @@ Nexpath is an AI developer tool that works as a behaviour-guidance layer for vib
 surfaces a quick **decision session** *between* your prompts so you stay aligned with specs, tests,
 and architecture decisions, without breaking your flow.
 
-**Built for:** Replit · Bolt · Lovable — fully supported & end-to-end tested.
+**Built for:** Replit · Lovable · Bolt — fully supported & end-to-end tested.
 
 ---
 
 ## What Is Nexpath?
 
 Nexpath is an **AI coding-productivity** extension for developers using in-browser AI coding agents
-like **Replit**, **Bolt**, and **Lovable**. Think of it as an **AI pair programmer** focused on
+like **Replit**, **Lovable**, and **Bolt**. Think of it as an **AI pair programmer** focused on
 *process*, not code — it watches your session and surfaces a lightweight advisory at key transition
 points in your **coding workflow**.
 
@@ -57,7 +57,7 @@ workflow without slowing it down.
 
 1. **Install** — from the **Chrome Web Store** (Chrome / Edge) or **Firefox Add-ons**.
 2. Open Nexpath's **options** page and paste your **OpenAI API key** (`sk-…`) → **Test** → **Save**.
-3. Pick your **advisory frequency** and **role**, then start prompting in Replit, Bolt, or Lovable —
+3. Pick your **advisory frequency** and **role**, then start prompting in Replit, Lovable, or Bolt —
    Nexpath surfaces sessions when they help, right after your agent finishes responding.
 
 ---

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Nexpath",
   "version": "0.1.5",
-  "description": "AI coding assistant for Replit, Bolt, and Lovable — a behaviour-guidance layer for vibe coders.",
+  "description": "AI coding assistant for Replit, Lovable, and Bolt — a behaviour-guidance layer for vibe coders.",
   "permissions": [
     "storage",
     "tabs"

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Nexpath",
   "version": "0.1.5",
-  "description": "AI coding assistant for Replit, Bolt, and Lovable — a behaviour-guidance layer for vibe coders.",
+  "description": "AI coding assistant for Replit, Lovable, and Bolt — a behaviour-guidance layer for vibe coders.",
   "permissions": [
     "storage",
     "tabs"


### PR DESCRIPTION
…t/Lovable/Bolt order

- move the Scope disclaimer from the top to the end (kept — clarifies this policy covers the browser extension only, not the CLI/VS Code)
- 'four supported AI coding sites' -> 'three' (StackBlitz not user-facing)
- reorder site lists to Replit, Lovable, Bolt.new (site-access + affiliation line + meta description); bump last-updated date