### PR TITLE
fix(pe): lower the PE/MPS-1 popup cooldown default from 15 to 7 prompts

### DIFF
--- a/src/cli/commands/stop.test.ts
+++ b/src/cli/commands/stop.test.ts
@@ -147,7 +147,7 @@ describe('runStop — deferred Prompt Enhancement popup (B-i)', () => {
     expect(result).toEqual({ outcome: 'no_pending' });
   });
 
-  // Popup cooldown (prompt_enhancement.popup_cooldown, default 15): after a PE/MPS-1 popup is shown,
+  // Popup cooldown (prompt_enhancement.popup_cooldown, default 7): after a PE/MPS-1 popup is shown,
   // new ones are suppressed for N prompts. The first popup always shows.
   it('popup cooldown: the FIRST popup always shows (no prior popup this session)', async () => {
     await insertPendingPe(store); // lastPromptEnhancementPromptIndex defaults to -1 → not in cooldown
@@ -159,7 +159,7 @@ describe('runStop — deferred Prompt Enhancement popup (B-i)', () => {
 
   it('popup cooldown: a NEW popup within the cooldown is SUPPRESSED — never launched, record consumed', async () => {
     await insertPendingPe(store);
-    // A popup was just shown this prompt → cooldown active (default 15, promptCount unchanged).
+    // A popup was just shown this prompt → cooldown active (default 7, promptCount unchanged).
     SessionStateManager.load(store, '/test/project').markPromptEnhancementPopupShown(store);
     const launch = inject('SHOULD NOT SHOW');
     const result = await runStop(makePayload(), store, undefined, undefined, undefined, launch);

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -460,13 +460,13 @@ async function maybeResumeInterruptedSequenceV1(
 /**
  * Resolve the PE / MPS-1 popup cooldown (in prompts) — how many prompts to suppress NEW popups after
  * one is shown. Config `prompt_enhancement.popup_cooldown` (project-scoped first, then global),
- * default 15. 0 disables the cooldown (every eligible prompt may pop). Non-numeric / negative → default.
+ * default 7. 0 disables the cooldown (every eligible prompt may pop). Non-numeric / negative → default.
  */
 function resolvePromptEnhancementPopupCooldownV1(store: Store, projectRoot: string): number {
   const raw = getConfig(store.db, `prompt_enhancement.popup_cooldown:${projectRoot}`)
     ?? getConfig(store.db, 'prompt_enhancement.popup_cooldown');
-  const n = raw === undefined ? 15 : Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n >= 0 ? n : 15;
+  const n = raw === undefined ? 7 : Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 7;
 }
 
 /**
@@ -546,7 +546,7 @@ export async function runStop(
     if (pendingPe) {
       let decision: PromptEnhancementStopDecision;
       // Popup cooldown: after a PE / MPS-1 popup is shown, suppress NEW ones for
-      // `prompt_enhancement.popup_cooldown` prompts (default 15). The FIRST popup always shows
+      // `prompt_enhancement.popup_cooldown` prompts (default 7). The FIRST popup always shows
       // (lastPopupIndex < 0). During cooldown, consume the pending record (so it does not linger) and
       // show nothing this turn. Continuation items (MPS-2) take a different Stop path and are NOT gated.
       const popupCooldown = resolvePromptEnhancementPopupCooldownV1(store, payload.cwd);

--- a/src/cli/shared/config-setters.ts
+++ b/src/cli/shared/config-setters.ts
@@ -48,7 +48,7 @@ export const PROMPT_ENHANCEMENT_POPUP_COOLDOWN_KEY = 'prompt_enhancement.popup_c
 /**
  * Validate and persist the PE / MPS-1 popup cooldown (a NON-NEGATIVE WHOLE NUMBER of prompts) at the
  * given config key (e.g. 'prompt_enhancement.popup_cooldown' or a ':/project' scoped variant).
- * After a popup is shown, new PE / MPS-1 popups are suppressed for this many prompts (default 15;
+ * After a popup is shown, new PE / MPS-1 popups are suppressed for this many prompts (default 7;
  * 0 disables the cooldown). Empty string is accepted and treated as unset (→ default).
  */
 export function setPromptEnhancementPopupCooldown(store: Store, key: string, value: string): void {

--- a/src/core/classifier/types.ts
+++ b/src/core/classifier/types.ts
@@ -107,7 +107,7 @@ export interface SessionState {
   /**
    * promptCount when a PE / MPS-1 popup was last SHOWN (Stop hook). Used by the popup-cooldown gate:
    * after a popup, new PE / MPS-1 popups are suppressed for `prompt_enhancement.popup_cooldown`
-   * prompts (default 15). -1 / absent = none shown yet (the first popup always shows). An active
+   * prompts (default 7). -1 / absent = none shown yet (the first popup always shows). An active
    * sequence's continuation items (MPS-2) are NOT gated by this — they are not new popups.
    */
   lastPromptEnhancementPromptIndex?: number;


### PR DESCRIPTION
Owner request: change the default `prompt_enhancement.popup_cooldown` from 15 to 7. After a PE / MPS-1 popup is shown, new PE / MPS-1 popups are now suppressed for 7 prompts (the config key still overrides; 0 disables; MPS-2 continuations remain ungated).

- stop.ts: resolvePromptEnhancementPopupCooldownV1 default + invalid-fallback 15 -> 7.
- doc comments "default 15" -> "default 7" kept in sync in stop.ts, config-setters.ts, core/classifier/types.ts, stop.test.ts.

Verified: tsc clean; stop + shared tests 68 pass (the cooldown behavior tests — first-popup-shows, within-cooldown-suppressed, 0-disables — all green at 7).