### PR TITLE
Disable Prompt Enhancement Sequence by Default

### DIFF
--- a/src/config/PromptEnhancementConfig.test.ts
+++ b/src/config/PromptEnhancementConfig.test.ts
@@ -13,15 +13,15 @@ import {
 import { ConfigValidationError } from './prompt-enhancement-errors.js';
 
 describe('DEP-TEST-01-B4-01 typed PE config contract', () => {
-  it('resolves the owner default as on without an explicit row', async () => {
+  it('resolves the owner default as off without an explicit row', async () => {
     const store = await openStore(':memory:');
     try {
       const snapshot = resolvePromptEnhancementSequenceConfig(store.db, '/project/a');
-      expect(snapshot.sequenceEnabled).toBe('on');
+      expect(snapshot.sequenceEnabled).toBe('off');
       expect(snapshot.validatedEffectiveConfigState).toBe('validated_default');
       expect(snapshot.sourceScope).toBe('default');
       expect(snapshot.arbitraryConfigRowsAreAuthority).toBe(false);
-      expect(getConfig(store.db, PROMPT_ENHANCEMENT_SEQUENCE_ENABLED_KEY)).toBe('on');
+      expect(getConfig(store.db, PROMPT_ENHANCEMENT_SEQUENCE_ENABLED_KEY)).toBe('off');
     } finally {
       store.db.close();
     }

--- a/src/config/prompt-enhancement-keys.ts
+++ b/src/config/prompt-enhancement-keys.ts
@@ -1,4 +1,4 @@
 /** Owner-validated PE configuration key names. */
 export const PROMPT_ENHANCEMENT_SEQUENCE_ENABLED_KEY = 'prompt_enhancement.sequence.enabled' as const;
-export const PROMPT_ENHANCEMENT_SEQUENCE_ENABLED_DEFAULT = 'on' as const;
+export const PROMPT_ENHANCEMENT_SEQUENCE_ENABLED_DEFAULT = 'off' as const;
 

--- a/src/prompt-enhancement/facade.ts
+++ b/src/prompt-enhancement/facade.ts
@@ -25,6 +25,7 @@ import {
 import { composeStructuredComposerOutputV1 } from './llm-composer.js';
 import { decidePromptEnhancementRouteViaLlmV1, type PromptEnhancementLlmRouteDecisionV1 } from './llm-route-decision.js';
 import { isValidApiKey } from '../config/ApiKeyResolver.js';
+import { resolvePromptEnhancementSequenceConfig } from '../config/PromptEnhancementConfig.js';
 import { planPromptEnhancementSections } from './templates/section-plan.js';
 import { routePromptEnhancement, isKnownPrimaryIntent, isKnownCapabilityId, isKnownDebugEvidenceForm, describePromptEnhancementSequencePlanV1, type PromptEnhancementCapabilityId, type PromptEnhancementRouteInput } from './routing-taxonomy.js';
 import { buildPromptEnhancementGuidanceFactsV1 } from './guidance-facts.js';
@@ -469,10 +470,17 @@ async function prepare(
     }
     // else → fall through to the describe fallback (single-prompt path), exactly as today.
   }
+  // MPS-1 display gate: the first-popup sequence summary respects the SAME `prompt_enhancement.sequence.enabled`
+  // config that gates the planner + MPS-2 continuation. When deps are threaded (the auto path), read the
+  // config — 'off' suppresses the summary too, so MPS-1 and MPS-2 turn off together. Contract-typed callers
+  // (no deps) cannot read the config and keep the prior behaviour (summary shown for sequence candidates).
+  const sequenceSummaryEnabled = seqDeps === undefined
+    ? true
+    : resolvePromptEnhancementSequenceConfig(seqDeps.db, request.projectRoot).sequenceEnabled === 'on';
   const result = buildResult(request, enhancementId, route, planning, composed, safety, noPopup, {
     deterministicFallbackApplied,
     preSubstitutionAuthorityEscalationState,
-  }, plannerSummary);
+  }, plannerSummary, sequenceSummaryEnabled);
   return { result, plannerItems, plannerPromptDirectives };
 }
 
@@ -509,6 +517,10 @@ function buildResult(
   // every non-sequence prompt, on any planner failure/refusal/single-outcome, and on every caller of the
   // contract-typed `preparePromptEnhancement` (no deps) — so the describe fallback path is byte-identical.
   plannerSummary?: { remainingTaskCount: number; taskRoleLabels: readonly string[]; taskSummaryLines: readonly string[] },
+  // MPS-1 config gate: false suppresses the first-popup sequence summary (`handoffAndSequenceSummary`) so
+  // `prompt_enhancement.sequence.enabled=off` turns MPS-1 off alongside MPS-2. Defaults true so the
+  // contract-typed (no-deps) callers are byte-identical to before.
+  sequenceSummaryEnabled: boolean = true,
 ): PromptEnhancementPrepareResultV1 {
   const currentBody: PromptEnhancementCurrentBodyV1 = {
     ...composed.currentBody,
@@ -601,7 +613,7 @@ function buildResult(
   const sequencePlan = isSequenceCandidate && plannerSummary === undefined
     ? describePromptEnhancementSequencePlanV1(request.sourcePrompt.text)
     : undefined;
-  let handoffAndSequenceSummary = !noPopup && disposition === 'show_current_body' && isSequenceCandidate
+  let handoffAndSequenceSummary = !noPopup && disposition === 'show_current_body' && isSequenceCandidate && sequenceSummaryEnabled
     ? buildPromptEnhancementHandoffMetadataV1({
         handoffDecisionId: `${enhancementId}:handoff`,
         requestId: request.requestId,


### PR DESCRIPTION
# Disable Prompt Enhancement Sequence by Default

## Summary

This PR brings the latest Prompt Enhancement configuration update from my fork into the upstream `main` branch.

## Changes

* Changed `prompt_enhancement.sequence.enabled` to be **off by default**.
* Updated the MPS-1 first-popup summary to respect the same configuration setting.
* Kept the existing Prompt Enhancement popup behavior unchanged.
* Users can still enable the sequence using `config set prompt_enhancement.sequence.enabled on`.
* Preserved the existing behavior for contract-typed callers without dependencies.

## Verification

The changes have been reviewed and the updated configuration flow has been checked.

Please review the PR and merge it into `main` if everything looks good.
