### PR TITLE
chore(ext): sync package-lock version with package.json (0.1.33) — mi…

### DIFF
--- a/src/ext-vscode/package-lock.json
+++ b/src/ext-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexpath-vscode",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexpath-vscode",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12"


### PR DESCRIPTION
chore(ext): sync package-lock version with package.json (0.1.33) — mssed in 9f5ef20; same convention 