### PR TITLE
Merge Queue-Flush and Popup-Cleanup Fixes into Staging

### DIFF
--- a/src/cli/commands/cursor-hook.ts
+++ b/src/cli/commands/cursor-hook.ts
@@ -35,6 +35,7 @@ import { runSequenceContinuationStop } from './submit-stop-decider.js';
 import { checkAndRecordCursorInvocation } from '../../cursor-hook/invocation-guard.js';
 import { bringPopupToFront } from '../../windsurf-hook/foreground.js';
 import { log } from '../../logger.js';
+import { killProcessTree } from '../../utils/kill-tree.js';
 import { readFileSync } from 'node:fs';
 
 /**
@@ -426,7 +427,7 @@ export async function runCursorHookAction(
         if (waited.timedOut) {
           // Hold exhausted before auto finished: do NOT decide (the signal never
           // landed) and never leave an orphan (R2 — Cursor won't reap it).
-          try { child?.kill(); } catch { /* already gone */ }
+          killProcessTree(child); // RC62: take the popup terminal too
         }
         logEvent('info', 'cursor_hook_auto', { spawned: child != null, timed_out: waited.timedOut === true });
       } else {
@@ -445,7 +446,7 @@ export async function runCursorHookAction(
         // Hold exhausted while the popup waited: fail open AND reap the stop
         // child — Cursor never reaps timed-out hooks (R2), and stop's popups
         // wait on the user with no bound of their own.
-        try { stopChildRef.current?.kill(); } catch { /* already gone */ }
+        killProcessTree(stopChildRef.current); // RC62: take the popup terminal too
       }
       if (!decided.timedOut && decided.value === 'block') decision = 'block';
       logEvent('info', 'cursor_hook_decision', {

--- a/src/cli/commands/windsurf-hook.ts
+++ b/src/cli/commands/windsurf-hook.ts
@@ -34,6 +34,7 @@ import {
 } from './submit-option-source.js';
 import { openStore, closeStore } from '../../store/db.js';
 import { log } from '../../logger.js';
+import { killProcessTree } from '../../utils/kill-tree.js';
 import { getPendingAdvisory, markAdvisoryShown } from '../../store/pending-advisories.js';
 import { isSubmitAdvisoryEnabledForHost } from './submit-flow-config.js';
 import { writeSubmitDecision, readReplacementEchoes, latestReplacementEchoAt,
@@ -774,7 +775,7 @@ export async function runWindsurfHookAction(
         decideAfterAuto = false;
         // No orphan may survive the hold (plan acceptance). The child is
         // detached from our lifetime explicitly rather than left running.
-        try { result.child?.kill(); } catch { /* already gone */ }
+        killProcessTree(result.child); // RC62: take the popup terminal too
       }
     } else {
       await waitForChild(result.child);
@@ -801,7 +802,7 @@ export async function runWindsurfHookAction(
       if (decided.timedOut) {
         // Hold exhausted while stop's popup waited — reap it so no popup
         // process outlives the hook (mirrors the auto orphan-kill above).
-        try { stopChildRef.current?.kill(); } catch { /* already gone */ }
+        killProcessTree(stopChildRef.current); // RC62: take the popup terminal too
       }
       // `!decided.timedOut` is likewise redundant today (a timed-out run yields
       // no value, so `value === 'block'` is already false) and equally kept as an

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -24,7 +24,7 @@ import { createInjectedRecordStore } from './injected-record.js';
 import { injectPeBody, injectPeBodyWithFallback, resolvePeVisibleSurfaceAckState } from './pe-delivery.js';
 import { createPePoller, type PePoller } from './pe-poller.js';
 import { createSubmitHookPoller, type SubmitHookPoller } from './submit-hook-poller.js';
-import { createSubmitClipboardDelivery, submitKeystroke, lastDarwinSubmitError, isDarwinAccessibilityDenial } from './submit-clipboard-delivery.js';
+import { createSubmitClipboardDelivery, submitKeystroke, lastDarwinSubmitError, isDarwinAccessibilityDenial, scheduleWindsurfQueueFlush } from './submit-clipboard-delivery.js';
 import {
   isWindsurfSubmitAdvisoryEnabled,
   isCursorSubmitAdvisoryEnabled,
@@ -848,6 +848,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         ),
         onOutcome: (outcome) => {
           log(`[nexpath] submit delivery outcome: ${outcome}`);
+          // RC61: a busy/reconnecting Devin session parks a delivered submit as
+          // "1 queued message" that only a further Enter sends — tap once.
+          if (outcome === 'delivered' && host === 'windsurf') {
+            scheduleWindsurfQueueFlush(
+              () => submitKeystroke({ host, focusEditor: () => void raiseAppWindow([vscode.env.appName.toLowerCase(), 'devin', 'windsurf']), appName: vscode.env.appName, submitLog: log }),
+              log,
+            );
+          }
           // RC16 (macOS tester, 2026-08-15): on darwin the auto-send keystroke
           // needs the Accessibility permission for the HOST APP. Without it the
           // refined text sits in the composer with zero guidance. One-time,

--- a/src/ext-vscode/src/submit-clipboard-delivery.test.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.test.ts
@@ -20,6 +20,7 @@ import {
   isDarwinAccessibilityDenial,
   buildWin32KeystrokeScript,
   WIN32_KEYSTROKE_TIMEOUT_MS,
+  scheduleWindsurfQueueFlush,
 } from './submit-clipboard-delivery.js';
 
 function deliveryHarness(over: Partial<SubmitClipboardDeliveryDeps> = {}) {
@@ -525,5 +526,45 @@ describe('⭐ RC59 — focusedWindowIsEditor brand needles', () => {
     });
     expect(logs.join(' ')).toContain('editor not focused after raise');
     expect(logs.join(' ')).toContain('appName=Devin');
+  });
+});
+
+/**
+ * ⭐ RC61 — the Devin queue-flush tap: a busy/reconnecting session parks a
+ * delivered submit as "1 queued message" that only a further Enter sends
+ * (the composer's own placeholder says so). One guarded tap, no-op when
+ * nothing queued.
+ */
+describe('⭐ RC61 — scheduleWindsurfQueueFlush', () => {
+  it('⭐ fires the submit fn exactly once after the delay, through the caller\'s guards', () => {
+    let fired = 0; const logs: string[] = [];
+    let scheduled: (() => void) | null = null; let delay = 0;
+    scheduleWindsurfQueueFlush(
+      () => { fired += 1; return true; },
+      (l) => logs.push(l),
+      2_500,
+      (fn, ms) => { scheduled = fn as () => void; delay = ms; return 0; },
+    );
+    expect(fired).toBe(0);          // nothing before the delay
+    expect(delay).toBe(2_500);
+    scheduled!();
+    expect(fired).toBe(1);
+    expect(logs.join(' ')).toContain('submit-queue-flush: tapped');
+  });
+
+  it('guards refusing ⇒ logged as skipped, never retried', () => {
+    const logs: string[] = [];
+    let scheduled: (() => void) | null = null;
+    scheduleWindsurfQueueFlush(() => false, (l) => logs.push(l), 1, (fn) => { scheduled = fn as () => void; return 0; });
+    scheduled!();
+    expect(logs.join(' ')).toContain('skipped (guards refused)');
+  });
+
+  it('a throwing submit fn is swallowed (the flush is best-effort)', () => {
+    const logs: string[] = [];
+    let scheduled: (() => void) | null = null;
+    scheduleWindsurfQueueFlush(() => { throw new Error('boom'); }, (l) => logs.push(l), 1, (fn) => { scheduled = fn as () => void; return 0; });
+    expect(() => scheduled!()).not.toThrow();
+    expect(logs.join(' ')).toContain('threw (ignored)');
   });
 });

--- a/src/ext-vscode/src/submit-clipboard-delivery.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.ts
@@ -456,3 +456,39 @@ export function submitKeystroke(deps: SubmitKeystrokeDeps = {}): boolean {
     return false;
   }
 }
+
+/**
+ * RC61 (Windows/Devin staging tester, 2026-08-24): when the agent session is
+ * busy or reconnecting at submit time ("Navigating.. Connecting to server"),
+ * Devin ACCEPTS the submitted replacement but parks it as "1 queued message" —
+ * and this build's queue does not auto-flush: the composer's own placeholder
+ * reads "Enter to send queued message (⏎)". The tester had to press that
+ * Enter by hand.
+ *
+ * This schedules exactly ONE follow-up Enter after a DELIVERED submit: if the
+ * message ran normally the composer is empty and the tap is a no-op (Cascade
+ * ignores Enter on an empty input); if it queued, the tap is the flush the UI
+ * asks for. The tap goes through the SAME `submitKeystroke` guards — the RC10
+ * popup-focus refusal, the RC11/RC59 editor-focus whitelist, the RC49/60
+ * win32 foreground script — and the RC43/46 quiet windows guarantee no
+ * Nexpath popup can be open this soon after a block, so the Enter cannot land
+ * anywhere but the editor's composer. Windsurf/Devin only — Cursor has no
+ * queue affordance and has never needed it.
+ */
+export const WINDSURF_QUEUE_FLUSH_DELAY_MS = 2_500;
+
+export function scheduleWindsurfQueueFlush(
+  submitFn: () => boolean,
+  log: (line: string) => void,
+  delayMs: number = WINDSURF_QUEUE_FLUSH_DELAY_MS,
+  setTimeoutFn: (fn: () => void, ms: number) => unknown = setTimeout,
+): void {
+  setTimeoutFn(() => {
+    try {
+      const ok = submitFn();
+      log(`[nexpath] submit-queue-flush: ${ok ? 'tapped' : 'skipped (guards refused)'} — no-op if nothing was queued`);
+    } catch {
+      log('[nexpath] submit-queue-flush: threw (ignored)');
+    }
+  }, delayMs);
+}

--- a/src/utils/kill-tree.test.ts
+++ b/src/utils/kill-tree.test.ts
@@ -1,0 +1,47 @@
+/** ⭐ RC62 — expiry reap takes the popup's terminal, not just the stop process. */
+import { describe, it, expect, vi } from 'vitest';
+import { killProcessTree } from './kill-tree.js';
+
+const fakeChild = (pid: number | undefined) => {
+  const kill = vi.fn();
+  return { child: { pid, kill } as never, kill };
+};
+
+describe('⭐ RC62 — killProcessTree', () => {
+  it('⭐ win32 uses taskkill /T /F on the child pid (tree incl. the start-window)', () => {
+    const calls: string[][] = [];
+    const { child } = fakeChild(4242);
+    killProcessTree(child, { platform: 'win32', runSync: (c, a) => { calls.push([c, ...a]); return {}; } });
+    expect(calls).toEqual([['taskkill', '/PID', '4242', '/T', '/F']]);
+  });
+
+  it('⭐ posix kills descendants (children-first) then the child itself', () => {
+    const killed: number[] = [];
+    const { child, kill } = fakeChild(100);
+    killProcessTree(child, {
+      platform: 'linux',
+      runSync: (_c, a) => {
+        const p = a[1];
+        if (p === '100') return { stdout: '200\n' };
+        if (p === '200') return { stdout: '300\n' };  // popup terminal under stop's child
+        return { stdout: '' };
+      },
+      killFn: (pid) => killed.push(pid),
+    });
+    expect(killed).toEqual([300, 200]);   // grandchild before child
+    expect(kill).toHaveBeenCalled();       // the stop child last
+  });
+
+  it('no child ⇒ no-op; no pid ⇒ falls back to plain kill (pre-RC62 behaviour)', () => {
+    expect(() => killProcessTree(null)).not.toThrow();
+    const { child, kill } = fakeChild(undefined);
+    killProcessTree(child);
+    expect(kill).toHaveBeenCalled();
+  });
+
+  it('a throwing runner still falls back to plain kill (fail-open reap)', () => {
+    const { child, kill } = fakeChild(7);
+    killProcessTree(child, { platform: 'linux', runSync: () => { throw new Error('no pgrep'); } });
+    expect(kill).toHaveBeenCalled();
+  });
+});

--- a/src/utils/kill-tree.ts
+++ b/src/utils/kill-tree.ts
@@ -1,0 +1,55 @@
+/**
+ * RC62 (Windows/Devin staging tester, 2026-08-24 — second live hit of the H4
+ * orphan-window mode): when the hold budget expires with a popup unanswered,
+ * the hook fails open (the prompt runs — correct) and reaps the `stop` child —
+ * but a plain `child.kill()` leaves the popup's TERMINAL alive: on win32 the
+ * console window `cmd start` opened, on Linux the gnome-terminal tab. The
+ * user then sees a live-looking popup whose Enter does nothing.
+ *
+ * Kill the DESCENDANT TREE instead — used ONLY on the already-failed expiry
+ * paths, so the normal flow is untouched by construction. Everything is
+ * best-effort and swallowed: reaping must never break the fail-open exit.
+ */
+import { spawnSync } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+
+export function killProcessTree(
+  child: ChildProcess | null | undefined,
+  deps: {
+    platform?: NodeJS.Platform;
+    runSync?: (cmd: string, args: string[]) => { stdout?: string | null };
+    killFn?: (pid: number) => void;
+  } = {},
+): void {
+  if (!child) return;
+  if (typeof child.pid !== 'number') {
+    // No pid to walk (already-reaped or synthetic child) — plain kill is all
+    // that is possible and all that was ever done here before RC62.
+    try { child.kill(); } catch { /* already gone */ }
+    return;
+  }
+  const platform = deps.platform ?? process.platform;
+  const runSync = deps.runSync ?? ((cmd: string, args: string[]) => {
+    try { return spawnSync(cmd, args, { encoding: 'utf8', timeout: 4000, stdio: ['ignore', 'pipe', 'ignore'] }); }
+    catch { return { stdout: null }; }
+  });
+  const kill = deps.killFn ?? ((pid: number) => { try { process.kill(pid); } catch { /* gone */ } });
+  try {
+    if (platform === 'win32') {
+      // taskkill /T takes the whole tree — the start-window console included.
+      runSync('taskkill', ['/PID', String(child.pid), '/T', '/F']);
+      return;
+    }
+    // POSIX: walk descendants via pgrep -P (depth-first), children before parent.
+    const collect = (pid: number, depth: number): number[] => {
+      if (depth > 6) return [];
+      const out = runSync('pgrep', ['-P', String(pid)]).stdout ?? '';
+      const kids = out.split('\n').map((l) => parseInt(l.trim(), 10)).filter((n) => Number.isFinite(n) && n > 1);
+      return kids.flatMap((k) => [...collect(k, depth + 1), k]);
+    };
+    for (const pid of collect(child.pid, 0)) kill(pid);
+    try { child.kill(); } catch { /* already gone */ }
+  } catch {
+    try { child.kill(); } catch { /* already gone */ }
+  }
+}


### PR DESCRIPTION
## Overview
This PR brings two small delivery-polish fixes into staging, addressing the last two
behaviours the Windows staging tester hit: a delivered replacement parked in Devin's
message queue awaiting a manual Enter, and an unanswered popup surviving as a dead
window after its hold expired.

## What's Included
- Queue-flush tap: after a delivered submit on Windsurf/Devin, one guarded follow-up
  Enter fires 2.5 s later — a busy or reconnecting session parks the replacement as
  "1 queued message" whose composer asks for a manual Enter; the tap sends it. When
  nothing is queued the composer is empty and the tap is a no-op. It runs through the
  full existing guard stack (popup-focus refusal, editor whitelist, foreground
  targeting), and the quiet windows guarantee no Nexpath popup can be open that soon
  after a block. Cursor is untouched.
- Popup cleanup on hold expiry: when a popup goes unanswered and the hold budget
  expires, the reap now takes the popup's whole process tree — the terminal window
  included — so the popup closes itself as the original prompt proceeds, instead of
  surviving as a dead window. This code lives only in the four expiry branches, which
  the normal flow never executes.
- Kept the related tests in sync: new pins for the tap (single fire through guards,
  refusal logged, throw swallowed) and the tree reap (taskkill shape, children-first
  walk, fallbacks).

## Verification
The entire diff against current staging is seven files: two new utility files, two
test files, and three production files whose changes are one-line swaps inside
already-failed expiry branches plus one gated post-delivery addition — everything
else is byte-identical to the build both staging testers validated today. The
extension suite (1159 tests) and the root suite pass, including TypeScript
validation.

Please review the changes and merge this PR into staging if everything looks good —
the Windows tester can then rerun the same flow and should see the queued message
send itself, and any ignored popup close itself when their prompt proceeds.