### PR TITLE
fix(ext-browser): fresh Firefox gecko id for AMO re-listing (v0.1.5)

### DIFF
--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -58,7 +58,7 @@
   "options_page": "options/options.html",
   "browser_specific_settings": {
     "gecko": {
-      "id": "{1c62eba0-51eb-4052-a4b2-30c66e5aa995}",
+      "id": "{80f4c1c7-1fb2-41d9-a4a1-7c2f4981d286}",
       "strict_min_version": "112.0",
       "data_collection_permissions": {
         "required": ["authenticationInfo", "websiteContent"]


### PR DESCRIPTION
The prior AMO add-on (gecko id {1c62eba0-...}) is being deleted to publish a LISTED (public) submission. A deleted AMO add-on id is permanently unusable, so a new gecko id is required. Version stays 0.1.5 — no functional change.