### PR TITLE
fix(ext-browser): drop inline source maps from the store build

### DIFF
--- a/scripts/build-ext.mjs
+++ b/scripts/build-ext.mjs
@@ -48,7 +48,11 @@ const browserLoggerPlugin = {
 const commonOpts = {
   bundle:    true,
   target:    'es2022',
-  sourcemap: 'inline',
+  // No source maps in the store build. Inline source maps pushed the service
+  // worker to ~5.3 MB and Firefox AMO's linter hard-fails any file it can't
+  // parse ("File is too large to parse"). Store builds must not ship maps
+  // anyway. Opt in for local debugging with NEXPATH_EXT_SOURCEMAP=1.
+  sourcemap: process.env.NEXPATH_EXT_SOURCEMAP === '1' ? 'inline' : false,
   minify:    false,
 };
 


### PR DESCRIPTION
Inline source maps inflated service-worker.js to ~5.3 MB, which Firefox AMO's linter rejects ('File is too large to parse'). Store builds must not ship maps. SW 5.31 MB -> 1.76 MB; store zips 1.6 MB -> 0.51 MB. Opt in for local debugging with NEXPATH_EXT_SOURCEMAP=1. No functional change; typecheck:ext clean, suite 7474/7474.