### PR TITLE
Fix Auto-Submit on Rebranded Devin Windows (Linux + Windows Focus Gates) into Staging

### DIFF
--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -208,10 +208,10 @@ function buildSubmitAdvisory(
     writeClipboard: (text) => Promise.resolve(vscode.env.clipboard.writeText(text)),
     // Reuse the shipped raiser — Linux/X11 only by design; elsewhere it returns
     // false and the paste still proceeds.
-    focus: async () => raiseAppWindow(host),
+    focus: async () => raiseAppWindow([vscode.env.appName.toLowerCase(), host === 'windsurf' ? 'devin' : 'cursor', host]),
     pasteKeystroke: () => pasteKeystroke({ win32Titles: [vscode.env.appName, host === 'cursor' ? 'Cursor' : 'Devin', 'Windsurf'] }),
     // RC11: Enter only when THIS editor is focused (one raise retry inside).
-    submitKeystroke: () => submitKeystroke({ host, focusEditor: () => void raiseAppWindow(host), appName: vscode.env.appName, submitLog: log }),
+    submitKeystroke: () => submitKeystroke({ host, focusEditor: () => void raiseAppWindow([vscode.env.appName.toLowerCase(), host === 'windsurf' ? 'devin' : 'cursor', host]), appName: vscode.env.appName, submitLog: log }),
     log,
   });
   return createSubmitAdvisoryForHost({
@@ -771,11 +771,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         writeClipboard: (text) => Promise.resolve(vscode.env.clipboard.writeText(text)),
         // Reuse the shipped raiser — Linux/X11 only by design; on other OSes it
         // returns false and the paste still proceeds (see the module's notes).
-        focus: async () => raiseAppWindow('windsurf'),
+        focus: async () => raiseAppWindow([vscode.env.appName.toLowerCase(), 'devin', 'windsurf']),
         pasteKeystroke: () => pasteKeystroke({ win32Titles: [vscode.env.appName, 'Devin', 'Windsurf'] }),
         // RC11: Enter only when Windsurf itself is focused — a blind Enter
         // pressed the Welcome view's "Start session" and closed the chat.
-        submitKeystroke: () => submitKeystroke({ host: 'windsurf', focusEditor: () => void raiseAppWindow('windsurf'), appName: vscode.env.appName, submitLog: log }),
+        submitKeystroke: () => submitKeystroke({ host: 'windsurf', focusEditor: () => void raiseAppWindow([vscode.env.appName.toLowerCase(), 'devin', 'windsurf']), appName: vscode.env.appName, submitLog: log }),
         log: (m) => log(m),
       });
 

--- a/src/ext-vscode/src/submit-clipboard-delivery.test.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.test.ts
@@ -452,10 +452,17 @@ describe('⭐ RC49 — buildWin32KeystrokeScript', () => {
     expect(ps.indexOf('GetForegroundWindow')).toBeLessThan(ps.indexOf('AppActivate'));
     expect(ps).toContain('$fg.EndsWith($t)');
   });
