### PR TITLE
release(0.1.34 content): RC63–RC66 post-publish fixes — delivery stall, Devin duplicate popups, cold-inject latency, spaced-username setup loop

### DIFF
--- a/src/cli/commands/windsurf-hook.test.ts
+++ b/src/cli/commands/windsurf-hook.test.ts
@@ -7,8 +7,13 @@ import {
   registerWindsurfHookCommand,
   runWindsurfHookAction,
   isReplacementEcho,
+  isDuplicateWindsurfInvocation,
   WINDSURF_BLOCK_CARD_MESSAGE,
 } from './windsurf-hook.js';
+import {
+  WINDSURF_INVOCATION_DIRNAME,
+  WINDSURF_FALLBACK_WINDOW_MS,
+} from '../../cursor-hook/invocation-guard.js';
 
 describe('handleWindsurfHookCli', () => {
   it('reads stdin and dispatches (event, raw, {cwd}) to the handler', async () => {
@@ -571,5 +576,141 @@ describe('⭐ RC46 — post_cascade_response quiet window without a sequence', (
     expect(handle).not.toHaveBeenCalled();
     expect(exits).toEqual([0]);
     await tmp.rm(proj, { recursive: true, force: true });
+  });
+});
+
+/**
+ * ⭐ RC64 — Windows Devin executes BOTH the global and the workspace
+ * hooks.json (RC21-era builds ran only the workspace file). One submit then
+ * spawned two full pipelines: two autos prepared two DIFFERENT enhancements,
+ * two popups, two blocks, two injected replacements (2026-08-25 tester
+ * screenshot: both queued). The twin must exit 0 having spawned NOTHING;
+ * the primary's exit 2 still blocks (Windsurf blocks on ANY hook's 2).
+ */
+describe('⭐ RC64 — duplicate windsurf invocations (global + workspace both execute)', () => {
+  const GATE_ENV = { NEXPATH_WINDSURF_PROMPTSUBMIT_ADVISORY: '1' };
+
+  async function tmpRoot(prefix: string) {
+    const fs = await import('node:fs/promises');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  }
+
+  it('key selection: execution_id → 10-min window; fallback trajectory+hash → SHORT window; neither → fail-open', () => {
+    const calls: Array<{ key: string; deps: { dirName?: string; maxAgeMs?: number } }> = [];
+    const spy = ((_r: string, _e: string, key: string, deps: never) => {
+      calls.push({ key, deps }); return false;
+    }) as never;
+    isDuplicateWindsurfInvocation('/r', 'pre_user_prompt',
+      { execution_id: 'e1', trajectory_id: 't', tool_info: { user_prompt: 'p' } }, spy);
+    isDuplicateWindsurfInvocation('/r', 'pre_user_prompt',
+      { trajectory_id: 't', tool_info: { user_prompt: 'p' } }, spy);
+    const none = isDuplicateWindsurfInvocation('/r', 'pre_user_prompt', {}, spy);
+    expect(calls[0]!.key).toBe('e1');
+    expect(calls[0]!.deps.dirName).toBe(WINDSURF_INVOCATION_DIRNAME);
+    expect(calls[0]!.deps.maxAgeMs).toBeUndefined(); // execution_id is unique per action — cursor default window
+    expect(calls[1]!.key.startsWith('t-')).toBe(true);
+    expect(calls[1]!.deps.maxAgeMs).toBe(WINDSURF_FALLBACK_WINDOW_MS);
+    expect(none).toEqual({ duplicate: false, key_kind: 'none' });
+    expect(calls).toHaveLength(2); // the keyless payload never reached the guard
+  });
+
+  it('⭐ pre leg: the twin exits 0 having spawned NOTHING (no auto, no decider)', async () => {
+    const root = await tmpRoot('rc64-pre-');
+    const PAYLOAD = JSON.stringify({
+      trajectory_id: 't-1', execution_id: 'exec-A',
+      tool_info: { user_prompt: 'hello world' },
+    });
+    const run = async () => {
+      const exits: number[] = [];
+      const handle = vi.fn(async () => ({ child: null } as never));
+      const decide = vi.fn(async () => 'allow' as const);
+      await runWindsurfHookAction('pre_user_prompt', { project: root }, {
+        env: { ...GATE_ENV },
+        readStdin: async () => PAYLOAD,
+        checkReplacementEcho: async () => false,
+        decidePromptSubmit: decide,
+        handle, waitForChild: async () => {}, raisePopup: () => {},
+        exit: (c: number) => { exits.push(c); },
+      } as never);
+      return { exits, handle, decide };
+    };
+    const first = await run();
+    expect(first.handle).toHaveBeenCalledTimes(1); // primary runs the full flow
+    expect(first.decide).toHaveBeenCalledTimes(1);
+    const twin = await run();
+    expect(twin.handle).not.toHaveBeenCalled();
+    expect(twin.decide).not.toHaveBeenCalled();
+    expect(twin.exits).toEqual([0]);
+    const fs = await import('node:fs/promises');
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('⭐ post leg: the twin never re-runs the continuation (no second MPS popup) nor the sweep', async () => {
+    const root = await tmpRoot('rc64-post-');
+    const PAYLOAD = JSON.stringify({
+      trajectory_id: 't-1', execution_id: 'exec-B',
+      tool_info: { response: 'done.' },
+    });
+    const run = async () => {
+      const exits: number[] = [];
+      const handle = vi.fn(async () => ({ child: null } as never));
+      const cont = vi.fn(async () => ({ ran: false }));
+      const suppress = vi.fn(async () => 0);
+      await runWindsurfHookAction('post_cascade_response', { project: root }, {
+        env: { ...GATE_ENV },
+        readStdin: async () => PAYLOAD,
+        checkReplacementEcho: async () => false,
+        suppressOldAdvisorySurface: suppress,
+        runSequenceContinuation: cont,
+        handle, waitForChild: async () => {}, raisePopup: () => {},
+        exit: (c: number) => { exits.push(c); },
+      } as never);
+      return { exits, cont, suppress };
+    };
+    const first = await run();
+    expect(first.suppress).toHaveBeenCalledTimes(1);
+    expect(first.cont).toHaveBeenCalledTimes(1);
+    const twin = await run();
+    expect(twin.cont).not.toHaveBeenCalled();
+    expect(twin.suppress).not.toHaveBeenCalled();
+    expect(twin.exits).toEqual([0]);
+    const fs = await import('node:fs/promises');
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('distinct execution_ids are never deduped (two REAL submits back-to-back)', async () => {
+    const root = await tmpRoot('rc64-distinct-');
+    const run = async (execId: string) => {
+      const handle = vi.fn(async () => ({ child: null } as never));
+      await runWindsurfHookAction('pre_user_prompt', { project: root }, {
+        env: { ...GATE_ENV },
+        readStdin: async () => JSON.stringify({
+          trajectory_id: 't-1', execution_id: execId, tool_info: { user_prompt: 'same text' },
+        }),
+        checkReplacementEcho: async () => false,
+        decidePromptSubmit: async () => 'allow' as const,
+        handle, waitForChild: async () => {}, raisePopup: () => {}, exit: () => {},
+      } as never);
+      return handle;
+    };
+    expect(await run('exec-1')).toHaveBeenCalledTimes(1);
+    expect(await run('exec-2')).toHaveBeenCalledTimes(1);
+    const fs = await import('node:fs/promises');
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('⭐ switch OFF ⇒ the guard is never consulted (old flow byte-identical)', async () => {
+    const check = vi.fn(() => ({ duplicate: true, key_kind: 'execution_id' as const }));
+    const handle = vi.fn(async () => ({ child: null } as never));
+    await runWindsurfHookAction('pre_user_prompt', { project: '/proj' }, {
+      env: {},
+      checkDuplicateInvocation: check,
+      handle, checkReplacementEcho: async () => false,
+      waitForChild: async () => {}, raisePopup: () => {}, exit: () => {},
+    } as never);
+    expect(check).not.toHaveBeenCalled();
+    expect(handle).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/commands/windsurf-hook.ts
+++ b/src/cli/commands/windsurf-hook.ts
@@ -25,7 +25,13 @@
  */
 import type { Command } from 'commander';
 import type { ChildProcess } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { runWindsurfHook, parsePayload, type RunResult } from '../../windsurf-hook/handler.js';
+import {
+  checkAndRecordCursorInvocation,
+  WINDSURF_INVOCATION_DIRNAME,
+  WINDSURF_FALLBACK_WINDOW_MS,
+} from '../../cursor-hook/invocation-guard.js';
 import { decideSubmitPrompt, type DeciderOptionSet, type DeciderSelection } from './submit-prompt-decider.js';
 import { runSequenceContinuationStop, SEQUENCE_CONTINUATION_QUIET_MS } from './submit-stop-decider.js';
 import {
@@ -349,6 +355,54 @@ export const WINDSURF_BLOCK_CARD_MESSAGE = 'Nexpath held this prompt';
  * Fail-open: any failure (no store, no state) reports `false` and the normal
  * path runs — worst case is today's behaviour, never a stranded prompt.
  */
+/**
+ * RC64 — duplicate hook-invocation guard, Windsurf half (Windows Devin,
+ * 2026-08-25). Windows registers BOTH the global `~/.codeium/windsurf/hooks.json`
+ * and the workspace `.windsurf/hooks.json` (RC21: that era's Devin executed
+ * ONLY the workspace file, so the global entry was inert armor — the newer
+ * Devin build executes BOTH). One submit then spawned two full pipelines: two
+ * autos prepared two DIFFERENT enhancements, two popups, two blocks, two
+ * injected replacements (tester screenshot: both queued behind the busy
+ * session). Same class as Cursor §8.1, same cure as RC50/56: an atomic
+ * exclusive-create claim, keyed on the payload's per-action `execution_id`
+ * (Windsurf's analog of Cursor's `generation_id`). The first invocation wins
+ * and runs everything; the twin exits 0 untouched — Windsurf blocks on ANY
+ * hook's exit 2, so the twin allowing changes nothing about the cancel
+ * (empirically: with both invocations blocking today, one card renders).
+ *
+ * Fallback when a payload has no `execution_id`: trajectory + content hash,
+ * with the SHORT `WINDSURF_FALLBACK_WINDOW_MS` — that key repeats on a
+ * legitimate same-text resubmit, and duplicates arrive milliseconds apart
+ * (RC50 measured 2–100 ms). No trajectory either ⇒ fail-open, run the flow.
+ */
+export function isDuplicateWindsurfInvocation(
+  projectRoot: string,
+  event: string,
+  payload: ReturnType<typeof parsePayload>,
+  guard: typeof checkAndRecordCursorInvocation = checkAndRecordCursorInvocation,
+): { duplicate: boolean; key_kind: 'execution_id' | 'fallback' | 'none' } {
+  const execId = payload?.execution_id ?? '';
+  if (execId) {
+    return {
+      duplicate: guard(projectRoot, event, execId, { dirName: WINDSURF_INVOCATION_DIRNAME }),
+      key_kind: 'execution_id',
+    };
+  }
+  const trajectory = payload?.trajectory_id ?? '';
+  if (!trajectory) return { duplicate: false, key_kind: 'none' };
+  const content = event === 'pre_user_prompt'
+    ? payload?.tool_info?.user_prompt ?? ''
+    : payload?.tool_info?.response ?? '';
+  const key = `${trajectory}-${createHash('sha256').update(content).digest('hex').slice(0, 16)}`;
+  return {
+    duplicate: guard(projectRoot, event, key, {
+      dirName: WINDSURF_INVOCATION_DIRNAME,
+      maxAgeMs: WINDSURF_FALLBACK_WINDOW_MS,
+    }),
+    key_kind: 'fallback',
+  };
+}
+
 export async function isReplacementEcho(
   projectRoot: string | undefined,
   promptText: string,
@@ -437,6 +491,8 @@ export interface WindsurfHookActionDeps {
   suppressOldAdvisorySurface?: (projectRoot: string, sessionId: string) => Promise<number>;
   /** RC41 seam: injected in tests; defaults to the real continuation runner. */
   runSequenceContinuation?: (projectRoot: string, host: 'windsurf' | 'cursor') => Promise<{ ran: boolean; blocked?: boolean; deferred?: boolean }>;
+  /** RC64 seam: duplicate-invocation check (duplicate ⇒ exit 0, do nothing). */
+  checkDuplicateInvocation?: typeof isDuplicateWindsurfInvocation;
   /**
    * Bound on the POST-leg stdin read. Separate from `stdinTimeoutMs` (the PRE
    * leg, which holds the user's prompt and must stay tight): nothing is held on
@@ -609,6 +665,20 @@ export async function runWindsurfHookAction(
         }),
       ]));
       preReadRaw = stdinRes.value ?? '';
+      // ── RC64: duplicate-invocation guard — MUST run before anything else
+      // spawns. A twin invocation (global + workspace registration, newer
+      // Devin executes both) would otherwise run its OWN auto + popup +
+      // block + delivery for the same submit. The twin ends here with exit 0;
+      // the primary's exit 2 still blocks (Windsurf blocks on ANY hook's 2).
+      {
+        const dupCheck = (deps.checkDuplicateInvocation ?? isDuplicateWindsurfInvocation)(
+          opts.project ?? process.cwd(), event, parsePayload(preReadRaw));
+        if (dupCheck.duplicate) {
+          log('warn', 'windsurf_hook_duplicate_invocation', { event, key_kind: dupCheck.key_kind });
+          exit(0);
+          return;
+        }
+      }
       // ── ORDERING (owner ruling: option A) ────────────────────────────────
       // The decision is DEFERRED to after `handle` + the child await below.
       // The option source reads the `pending_advisory` row that `nexpath auto`
@@ -660,6 +730,19 @@ export async function runWindsurfHookAction(
         }),
       ]);
       preReadRaw = raw ?? '';
+      // ── RC64: same duplicate guard on the post leg. The suppression sweep
+      // below is idempotent, but the RC41 continuation is NOT — a twin
+      // invocation would open a SECOND MPS popup for the same response event.
+      // The primary runs everything; the twin ends here.
+      {
+        const dupCheck = (deps.checkDuplicateInvocation ?? isDuplicateWindsurfInvocation)(
+          opts.project ?? process.cwd(), event, parsePayload(preReadRaw));
+        if (dupCheck.duplicate) {
+          log('warn', 'windsurf_hook_duplicate_invocation', { event, key_kind: dupCheck.key_kind });
+          exit(0);
+          return;
+        }
+      }
       const sessionId = parsePayload(preReadRaw)?.trajectory_id ?? '';
       if (sessionId) {
         const suppress = deps.suppressOldAdvisorySurface ?? suppressOldAdvisorySurfaceForSession;

--- a/src/cursor-hook/invocation-guard.test.ts
+++ b/src/cursor-hook/invocation-guard.test.ts
@@ -4,7 +4,11 @@
  * invocation stagger made a read-modify-write registry a coin-flip.
  */
 import { describe, it, expect } from 'vitest';
-import { checkAndRecordCursorInvocation, cursorInvocationMarkerName } from './invocation-guard.js';
+import {
+  checkAndRecordCursorInvocation,
+  cursorInvocationMarkerName,
+  WINDSURF_INVOCATION_DIRNAME,
+} from './invocation-guard.js';
 
 function memFs() {
   const files = new Set<string>();
@@ -59,5 +63,47 @@ describe('⭐ RC50/RC56 — atomic duplicate-invocation claim', () => {
 
   it('marker names are fs-safe', () => {
     expect(cursorInvocationMarkerName('beforeSubmitPrompt', 'a/b:c*d')).toBe('beforeSubmitPrompt-a_b_c_d');
+  });
+});
+
+/**
+ * ⭐ RC64 — the guard is reused for WINDSURF (Windows Devin executes both the
+ * global and the workspace hooks.json — one submit, two full pipelines, two
+ * different enhancements). Markers get their own dir, and short windows are
+ * made HONEST: pruning only ever ran on winners, so a stale marker could sit
+ * forever and dedupe a legitimate repeat of a fallback (trajectory+hash) key.
+ */
+describe('⭐ RC64 — custom dir + honest claim window', () => {
+  it('dirName routes markers to the windsurf dir (cursor default untouched)', () => {
+    const paths: string[] = [];
+    const capture = {
+      mkdirFn: () => {}, readdirFn: () => [] as string[],
+      writeExclusiveFn: (p: string) => { paths.push(p); },
+    };
+    checkAndRecordCursorInvocation('/p', 'e', 'k', capture);
+    checkAndRecordCursorInvocation('/p', 'e', 'k', { ...capture, dirName: WINDSURF_INVOCATION_DIRNAME });
+    expect(paths[0]).toContain('cursor-hook-invocations');
+    expect(paths[1]).toContain('windsurf-hook-invocations');
+  });
+
+  it('⭐ a marker OLDER than the window is stale: reclaimed, NOT a duplicate', () => {
+    const fs = memFs();
+    expect(checkAndRecordCursorInvocation('/p', 'pre', 'k', { ...fs.deps(1_000), maxAgeMs: 10_000 })).toBe(false);
+    expect(checkAndRecordCursorInvocation('/p', 'pre', 'k', { ...fs.deps(12_000), maxAgeMs: 10_000 })).toBe(false);
+  });
+
+  it('⭐ inside the window the repeat IS a duplicate', () => {
+    const fs = memFs();
+    expect(checkAndRecordCursorInvocation('/p', 'pre', 'k', { ...fs.deps(1_000), maxAgeMs: 10_000 })).toBe(false);
+    expect(checkAndRecordCursorInvocation('/p', 'pre', 'k', { ...fs.deps(10_999), maxAgeMs: 10_000 })).toBe(true);
+  });
+
+  it('EEXIST again after the stale removal ⇒ a live twin re-claimed ⇒ duplicate', () => {
+    const fs = memFs();
+    checkAndRecordCursorInvocation('/p', 'pre', 'k', { ...fs.deps(1_000), maxAgeMs: 10 });
+    // removeFn is a no-op ⇒ the retry hits EEXIST again, as if a twin re-claimed.
+    expect(checkAndRecordCursorInvocation('/p', 'pre', 'k', {
+      ...fs.deps(50_000), maxAgeMs: 10, removeFn: () => {},
+    })).toBe(true);
   });
 });

--- a/src/cursor-hook/invocation-guard.ts
+++ b/src/cursor-hook/invocation-guard.ts
@@ -26,6 +26,24 @@ import { join } from 'node:path';
 export const CURSOR_INVOCATION_DIRNAME = 'cursor-hook-invocations';
 export const CURSOR_INVOCATION_MAX_AGE_MS = 10 * 60_000;
 
+/**
+ * RC64 — the same duplicate class hit WINDSURF/Devin on Windows (2026-08-25
+ * tester screenshot: one submit → TWO different enhancements queued). Windows
+ * registers both the global `~/.codeium/windsurf/hooks.json` and the workspace
+ * `.windsurf/hooks.json` (RC21-era Devin executed only the workspace file;
+ * newer builds execute BOTH). Windsurf's payload carries a per-action
+ * `execution_id` — the honest analog of Cursor's `generation_id` — so the
+ * identical atomic claim applies; markers just live in their own dir.
+ */
+export const WINDSURF_INVOCATION_DIRNAME = 'windsurf-hook-invocations';
+/**
+ * RC64 fallback window, used only when a payload has NO execution_id and the
+ * key degrades to trajectory+content-hash. That key REPEATS on a legitimate
+ * same-text resubmit, so the window must be shorter than a human retry while
+ * still covering the duplicate spawn burst (RC50 measured 2–100 ms apart).
+ */
+export const WINDSURF_FALLBACK_WINDOW_MS = 10_000;
+
 export function cursorInvocationDir(projectRoot: string): string {
   return join(projectRoot, '.nexpath', CURSOR_INVOCATION_DIRNAME);
 }
@@ -44,6 +62,15 @@ export interface CursorInvocationGuardDeps {
   /** mtime (ms) of a marker, for pruning. */
   mtimeMsFn?: (p: string) => number;
   removeFn?: (p: string) => void;
+  /** RC64: marker directory under `.nexpath/` (default: Cursor's). */
+  dirName?: string;
+  /**
+   * RC64: the claim window. An existing marker OLDER than this is STALE — it
+   * is removed and the claim retried, so a repeating key (the windsurf
+   * fallback hash) stops deduplicating once the window has passed. Also the
+   * pruning age. Default: the original 10-minute Cursor window.
+   */
+  maxAgeMs?: number;
 }
 
 /**
@@ -59,26 +86,45 @@ export function checkAndRecordCursorInvocation(
 ): boolean {
   try {
     if (!generationId) return false;
-    const dir = cursorInvocationDir(projectRoot);
+    const maxAgeMs = deps.maxAgeMs ?? CURSOR_INVOCATION_MAX_AGE_MS;
+    const dir = join(projectRoot, '.nexpath', deps.dirName ?? CURSOR_INVOCATION_DIRNAME);
     const marker = join(dir, cursorInvocationMarkerName(event, generationId));
     const mkdir = deps.mkdirFn ?? ((p: string) => mkdirSync(p, { recursive: true }));
     const writeExclusive = deps.writeExclusiveFn ?? ((p: string) => writeFileSync(p, '', { flag: 'wx' }));
+    const mtimeMs = deps.mtimeMsFn ?? ((p: string) => statSync(p).mtimeMs);
+    const remove = deps.removeFn ?? ((p: string) => rmSync(p, { force: true }));
     try { mkdir(dir); } catch { /* exists / creatable race — the create below decides */ }
-    try {
-      writeExclusive(marker); // ← the atomic claim
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') return true; // someone else won this key
-      return false; // any other fs problem: fail-open, run the flow
+    const attemptClaim = (): 'won' | 'dup' | 'error' => {
+      try { writeExclusive(marker); return 'won'; } // ← the atomic claim
+      catch (err) { return (err as NodeJS.ErrnoException)?.code === 'EEXIST' ? 'dup' : 'error'; }
+    };
+    let claim = attemptClaim();
+    if (claim === 'dup') {
+      // RC64: a marker OLDER than the window is a stale leftover, not a live
+      // twin — remove it and retry once. This is what makes short windows
+      // honest (pruning only ever ran on WINNERS, so a stale marker could sit
+      // forever and dedupe a legitimate repeat of the key). A second EEXIST
+      // after the removal means another process re-claimed in the gap: a real
+      // duplicate. Errors while aging keep the 'dup' verdict — the EEXIST
+      // already proved a marker exists, and the common case is a twin created
+      // milliseconds ago.
+      try {
+        const now = (deps.now ?? (() => Date.now()))();
+        if (now - mtimeMs(marker) > maxAgeMs) {
+          remove(marker);
+          claim = attemptClaim();
+        }
+      } catch { /* keep 'dup' */ }
     }
+    if (claim === 'dup') return true; // someone else won this key
+    if (claim === 'error') return false; // any other fs problem: fail-open, run the flow
     // Won the claim — prune stale markers best-effort (never affects the answer).
     try {
       const now = (deps.now ?? (() => Date.now()))();
       const readdir = deps.readdirFn ?? readdirSync;
-      const mtimeMs = deps.mtimeMsFn ?? ((p: string) => statSync(p).mtimeMs);
-      const remove = deps.removeFn ?? ((p: string) => rmSync(p, { force: true }));
       for (const name of readdir(dir)) {
         const p = join(dir, name);
-        try { if (now - mtimeMs(p) > CURSOR_INVOCATION_MAX_AGE_MS) remove(p); } catch { /* best-effort */ }
+        try { if (now - mtimeMs(p) > maxAgeMs) remove(p); } catch { /* best-effort */ }
       }
     } catch { /* pruning is optional */ }
     return false;

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -24,7 +24,7 @@ import { createInjectedRecordStore } from './injected-record.js';
 import { injectPeBody, injectPeBodyWithFallback, resolvePeVisibleSurfaceAckState } from './pe-delivery.js';
 import { createPePoller, type PePoller } from './pe-poller.js';
 import { createSubmitHookPoller, type SubmitHookPoller } from './submit-hook-poller.js';
-import { createSubmitClipboardDelivery, submitKeystroke, lastDarwinSubmitError, isDarwinAccessibilityDenial, scheduleWindsurfQueueFlush } from './submit-clipboard-delivery.js';
+import { createSubmitClipboardDelivery, submitKeystroke, lastDarwinSubmitError, isDarwinAccessibilityDenial, scheduleWindsurfQueueFlush, warmWin32KeystrokePath } from './submit-clipboard-delivery.js';
 import {
   isWindsurfSubmitAdvisoryEnabled,
   isCursorSubmitAdvisoryEnabled,
@@ -245,6 +245,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // merely carried our branch's NAME — nothing in the product could contradict
   // the prompt string. Now the first two log lines identify the build.
   log(`[nexpath] build: ${typeof __NEXPATH_BUILD__ === 'string' ? __NEXPATH_BUILD__ : 'unknown'}`);
+  // RC65: warm the win32 PowerShell/Add-Type keystroke path once per session —
+  // the first real paste/Enter otherwise pays the ~8 s cold compile (RC52's
+  // measurement; the padal Cursor round's 31.7 s inject stage sat on top of
+  // it). Fire-and-forget, self-gated to win32, all failures swallowed.
+  warmWin32KeystrokePath(log);
 
   // Expose the extension root so the chat-history watcher can load the
   // better-sqlite3 binary matching THIS host's Electron ABI from prebuilds/<abi>/
@@ -395,7 +400,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   //                                        below. See chat-input-injector-mechanism-truth.test.ts.
   const CURSOR_CHAT_FOCUS_COMMANDS = CURSOR_CHAT_FOCUS_COMMANDS_V1;
   const cursorInject = async (text: string): Promise<boolean> => {
+    // RC65: per-stage timing. The padal round's 31.7 s inject was one opaque
+    // gap between `extension_observed` and `inject_dispatched` — no way to
+    // split a cold PowerShell compile from a busy Cursor absorbing the focus
+    // command. Now every slow round names its stage in one line.
+    const t0 = Date.now();
     await vscode.env.clipboard.writeText(text);
+    const tClip = Date.now();
     raiseAppWindow('cursor');
     await new Promise((r) => setTimeout(r, 150));
     let focused = false;
@@ -415,9 +426,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         break;
       } catch { /* try next focus command */ }
     }
+    const tFocus = Date.now();
     await new Promise((r) => setTimeout(r, focused ? 400 : 250));
+    const tSettle = Date.now();
     const ok = pasteKeystroke({ win32Titles: [vscode.env.appName, 'Cursor'] });
+    const tPaste = Date.now();
     log(`[nexpath] cursor inject → ${ok ? `auto-pasted into existing chat (${focused ? focusedVia + ' → ' : ''}Ctrl+V)` : 'no keystroke tool found; left on clipboard'}`);
+    log(`[nexpath] cursor inject timing: clipboard=${tClip - t0}ms focus=${tFocus - tClip}ms(${focusedVia || 'none'}) settle=${tSettle - tFocus}ms paste=${tPaste - tSettle}ms total=${tPaste - t0}ms`);
     return ok;
   };
 

--- a/src/ext-vscode/src/installer/prereq.ts
+++ b/src/ext-vscode/src/installer/prereq.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { quoteForWindowsShell } from '../shell-quote.js';
 
 /**
  * Prerequisite probes for the auto-installer.
@@ -34,9 +35,17 @@ const defaultRun: RunFn = (cmd, args) => {
   // without a shell (post CVE-2024-27980). `shell: true` lets the OS resolve
   // either the `.exe` (node) or the `.cmd` (npm) form. A short timeout keeps a
   // hung probe from blocking activation.
-  const r = spawnSync(cmd, args, {
+  //
+  // RC66: with the shell, args are CONCATENATED unquoted — the staged-CLI
+  // probe's path arg split at the space in "C:\Users\SALVI GAURAV\..." and a
+  // healthy install was reported "dependencies missing/incomplete" forever
+  // (endless re-setup + error toast on every spaced-username machine). Quote
+  // spaced tokens; space-free spawns are byte-identical. `cmd` here is always
+  // a bare name ('node'/'npm'/'nexpath') and is deliberately left untouched.
+  const useShell = process.platform === 'win32';
+  const r = spawnSync(cmd, useShell ? args.map(quoteForWindowsShell) : args, {
     encoding: 'utf8',
-    shell: process.platform === 'win32',
+    shell: useShell,
     timeout: 10_000,
     windowsHide: true,
   });

--- a/src/ext-vscode/src/ipc.ts
+++ b/src/ext-vscode/src/ipc.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import type { SpawnOptions } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { bringPopupToFront } from './popup-foreground.js';
+import { shellSafeSpawnTokens } from './shell-quote.js';
 import { readInjectedPrompt } from './advisory-store-reader.js';
 
 /**
@@ -257,8 +258,15 @@ function buildSpawnOptions(opts: IpcOptions): SpawnOptions {
   // or `node`-shebang script; Node's spawn refuses to execute a `.cmd` shim
   // without a shell (post CVE-2024-27980) → `spawnAuto failed` / capture never
   // runs. Spawning through cmd.exe lets Windows resolve the `.cmd`. POSIX is
-  // unaffected (shell stays false). Args here are simple (`auto`/`stop` +
-  // `--db <~/.nexpath path>`), so shell concatenation is safe.
+  // unaffected (shell stays false).
+  //
+  // RC66: the old note here — "args are simple, so shell concatenation is
+  // safe" — was FALSE the moment a Windows username contains a space: both the
+  // NEXPATH_BIN shim path and the `--db <~/.nexpath path>` arg live under the
+  // user's home ("C:\Users\SALVI GAURAV\.nexpath\..."), and the shell splits
+  // them unquoted. The spawn call sites now pass their tokens through
+  // `shellSafeSpawnTokens` (spaced tokens quoted on win32 only; every
+  // space-free spawn stays byte-identical).
   return {
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd:   opts.cwd ?? process.cwd(),
@@ -285,7 +293,9 @@ export function spawnAuto(
   const bin = resolveBinaryPath(opts);
   const args = buildArgs('auto', opts.dbPath);
   const spawner = opts.spawnFn ?? spawn;
-  const child = spawner(bin, args, buildSpawnOptions(opts));
+  // RC66: quote spaced tokens for the win32 shell spawn (see buildSpawnOptions).
+  const safe = shellSafeSpawnTokens(bin, args);
+  const child = spawner(safe.bin, safe.args, buildSpawnOptions(opts));
 
   return new Promise<void>((resolve, reject) => {
     let stderr = '';
@@ -349,7 +359,9 @@ export function spawnStop(
   const bin = resolveBinaryPath(opts);
   const args = buildArgs('stop', opts.dbPath);
   const spawner = opts.spawnFn ?? spawn;
-  const child = spawner(bin, args, buildSpawnOptions(opts));
+  // RC66: quote spaced tokens for the win32 shell spawn (see buildSpawnOptions).
+  const safe = shellSafeSpawnTokens(bin, args);
+  const child = spawner(safe.bin, safe.args, buildSpawnOptions(opts));
 
   // Layer C's `nexpath stop` opens the advisory popup as a separate OS window.
   // macOS/Windows foreground it at launch; Linux/gnome-terminal can't, so under

--- a/src/ext-vscode/src/shell-quote.test.ts
+++ b/src/ext-vscode/src/shell-quote.test.ts
@@ -1,0 +1,76 @@
+/**
+ * ⭐ RC66 — spaces in Windows paths broke every `shell: true` spawn that
+ * carried a path token (marketplace tester "SALVI GAURAV", 2026-08-25):
+ * the staged-CLI health probe reported a HEALTHY install as "dependencies
+ * missing/incomplete" forever (endless re-setup + an error toast after every
+ * run), and the ipc auto/stop spawns carried the same hazard in both their
+ * NEXPATH_BIN shim path and the `--db` arg. Node's DEP0190 names the exact
+ * mechanism: with a shell, args are concatenated UNQUOTED.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { quoteForWindowsShell, shellSafeSpawnTokens } from './shell-quote.js';
+
+describe('⭐ RC66 — quoteForWindowsShell', () => {
+  it('⭐ a token with a space is wrapped in quotes', () => {
+    expect(quoteForWindowsShell('C:\\Users\\SALVI GAURAV\\.nexpath\\cli\\0.1.4\\dist\\cli\\index.js'))
+      .toBe('"C:\\Users\\SALVI GAURAV\\.nexpath\\cli\\0.1.4\\dist\\cli\\index.js"');
+  });
+
+  it('⭐ a token WITHOUT whitespace is returned UNCHANGED — space-free machines spawn byte-identical lines', () => {
+    for (const t of ['node', 'npm', 'nexpath', '--version', 'auto', '--db',
+      'C:\\Users\\padal\\.nexpath\\bin\\nexpath.cmd']) {
+      expect(quoteForWindowsShell(t)).toBe(t);
+    }
+  });
+
+  it('embedded quotes are stripped, not escaped (RC29 rule: `"` cannot appear in a Windows path)', () => {
+    expect(quoteForWindowsShell('C:\\bad "dir"\\x.js')).toBe('"C:\\bad dir\\x.js"');
+  });
+
+  it('tabs count as whitespace too', () => {
+    expect(quoteForWindowsShell('a\tb')).toBe('"a\tb"');
+  });
+});
+
+describe('⭐ RC66 — shellSafeSpawnTokens', () => {
+  const bin = 'C:\\Users\\SALVI GAURAV\\.nexpath\\bin\\nexpath.cmd';
+  const args = ['auto', '--db', 'C:\\Users\\SALVI GAURAV\\.nexpath\\prompts.db'];
+
+  it('⭐ win32: bin AND spaced args are quoted, plain args untouched', () => {
+    const safe = shellSafeSpawnTokens(bin, args, 'win32');
+    expect(safe.bin).toBe(`"${bin}"`);
+    expect(safe.args).toEqual(['auto', '--db', '"C:\\Users\\SALVI GAURAV\\.nexpath\\prompts.db"']);
+  });
+
+  it('⭐ off win32 the tokens pass through untouched (no shell is used there)', () => {
+    for (const p of ['linux', 'darwin'] as const) {
+      expect(shellSafeSpawnTokens(bin, args, p)).toEqual({ bin, args });
+    }
+  });
+});
+
+/**
+ * The mechanism itself, live: the exact spawn pattern the probe used fails on
+ * a spaced path when unquoted and succeeds when quoted. `shell: true` arg
+ * concatenation behaves the same on every OS, so this pin is honest off
+ * Windows too (posix sh double-quotes have the same grouping semantics).
+ */
+describe('⭐ RC66 — live spawn proof: quoting is what fixes the spaced path', () => {
+  it('⭐ unquoted spaced path fails under a shell; the quoted token succeeds', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rc66-'));
+    const spaced = join(root, 'SALVI GAURAV', 'dist');
+    mkdirSync(spaced, { recursive: true });
+    const entry = join(spaced, 'index.js');
+    writeFileSync(entry, 'console.log("0.1.4")');
+    const broken = spawnSync('node', [entry, '--version'], { shell: true, encoding: 'utf8', timeout: 10_000 });
+    const fixed = spawnSync('node', [quoteForWindowsShell(entry), '--version'], { shell: true, encoding: 'utf8', timeout: 10_000 });
+    rmSync(root, { recursive: true, force: true });
+    expect(broken.status).not.toBe(0); // the shipped 0.1.33 behaviour on this machine
+    expect(fixed.status).toBe(0);
+    expect((fixed.stdout ?? '').trim()).toBe('0.1.4');
+  });
+});

--- a/src/ext-vscode/src/shell-quote.ts
+++ b/src/ext-vscode/src/shell-quote.ts
@@ -1,0 +1,40 @@
+/**
+ * RC66 (Windows/Cursor marketplace tester "SALVI GAURAV", 2026-08-25) —
+ * quoting for win32 `shell: true` spawns.
+ *
+ * With `shell: true`, Node CONCATENATES the command and args into one line
+ * with NO escaping (its own DEP0190 warns about exactly this). Any token
+ * containing a space then splits: the health probe ran
+ *     node C:\Users\SALVI GAURAV\.nexpath\...\index.js --version
+ * and node tried to execute `C:\Users\SALVI` — so a perfectly healthy staged
+ * CLI was reported "dependencies missing/incomplete" on EVERY machine whose
+ * Windows username contains a space, looping setup forever with an error
+ * toast after each run. Same class RC29 fixed in the hooks.json writer; these
+ * are the two remaining shell-spawn sites (prereq probe + ipc auto/stop).
+ *
+ * Node's shell wrapper on win32 encloses the whole joined command in its own
+ * outer quotes (`cmd.exe /d /s /c "<joined>"`), so pre-quoting individual
+ * tokens here is preserved verbatim — the standard, well-trodden fix.
+ *
+ * A `"` cannot appear in a Windows path at all, so embedded quotes are
+ * stripped rather than escaped (RC29's rule, verbatim). Tokens without
+ * whitespace are returned UNCHANGED — on every space-free machine the spawned
+ * command line is byte-identical to before this fix.
+ */
+export function quoteForWindowsShell(token: string): string {
+  if (!/\s/.test(token)) return token;
+  return `"${token.replace(/"/g, '')}"`;
+}
+
+/**
+ * Shell-safe (bin, args) for a `shell: platform === 'win32'` spawn.
+ * Off win32 the shell is never used there — tokens pass through untouched.
+ */
+export function shellSafeSpawnTokens(
+  bin: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): { bin: string; args: string[] } {
+  if (platform !== 'win32') return { bin, args };
+  return { bin: quoteForWindowsShell(bin), args: args.map(quoteForWindowsShell) };
+}

--- a/src/ext-vscode/src/submit-advisory-runtime.test.ts
+++ b/src/ext-vscode/src/submit-advisory-runtime.test.ts
@@ -173,9 +173,13 @@ describe('⭐ BLOCK/INJECTION RACE — proven, not assumed (H3 acceptance)', () 
   });
 
   it('does NOT deliver while the hook is still alive', async () => {
+    // RC63: the fixture's blockIssuedAt must be FRESH — the grace cap now
+    // precedes the liveness checks, so an ancient timestamp (correctly)
+    // delivers regardless of a recycled-"alive" pid. This pin's claim is
+    // about WITHIN the grace window.
     const removed: string[] = [];
     const r = await readPendingSubmitDecision('/proj', {
-      read: async () => RECORD,
+      read: async () => JSON.stringify({ ...JSON.parse(RECORD), createdAt: Date.now(), blockIssuedAt: Date.now() - 1_000 }),
       remove: async (p: string) => { removed.push(p); },
       isProcessAlive: (pid: number) => { expect(pid).toBe(4242); return true; },
     });
@@ -199,14 +203,22 @@ describe('⭐ BLOCK/INJECTION RACE — proven, not assumed (H3 acceptance)', () 
   it('a deferred record is retried and delivered on a later poll', async () => {
     // Proves the deferral is a WAIT, not a drop.
     let alive = true;
+    // NOTE: this block's RECORD is a JSON STRING (locally shadowed) — parse, patch, re-stringify ONCE (stable settle key).
+    const frozenRecord = JSON.stringify({ ...JSON.parse(RECORD), createdAt: Date.now(), blockIssuedAt: Date.now() - 1_000 });
     const deps = {
-      read: async () => RECORD,
+      // RC63: within the grace window throughout — alive defers, then death
+      // starts the RC40 settle, then delivery. The record is FROZEN once:
+      // regenerating blockIssuedAt per read would mint a fresh settle key
+      // every call and defer forever. Real 1.5 s settle waited out.
+      read: async () => frozenRecord,
       remove: async () => {},
       isProcessAlive: () => alive,
     };
-    expect(await readPendingSubmitDecision('/proj', deps)).toBeNull();
+    expect(await readPendingSubmitDecision('/proj', deps)).toBeNull();   // alive ⇒ defer
     alive = false;
-    expect((await readPendingSubmitDecision('/proj', deps))?.decisionId).toBe('sd-1');
+    expect(await readPendingSubmitDecision('/proj', deps)).toBeNull();   // dead first-seen ⇒ settle starts
+    await new Promise((r) => setTimeout(r, 1_600));
+    expect((await readPendingSubmitDecision('/proj', deps))?.decisionId).toBe('sd-1'); // settle elapsed ⇒ delivered
   });
 
   it('treats a NON-ESRCH probe error as ALIVE — the conservative direction', () => {
@@ -930,5 +942,32 @@ describe('⭐ RC35 — writeSessionEnvSnapshot', () => {
   it('extension.ts calls it at activation (structural)', () => {
     const src = readFileSync(join(__dirname, 'extension.ts'), 'utf8');
     expect(src).toMatch(/writeSessionEnvSnapshot\(\);/);
+  });
+});
+
+/**
+ * ⭐ RC63 — the grace cap must dominate EVERY liveness check. On Windows the
+ * dead hook's pid gets recycled, so `isAlive(hookPid)` can read true long
+ * after the hook exited (32 s observed live; EPERM-recycled = forever). Past
+ * the cap, delivery always proceeds.
+ */
+describe('⭐ RC63 — grace cap precedes the hookPid check', () => {
+  const rec = { hookPid: 111, hookShellPid: 222, blockIssuedAt: 100_000 };
+
+  it('⭐ hookPid "alive" past the grace window ⇒ DELIVER (the 32s stall / EPERM-forever case)', () => {
+    const alive = () => true; // pid recycled — everything reads alive
+    expect(shouldDeferForHookExit(rec, alive, 100_000 + 10_001)).toBe(false);
+  });
+
+  it('hookPid alive INSIDE the window still defers (the real teardown case)', () => {
+    expect(shouldDeferForHookExit(rec, () => true, 100_000 + 3_000)).toBe(true);
+  });
+
+  it('normal path timing unchanged: dead pids ⇒ settle then deliver', () => {
+    const dead = () => false;
+    const t0 = 200_000;
+    const r = { hookPid: 11, hookShellPid: 22, blockIssuedAt: t0 };
+    expect(shouldDeferForHookExit(r, dead, t0 + 2_000)).toBe(true);           // first sight: settle starts
+    expect(shouldDeferForHookExit(r, dead, t0 + 2_000 + 1_501)).toBe(false);  // settle elapsed: deliver
   });
 });

--- a/src/ext-vscode/src/submit-advisory-runtime.ts
+++ b/src/ext-vscode/src/submit-advisory-runtime.ts
@@ -273,8 +273,19 @@ export function shouldDeferForHookExit(
   isAlive: (pid: number) => boolean,
   now: number,
 ): boolean {
+  // RC63 (marketplace smoke test, Windows/Cursor 2026-08-24): the grace cap
+  // must be the FIRST check. It used to sit after the hookPid-alive test, so
+  // it capped a lingering SHELL but not a lingering hookPid — and on Windows
+  // the dead hook's pid gets recycled to unrelated processes, which made
+  // `isAlive(hookPid)` true for as long as the pid's NEW owner lived: the
+  // smoke test observed its decision 32 s late (sinceBlockIssuedMs: 32063),
+  // and a pid recycled to a system process (EPERM ⇒ alive) would have stalled
+  // FOREVER. A real hook can never be alive 10 s after its own block — the
+  // block IS its exit — so past the grace window every "alive" answer is the
+  // recycling artifact. Latent since RC40 (probabilistic, dice per turn), not
+  // a regression of any later change.
+  if (now - record.blockIssuedAt > SHELL_EXIT_GRACE_MS) return false; // never stall — caps EVERY check below
   if (isAlive(record.hookPid)) return true;
-  if (now - record.blockIssuedAt > SHELL_EXIT_GRACE_MS) return false; // never stall
   if (record.hookShellPid !== undefined && isAlive(record.hookShellPid)) return true;
   // ── RC40 (measured LIVE on Ubuntu, 2026-08-21 12:52): the settle applies to
   // EVERY platform, not just the win32 wrapper. The host cancels the held

--- a/src/ext-vscode/src/submit-clipboard-delivery.test.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.test.ts
@@ -21,6 +21,8 @@ import {
   buildWin32KeystrokeScript,
   WIN32_KEYSTROKE_TIMEOUT_MS,
   scheduleWindsurfQueueFlush,
+  warmWin32KeystrokePath,
+  WIN32_USER32_ADDTYPE,
 } from './submit-clipboard-delivery.js';
 
 function deliveryHarness(over: Partial<SubmitClipboardDeliveryDeps> = {}) {
@@ -566,5 +568,80 @@ describe('⭐ RC61 — scheduleWindsurfQueueFlush', () => {
     scheduleWindsurfQueueFlush(() => { throw new Error('boom'); }, (l) => logs.push(l), 1, (fn) => { scheduled = fn as () => void; return 0; });
     expect(() => scheduled!()).not.toThrow();
     expect(logs.join(' ')).toContain('threw (ignored)');
+  });
+});
+
+/**
+ * ⭐ RC65 — the activation pre-warm (Windows/Cursor marketplace tester,
+ * 2026-08-25: the inject stage sat 31.7 s on the session's FIRST keystroke —
+ * RC52's cold Add-Type compile plus a busy Cursor). One throwaway compile at
+ * activation warms the machine caches; correctness rests on the warmup
+ * compiling the BYTE-IDENTICAL source the real scripts use.
+ */
+describe('⭐ RC65 — warmWin32KeystrokePath', () => {
+  function fakeChild() {
+    const handlers = new Map<string, (a?: unknown) => void>();
+    return {
+      handlers,
+      on: (ev: 'exit' | 'error', fn: (a?: unknown) => void) => { handlers.set(ev, fn); },
+      unref: vi.fn(),
+      kill: vi.fn(),
+    };
+  }
+
+  it('⭐ the real keystroke scripts START with the warmed Add-Type source (byte-identity)', () => {
+    expect(buildWin32KeystrokeScript(['Cursor'], '^v').startsWith(WIN32_USER32_ADDTYPE)).toBe(true);
+    expect(buildWin32KeystrokeScript(['Devin'], '{ENTER}').startsWith(WIN32_USER32_ADDTYPE)).toBe(true);
+  });
+
+  it('⭐ win32: spawns ONE powershell that compiles the helper and sends NO keys', () => {
+    const child = fakeChild();
+    const spawns: Array<{ cmd: string; args: string[] }> = [];
+    const ok = warmWin32KeystrokePath(() => {}, {
+      platform: 'win32',
+      spawnFn: (cmd, args) => { spawns.push({ cmd, args }); return child; },
+    });
+    expect(ok).toBe(true);
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0]!.cmd).toBe('powershell');
+    const script = spawns[0]!.args.join(' ');
+    expect(script).toContain(WIN32_USER32_ADDTYPE);
+    expect(script).toContain('exit 0');
+    expect(script).not.toContain('SendKeys');
+    expect(script).not.toContain('AppActivate');
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('non-win32: a no-op — nothing spawns', () => {
+    const spawnFn = vi.fn();
+    expect(warmWin32KeystrokePath(() => {}, { platform: 'linux', spawnFn })).toBe(false);
+    expect(warmWin32KeystrokePath(() => {}, { platform: 'darwin', spawnFn })).toBe(false);
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it('logs the warm duration on exit', () => {
+    const child = fakeChild();
+    const logs: string[] = [];
+    let t = 1_000;
+    warmWin32KeystrokePath((l) => logs.push(l), {
+      platform: 'win32', now: () => t, spawnFn: () => child,
+    });
+    t = 8_025;
+    child.handlers.get('exit')!(0);
+    expect(logs.join(' ')).toContain('pre-warm: compiler warmed in 7025 ms (exit 0)');
+  });
+
+  it('spawn error is logged and swallowed (worst case = today\'s cold first keystroke)', () => {
+    const child = fakeChild();
+    const logs: string[] = [];
+    warmWin32KeystrokePath((l) => logs.push(l), { platform: 'win32', spawnFn: () => child });
+    child.handlers.get('error')!(new Error('powershell missing'));
+    expect(logs.join(' ')).toContain('pre-warm: spawn failed');
+  });
+
+  it('a throwing spawn never breaks activation', () => {
+    expect(warmWin32KeystrokePath(() => {}, {
+      platform: 'win32', spawnFn: () => { throw new Error('EPERM'); },
+    })).toBe(false);
   });
 });

--- a/src/ext-vscode/src/submit-clipboard-delivery.ts
+++ b/src/ext-vscode/src/submit-clipboard-delivery.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 /**
  * Clipboard-fallback delivery for the submit-time advisory (hook milestone H3, Q3).
@@ -307,6 +307,68 @@ export function isDarwinAccessibilityDenial(err: string | null): boolean {
 export const WIN32_KEYSTROKE_TIMEOUT_MS = 20_000;
 
 /**
+ * RC65: the user32 Add-Type prelude, extracted so the activation pre-warm
+ * compiles the BYTE-IDENTICAL C# source the real keystroke scripts use (the
+ * cold cost being warmed is csc/.NET/Defender machine caches keyed off this
+ * compile — a different source would warm nothing).
+ */
+export const WIN32_USER32_ADDTYPE =
+  `Add-Type '[DllImport("user32.dll")]public static extern System.IntPtr GetForegroundWindow();[DllImport("user32.dll")]public static extern int GetWindowText(System.IntPtr h,System.Text.StringBuilder s,int n);' -Name U -Namespace W;`;
+
+/**
+ * RC65 (Windows/Cursor marketplace tester, 2026-08-25): the FIRST win32
+ * keystroke of a session pays the cold Add-Type cost — RC52 measured 8025 ms
+ * cold vs 805 ms warm, and the padal round's inject stage sat ~31 s with a
+ * busy Cursor on top of it. The cost is machine-cache-shaped (csc.exe + .NET
+ * assemblies into file cache, Defender's first scan of the compiled helper),
+ * so ONE throwaway compile at activation warms every later spawn: the
+ * delivery-path paste (^v) and submit ({ENTER}) then run warm even on the
+ * session's first real popup.
+ *
+ * Fire-and-forget: activation is never blocked (async spawn, unref), every
+ * failure is logged and swallowed — the worst case is exactly today's cold
+ * first keystroke. Self-gated to win32; a no-op everywhere else.
+ */
+export function warmWin32KeystrokePath(
+  logFn: (line: string) => void,
+  deps: {
+    platform?: NodeJS.Platform;
+    now?: () => number;
+    spawnFn?: (cmd: string, args: string[]) => {
+      on: (ev: 'exit' | 'error', fn: (a?: unknown) => void) => unknown;
+      unref?: () => void;
+      kill?: () => void;
+    };
+  } = {},
+): boolean {
+  const platform = deps.platform ?? process.platform;
+  if (platform !== 'win32') return false;
+  try {
+    const now = deps.now ?? Date.now;
+    const start = now();
+    const spawnFn = deps.spawnFn ?? ((cmd: string, args: string[]) =>
+      spawn(cmd, args, { stdio: 'ignore', windowsHide: true }));
+    const child = spawnFn('powershell', ['-NoProfile', '-Command', `${WIN32_USER32_ADDTYPE}exit 0`]);
+    // Hygiene only: a hung PowerShell is inert (stdio ignored, unref'd), but
+    // don't leave one per activation lying around forever.
+    const reap = setTimeout(() => { try { child.kill?.(); } catch { /* already gone */ } }, 30_000);
+    if (typeof (reap as { unref?: () => void }).unref === 'function') (reap as unknown as { unref: () => void }).unref();
+    child.on('exit', (code) => {
+      clearTimeout(reap as Parameters<typeof clearTimeout>[0]);
+      logFn(`[nexpath] win32 keystroke pre-warm: compiler warmed in ${now() - start} ms (exit ${String(code ?? 'null')})`);
+    });
+    child.on('error', () => {
+      clearTimeout(reap as Parameters<typeof clearTimeout>[0]);
+      logFn('[nexpath] win32 keystroke pre-warm: spawn failed — the first real keystroke will pay the cold compile');
+    });
+    child.unref?.();
+    return true;
+  } catch {
+    return false; // never let warming interfere with activation
+  }
+}
+
+/**
  * RC49 — the shared win32 keystroke script: FOREGROUND-FIRST, then AppActivate.
  *
  * The Devin tester's RC47 toast proved AppActivate can fail even while the
@@ -325,7 +387,7 @@ export const WIN32_KEYSTROKE_TIMEOUT_MS = 20_000;
 export function buildWin32KeystrokeScript(titles: readonly string[], sendKeys: string): string {
   const psTitles = titles.map((t) => `'${t.replace(/'/g, "''")}'`).join(',');
   return (
-    `Add-Type '[DllImport("user32.dll")]public static extern System.IntPtr GetForegroundWindow();[DllImport("user32.dll")]public static extern int GetWindowText(System.IntPtr h,System.Text.StringBuilder s,int n);' -Name U -Namespace W;` +
+    WIN32_USER32_ADDTYPE +
     `$w=New-Object -ComObject WScript.Shell;` +
     `$b=New-Object System.Text.StringBuilder 256;[void][W.U]::GetWindowText([W.U]::GetForegroundWindow(),$b,256);$fg=$b.ToString();` +
     `$ok=$false;` +


### PR DESCRIPTION
## Release framing

0.1.33 on the marketplaces (44ec6c6) carries four latent Windows bugs, each now reported by a
real machine: a ~30s (worst-case unbounded) delivery stall, duplicate popups on newer Windows
Devin, a >1-minute first inject on Cursor, and an endless setup loop for any user whose
Windows username contains a space. This PR is the complete fix set — the content of the
**0.1.34 patch**. Full technical detail in the prompt-enhancement PR; per-machine retest
matrix in the staging PR (retest green, including the Devin block-card check that closes
RC64's stated assumption).

None of the four are regressions from the milestone merge: RC63 is latent since RC40, RC64 is
a Devin behaviour change (newer builds execute both hooks.json files), RC65 is the measured
cold-compile cost surfacing on a slow machine, RC66 is latent since the installer's probe
existed. Off their trigger conditions all four are byte-identical (pinned; ext 1175/1175, root
suite unchanged).

## Note for the merge

Main is 3 commits ahead of the milestone merge (#119, d83b154 MPS-off default) — different
files, no conflicts expected with these 4 commits.

## After merge — 0.1.34 release steps
1. Bump `src/ext-vscode/package.json` to 0.1.34 AND `package-lock.json` (both fields, per the
   46789b5 convention) in one commit.
2. Publish via `publish-extension.yml` (tag `vsix-v0.1.34` or workflow_dispatch publish=true);
   needs VSCE_PAT / OVSX_PAT as before.
3. Post-publish smoke test on a marketplace install — including one machine with a spaced
   username, the dimension 0.1.33's matrix missed.