### PR TITLE
ci(publish): serial vitest in the QEMU arm64 job — Run #9 failed with all 1175 tests passing

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -130,6 +130,13 @@ jobs:
         with:
           platforms: arm64
 
+      # Tests run SERIALLY here (--no-file-parallelism) — under QEMU everything
+      # is 10-20x slower and vitest's worker<->main RPC has a fixed 60s timeout:
+      # Run #9 failed with "[vitest-worker]: Timeout calling snapshotSaved"
+      # while ALL 1175 tests PASSED (the starved main thread just missed the
+      # RPC window, and vitest exits 1 on that "unhandled error"). One worker
+      # means no cross-worker starvation, so the class cannot fire. Native
+      # jobs keep the parallel default.
       - name: Build + package inside arm64 container
         run: |
           docker run --rm --platform linux/arm64 \
@@ -137,7 +144,7 @@ jobs:
             node:20-bullseye bash -lc "
               npm ci &&
               npx tsc --noEmit &&
-              npm test &&
+              npm test -- --no-file-parallelism &&
               npm run build &&
               mkdir -p dist-vsix &&
               node scripts/package-with-electron-abi.mjs --target linux-arm64 --out dist-vsix/


### PR DESCRIPTION
## What happened in Run #9

`Package (linux-arm64)` exited 1 while its own log shows **58 files / 1175 tests, all
passed**. The failure is a vitest infrastructure flake, not a test failure: the arm64 job is
the only emulated one (QEMU, ~10–20× slower — npm ci took 11 min), and vitest's worker↔main
RPC (`snapshotSaved`) has a fixed 60s timeout. The starved main thread missed the window
once; vitest counts that as an "unhandled error" and exits 1 regardless of test results.
All four native jobs were green. Yesterday's run passed because the flake is
load-probabilistic — the RC63–66 pins added 13 tests (three multi-second real-timer/spawn
ones), which pushed the emulated run over the line.

## The fix

One line in the arm64 container: `npm test -- --no-file-parallelism`. A single worker means
no cross-worker starvation, so the RPC-timeout class cannot fire — and all 1175 tests still
run on arm64. Native jobs keep the parallel default, untouched. Flag validated locally
(1175/1175 serial); YAML validated. Workflow-only — no product code, nothing users run.

## Before re-running the publish

Run #9 was on main with the package still at **0.1.33** (`> nexpath-vscode@0.1.33 test` in
its log) — even fully green it would have failed at publish on the duplicate version.
Sequence: merge this (the workflow runs from main's copy of the yml) → land the 0.1.34
version + package-lock bump in one commit → re-run.