-  it('suffix matching, not substring — a browser tab titled "… - Chrome" cannot match', () => {
-    const ps = buildWin32KeystrokeScript(['Cursor'], '{ENTER}');
-    expect(ps).not.toContain('Contains');
-    expect(ps).toContain('EndsWith');
+  it('delimiter-safe matching (RC60 flip): mid-title app names match, bare substrings do not', () => {
+    // FLIPPED 2026-08-24 (RC60): the original pin asserted suffix-ONLY ("not
+    // substring") — which refused a real Devin foreground window titled
+    // "<folder> - Devin - <session>". The browser-tab hazard is still guarded:
+    // matching requires the delimited segment " - <name> - ", a start
+    // "<name> - ", an exact match, or the original suffix — never a bare
+    // substring anywhere in the title.
+    const ps = buildWin32KeystrokeScript(['Devin'], '{ENTER}');
+    expect(ps).toContain("$fg.EndsWith($t)");
+    expect(ps).toContain("$fg.StartsWith($t + ' - ')");
+    expect(ps).toContain("$fg.Contains(' - ' + $t + ' - ')");
   });
   it('keeps the retry rounds and the FOREGROUND diagnostic', () => {
     const ps = buildWin32KeystrokeScript(['Devin'], '{ENTER}');

--- a/src/ext-vscode/src/submit-clipboard-delivery.test.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.test.ts
@@ -473,3 +473,50 @@ describe('⭐ RC52 — win32 keystroke timeout', () => {
     expect(WIN32_KEYSTROKE_TIMEOUT_MS).toBeGreaterThanOrEqual(20_000);
   });
 });
+
+/**
+ * ⭐ RC59 — the Linux Devin-branding gate (staging tester 2026-08-24): the
+ * single 'windsurf' needle refused Enter on every Devin-branded Linux install
+ * (title "… - Devin"). The RC47 class, ported to the Linux gate at last:
+ * live appName leads, static brand names cover unthreaded callers.
+ */
+describe('⭐ RC59 — focusedWindowIsEditor brand needles', () => {
+  const deps = (title: string, appName?: string) => ({
+    platform: 'linux' as const, env: { DISPLAY: ':0' },
+    hasCommand: () => true, runCapture: () => title, appName,
+  });
+
+  it('⭐ the tester\'s exact failing title now passes for host windsurf', () => {
+    expect(focusedWindowIsEditor('windsurf', deps('nexpath testing - Devin'))).toBe(true);
+  });
+
+  it('Windsurf-branded titles keep passing (owner-machine regression pin)', () => {
+    expect(focusedWindowIsEditor('windsurf', deps('nexpath - Windsurf'))).toBe(true);
+  });
+
+  it('live appName leads — a future rebrand matches without a code change', () => {
+    expect(focusedWindowIsEditor('windsurf', deps('proj - Cascade IDE', 'Cascade IDE'))).toBe(true);
+  });
+
+  it('unrelated windows still refuse (the RC11 hazard stays guarded)', () => {
+    expect(focusedWindowIsEditor('windsurf', deps('bank statement - Chrome'))).toBe(false);
+  });
+
+  it('cursor host is unaffected by the windsurf needles', () => {
+    expect(focusedWindowIsEditor('cursor', deps('proj - Devin'))).toBe(false);
+    expect(focusedWindowIsEditor('cursor', deps('proj - Cursor'))).toBe(true);
+  });
+
+  it('⭐ the linux submit failure now NAMES its gate via submitLog', () => {
+    const logs: string[] = [];
+    submitKeystroke({
+      platform: 'linux', host: 'windsurf', appName: 'Devin',
+      env: { DISPLAY: ':0' },
+      isPopupFocused: () => false,
+      isEditorFocused: () => false, focusEditor: () => {},
+      submitLog: (m) => logs.push(m),
+    });
+    expect(logs.join(' ')).toContain('editor not focused after raise');
+    expect(logs.join(' ')).toContain('appName=Devin');
+  });
+});

--- a/src/ext-vscode/src/submit-clipboard-delivery.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.ts
@@ -257,6 +257,9 @@ export function focusedWindowIsEditor(host: 'windsurf' | 'cursor', deps: {
   env?: NodeJS.ProcessEnv;
   hasCommand?: (cmd: string) => boolean;
   runCapture?: (cmd: string, args: string[]) => string | null;
+  /** RC59: the LIVE `vscode.env.appName`, matched first — rebrands ("Devin",
+   *  "Devin - Next", …) title their windows by the live name, not "Windsurf". */
+  appName?: string;
 } = {}): boolean {
   const platform = deps.platform ?? process.platform;
   const env = deps.env ?? process.env;
@@ -269,8 +272,19 @@ export function focusedWindowIsEditor(host: 'windsurf' | 'cursor', deps: {
     const title = runCapture('xdotool', ['getactivewindow', 'getwindowname']);
     if (!title) return false;
     if (NEXPATH_POPUP_TITLE_MARKERS.some((m) => title.includes(m))) return false;
-    const needle = host === 'windsurf' ? 'windsurf' : 'cursor';
-    return title.toLowerCase().includes(needle);
+    // RC59 (Linux/Devin staging tester, 2026-08-24): the single 'windsurf'
+    // needle refused the Enter on every Devin-BRANDED Linux install — the
+    // window title is "… - Devin", no 'windsurf' substring, so this returned
+    // false, the raise (class 'windsurf') also missed, and every submit ended
+    // `submit_failed` in ~60 ms. The exact class RC47 fixed on win32
+    // (AppActivate candidates), never ported to this Linux gate: the one
+    // untested branding cell. Live appName leads; the static brand names
+    // cover machines where it is not threaded.
+    const needles = host === 'windsurf' ? ['windsurf', 'devin'] : ['cursor'];
+    const appNeedle = deps.appName?.trim().toLowerCase();
+    if (appNeedle && !needles.includes(appNeedle)) needles.unshift(appNeedle);
+    const t = title.toLowerCase();
+    return needles.some((n) => t.includes(n));
   } catch {
     return false; // cannot verify ⇒ do not press Enter blind
   }
@@ -338,9 +352,15 @@ export function submitKeystroke(deps: SubmitKeystrokeDeps = {}): boolean {
   // button and closed the user's chat.
   if (deps.host) {
     const isEditorFocused = deps.isEditorFocused ?? focusedWindowIsEditor;
-    if (!isEditorFocused(deps.host, { platform, env })) {
+    const focusDeps = { platform, env, appName: deps.appName };
+    if (!isEditorFocused(deps.host, focusDeps)) {
       deps.focusEditor?.();
-      if (!isEditorFocused(deps.host, { platform, env })) return false;
+      if (!isEditorFocused(deps.host, focusDeps)) {
+        // RC59: name the refusing gate — the linux submit_failed used to be
+        // indistinguishable from a missing tool (same one-line outcome).
+        deps.submitLog?.(`[nexpath] submit-linux: editor not focused after raise (host=${deps.host}, appName=${deps.appName ?? 'unset'})`);
+        return false;
+      }
     }
   }
   // CORRECTED 2026-08-10 — these previously defaulted to `() => false`, which made
@@ -414,10 +434,15 @@ export function submitKeystroke(deps: SubmitKeystrokeDeps = {}): boolean {
       return false;
     }
     // Linux (X11, or Wayland with a compatible tool)
-    if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return false;
+    if (!env.DISPLAY && !env.WAYLAND_DISPLAY) {
+      deps.submitLog?.('[nexpath] submit-linux: no DISPLAY/WAYLAND_DISPLAY in env');
+      return false;
+    }
     if (has('xdotool')) return run('xdotool', ['key', '--clearmodifiers', 'Return']);
     if (has('wtype')) return run('wtype', ['-k', 'Return']);
     if (has('ydotool')) return run('ydotool', ['key', '28:1', '28:0']); // KEY_ENTER
+    // RC59: the silent false here looked identical to the focus refusal.
+    deps.submitLog?.('[nexpath] submit-linux: no keystroke tool found (xdotool/wtype/ydotool)');
     return false;
   } catch {
     return false;

--- a/src/ext-vscode/src/submit-clipboard-delivery.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.ts
@@ -329,7 +329,15 @@ export function buildWin32KeystrokeScript(titles: readonly string[], sendKeys: s
     `$w=New-Object -ComObject WScript.Shell;` +
     `$b=New-Object System.Text.StringBuilder 256;[void][W.U]::GetWindowText([W.U]::GetForegroundWindow(),$b,256);$fg=$b.ToString();` +
     `$ok=$false;` +
-    `foreach($t in @(${psTitles})){if($fg -eq $t -or $fg.EndsWith($t)){$ok=$true;break}};` +
+    // RC60 (Windows/Devin staging tester, 2026-08-24): this Devin build titles
+    // windows "<folder> - Devin - <session title>" — the app name sits MID-title,
+    // so suffix-only matching refused a foreground window that WAS the editor
+    // (FOREGROUND=testing - Devin - set up my food delivery app…; status=1).
+    // Delimiter-safe containment (" - Devin - ") accepts every editor shape
+    // (suffix, prefix-with-delimiter, mid-title) while still rejecting the
+    // browser-tab hazard EndsWith was built for ("Cursor docs - Chrome" has no
+    // delimited " - Cursor - " segment).
+    `foreach($t in @(${psTitles})){if($fg -eq $t -or $fg.EndsWith($t) -or $fg.StartsWith($t + ' - ') -or $fg.Contains(' - ' + $t + ' - ')){$ok=$true;break}};` +
     `if(-not $ok){` +
     `foreach($r in 1..2){` +
     `foreach($t in @(${psTitles})){if($w.AppActivate($t)){$ok=$true;break}};` +

--- a/src/ext-vscode/src/windsurf-autopaste.test.ts
+++ b/src/ext-vscode/src/windsurf-autopaste.test.ts
@@ -110,3 +110,27 @@ describe('⭐ RC49 — pasteKeystroke win32 targeting', () => {
     expect(calls[0]!.join(' ')).not.toContain('GetForegroundWindow');
   });
 });
+
+/** ⭐ RC59 — raiseAppWindow candidate list: rebranded hosts carry their own WM_CLASS. */
+describe('⭐ RC59 — raiseAppWindow candidates', () => {
+  it('tries each candidate until one raises', () => {
+    const tried: string[] = [];
+    const ok = raiseAppWindow(['devin', 'windsurf'], {
+      platform: 'linux', env: { DISPLAY: ':0' },
+      hasCommand: (c) => c === 'wmctrl',
+      run: (_c, args) => { tried.push(args[2]!); return args[2] === 'windsurf'; },
+    });
+    expect(ok).toBe(true);
+    expect(tried).toEqual(['devin', 'windsurf']);
+  });
+
+  it('a single string keeps the old behaviour byte-identical', () => {
+    const tried: string[] = [];
+    raiseAppWindow('windsurf', {
+      platform: 'linux', env: { DISPLAY: ':0' },
+      hasCommand: (c) => c === 'wmctrl',
+      run: (_c, args) => { tried.push(args[2]!); return true; },
+    });
+    expect(tried).toEqual(['windsurf']);
+  });
+});

--- a/src/ext-vscode/src/windsurf-autopaste.ts
+++ b/src/ext-vscode/src/windsurf-autopaste.ts
@@ -64,15 +64,18 @@ function defaultRun(cmd: string, args: string[]): boolean {
  * (Linux/X11). No-op (returns false) elsewhere or when no tool is present.
  * `appClass` is matched against the X11 window class (e.g. 'windsurf', 'cursor').
  */
-export function raiseAppWindow(appClass: string, deps: AutoPasteDeps = {}): boolean {
+export function raiseAppWindow(appClass: string | readonly string[], deps: AutoPasteDeps = {}): boolean {
   const platform = deps.platform ?? process.platform;
   const env = deps.env ?? process.env;
   if (platform !== 'linux') return false;
   if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return false;
   const has = deps.hasCommand ?? defaultHasCommand;
   const run = deps.run ?? defaultRun;
-  if (has('wmctrl')) return run('wmctrl', ['-x', '-a', appClass]);
-  if (has('xdotool')) return run('xdotool', ['search', '--class', appClass, 'windowactivate', '--sync']);
+  // RC59: rebranded hosts (Devin) carry their own WM_CLASS — try every
+  // candidate until one raises. A single string keeps the old behaviour.
+  const candidates = typeof appClass === 'string' ? [appClass] : appClass;
+  if (has('wmctrl')) return candidates.some((c) => run('wmctrl', ['-x', '-a', c]));
+  if (has('xdotool')) return candidates.some((c) => run('xdotool', ['search', '--class', c, 'windowactivate', '--sync']));
   return false;
 }
 


### PR DESCRIPTION
## Overview
This PR fixes the auto-submit failures both staging testers reported today on
Devin-branded installs: the popup and inject worked, but the final Enter was refused by
the editor-focus safety gates, which only recognised "Windsurf"-shaped window titles.

## What's Included
- Linux focus gate: recognises the live application name and the Devin branding — the
  previous single "windsurf" needle refused every auto-submit on Devin-branded Linux
  installs (the Ubuntu tester's `submit failed` in ~60 ms).
- Windows foreground match: accepts the app name mid-title with delimiter-safe matching —
  this Devin build titles windows "<folder> - Devin - <session>", which the previous
  suffix-only match refused even though the editor was the foreground window (the Windows
  tester's `AppActivate failed` line).
- Window raising tries candidate window classes (live app name, Devin, Windsurf) instead
  of a single hardcoded class.
- The safety hazards both gates exist for remain guarded: bare substrings and browser-tab
  titles ("… - Chrome") are still refused, and unrelated windows never receive the Enter.
- Linux submit failures now name their exact gate in the log (focus / missing tool /
  no display), so any future report is a one-line diagnosis.
- No flow, popup, or delivery logic is touched — these are the keystroke targeting gates
  only; all other platforms and the switch-off (old flow) behaviour are byte-identical.

## Verification
The extension suite passes (1156 tests, including new pins for both testers' exact
window titles and flipped pins documenting the deliberate matching change). The Linux fix
was live-verified on a real Devin-titled focused window; the Windows matching semantics
were proven with an ordinal truth table over the tester's exact title plus the
must-refuse hazard cases. TypeScript validation passes.

Please review the changes and merge this PR into staging if everything looks good — both
staging testers can then pull, rebuild, and retest the same prompts.