### PR TITLE
Add and Refine Contributor Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,230 +1,114 @@
 # Contributing to Nexpath
 
-We're glad you're here. Whether you're fixing a bug, certifying a new agent, or improving the
-docs, every contribution makes Nexpath more trustworthy.
-
-New here? Read the [README](README.md) first — it covers what Nexpath does and how to install it.
-This guide covers what you need in order to *change* it.
+Read the [README](README.md) first — it covers what Nexpath does and how to install it. This guide
+covers how to change it.
 
 ## Ways to Contribute
 
-- **End-to-end agent testing** — verify Nexpath against agents we have not certified yet
-- **Code** — fix bugs, improve the pipeline, add agent support
-- **Documentation** — the README, this guide, or the CLI help text
-- **Bug reports and feature requests** — through
-  [Issues](https://github.com/hi0001234d/nexpath/issues)
-- **Community support** — help other users in
-  [Discussions](https://github.com/hi0001234d/nexpath/discussions)
+- **End-to-end agent testing** — run Nexpath against agents we have not certified yet
+- **Code** — bug fixes, pipeline work, new agent support
+- **Docs** — the README, this guide, or the CLI help text
+- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
+  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
 
-## Reporting Bugs or Issues
+> Only Claude Code is certified end-to-end today. Testing another agent from the README's support
+> table is the highest-value contribution, and needs no codebase knowledge.
 
-[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first to avoid duplicates,
-then [open a new one](https://github.com/hi0001234d/nexpath/issues/new).
+## Reporting Bugs
 
-> 🔐 **Important:** If you discover a security vulnerability, please use the
-> [GitHub security tool to report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new)
-> instead of opening a public issue.
+[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first, then
+[open a new one](https://github.com/hi0001234d/nexpath/issues/new) with:
 
-A great bug report contains:
+- OS, Node version, Nexpath version, and which AI coding agent
+- The exact prompt or command that reproduces it
+- What you expected, and the actual error text
+- Output of `nexpath status` — plus `nexpath log` for advisory or popup issues
+  (`NEXPATH_DEBUG=1` for verbose stderr)
 
-- **A quick summary** of what you were doing
-- **Your environment** — OS, Node version, Nexpath version, and which AI coding agent
-- **Steps to reproduce** — the actual prompt or command, not a description of it
-- **Expected vs. actual** — with the exact error text
-- **Diagnostics** — output of `nexpath status`, plus `nexpath log` for advisory or popup issues.
-  Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
-
-⚠️ `nexpath status` dumps your full config and `nexpath log` may include your own prompts — read
-both before pasting them publicly and redact anything private.
+> 🔐 Found a security vulnerability?
+> [Report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new), not in a
+> public issue.
+>
+> ⚠️ `nexpath status` dumps your config and `nexpath log` may contain your prompts — redact before
+> pasting.
 
 ## Before You Start
 
-- All contributions begin with a GitHub Issue — except typos, small bug fixes, minor wording
-  changes, and type-only fixes.
-- For features, check [Issues](https://github.com/hi0001234d/nexpath/issues) and Discussions for
-  similar ideas first.
-- If your idea is new, open an issue with the problem, your approach, and why it belongs in
-  Nexpath.
-- Wait for maintainer approval before implementing. **PRs without approved issues may be
-  closed** — Nexpath's pipeline has interlocking gates, and a local-looking change can move
-  behaviour three stages downstream.
-
-New contributors: start with
-[`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
-[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted). Beyond the tracker,
-these areas need help most:
-
-- **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
-  Code is certified today; the README's support table lists the rest. Install Nexpath against
-  another agent, run real prompts through it, and report exactly what happened.
-- **Cross-platform verification** — Nexpath touches OS credential storage and writes local state,
-  so it breaks in platform-specific ways. Windows reports are especially useful.
-- **Pipeline correctness** — `src/prompt-enhancement/` and `src/decision-session/` carry most of
-  the product behaviour and most of the test suite.
+- Open an issue first — except typos, small bug fixes, and type-only changes
+- State the problem, your approach, and why it belongs in Nexpath
+- Wait for maintainer approval. **PRs without an approved issue may be closed.**
+- New here? Start with
+  [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
+  [`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted)
 
 ## Development Setup
 
-Requirements:
+Node.js 18+ (20+ recommended), npm 9+, and git. Everything else comes from `devDependencies`.
 
-- **Node.js 18+** — development happens on Node 20+; Node 22 is known to work
-- **npm 9+** — ships with Node 18 and newer
-- **git**
-
-Nothing else is needed for the core CLI — TypeScript, `tsx`, and `vitest` come from
-`devDependencies`.
-
-Install steps are in the
-[README](README.md#add-nexpath-to-your-development-workflow--installation). Clone **your fork**, not
-the canonical repo, and add the original as `upstream` so you can rebase later:
+Fork the repo, then:
 
 ```bash
-git remote add upstream https://github.com/hi0001234d/nexpath.git
+git clone https://github.com/<your-username>/nexpath.git
+cd nexpath
 npm install
+git remote add upstream https://github.com/hi0001234d/nexpath.git
 ```
+
+Build and link steps are in the
+[README](README.md#add-nexpath-to-your-development-workflow--installation).
 
 ## Common Checks
 
-**Read this before you open a PR.** Nexpath does **not** run tests on pull requests — the GitHub
-Actions workflows only fire on release tags, so **your local run is the only gate that exists.**
+Nexpath runs **no CI on pull requests** — your local run is the only gate.
 
 ```bash
-npm run build          # includes the prebuild gates
+npm run build          # prebuild gates: content-template + selectability
 npm run typecheck      # core CLI + server
-npm test               # vitest run, whole tree
-npm run pe:leak-guard  # read-only confidentiality scan
+npm run typecheck:ext  # required if you touched src/ext-browser/
+npm test               # vitest, whole tree
+npm run pe:leak-guard  # confidentiality scan
 ```
 
-**Build** — `prebuild` runs `scripts/check-build-gate.ts` and aborts on two hard gates:
+Expected behaviour before you debug your own change:
 
-- **Content-template gate** — every shipped record must be schema-valid and have a level-1 floor.
-- **Selectability gate** — every prompt-enhancement intent must be reachable by a realistic prompt
-  through the production router.
-- If the build aborts on a template you touched, fix the record — do not bypass the gate.
+- **Build gates** — a content template that is schema-invalid, missing its level-1 floor, or
+  unreachable by a realistic prompt aborts the build. Fix the record; don't bypass the gate.
+- **Tests** — two files fail with `ENOENT` on a public clone because they read a private submodule.
+  These are the only accepted failures.
+- **Leak guard** — not clean on `main` today. Run it before and after your change; your diff must
+  add no new findings.
+- **`src/ext-vscode/`** — a separate package, excluded from every root check. Run its own
+  `npm install && npm run typecheck && npm run test && npm run build`.
 
-**Typecheck** — both commands must produce no output:
-
-- `npm run typecheck` covers the core CLI and server.
-- `npm run typecheck:ext` covers `src/ext-browser/` (excluded from the root `tsconfig.json`) —
-  mandatory if you touched that directory.
-
-**Tests** — `npm test` takes a minute or two:
-
-- On a clean public clone it exits **1**: two files read planning documents from a private submodule
-  and fail with `ENOENT` for reasons unrelated to your change —
-  `src/prompt-enhancement/dev-plan-table-integrity.test.ts` and
-  `src/prompt-enhancement/hv1-env-supply.test.ts`.
-- **These two are the only accepted failures.** Exclude exactly those for a clean signal:
-
-  ```bash
-  npx vitest run \
-    --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
-    --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
-    --exclude "**/node_modules/**" \
-    --exclude "src/ext-vscode/**"
-  ```
-
-- On an unmodified `main` that run reports zero failures. Never add files to the exclude list to
-  make a run go green.
-
-**Leak guard** — `npm run pe:leak-guard` fails on confidentiality leak tokens (internal names,
-phase codes, private paths) in public-going prompt-enhancement files:
-
-- It is not clean on `main` today; those findings are known and tracked.
-- Run it before and after your change and confirm your diff **adds no new findings**.
-
-**Sub-packages** — `src/ext-vscode/` is excluded from the root build, typecheck, and test run; it
-is a separate npm package with a native dependency:
+For a clean test signal:
 
 ```bash
-cd src/ext-vscode
-npm install && npm run typecheck && npm run test && npm run build
+npx vitest run \
+  --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
+  --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
+  --exclude "**/node_modules/**" \
+  --exclude "src/ext-vscode/**"
 ```
 
-`src/ext-browser/` is different — its tests run in the root suite, its types do not. Build it with
-`npm run build:ext`.
+Never add files to that exclude list to make a run go green.
 
-## Writing and Submitting Code
+## Pull Requests
 
-1. **Keep pull requests focused**
+- One feature or fix per PR, split into logical commits
+- Conventional commit titles — `fix(pe): lower the popup cooldown default`
+- Relative imports need the `.js` extension (`NodeNext` ESM) — the most common first-build failure
+- `strict` is on: no `any`, no stray `console.log`
+- Never commit secrets, API keys, real home paths, or internal planning terminology
+- Tests live next to the code as `<module>.test.ts` — a bug fix needs one that fails before the fix
+  and passes after
+- Rebase on `upstream/main`, target `main`, and link the issue with `Fixes #123`
+- **Paste real command output as testing evidence.** "Should pass" is not evidence. If a check is
+  blocked, say which one, why, and what you ran instead.
 
-    - One feature or bug fix per PR; split larger work into related PRs
-    - Break changes into logical commits that can be reviewed independently
-
-2. **Code quality**
-
-    - This project is `NodeNext` ESM (`"type": "module"`), so relative imports need the `.js`
-      extension even in TypeScript — `import { thing } from './thing.js'`. This is the single most
-      common thing that breaks a first build.
-    - `strict` is on — use precise types, avoid `any`
-    - Strip stray `console.log` calls before you push
-    - Never commit secrets, API keys, real home paths, personal names, or internal planning
-      terminology
-
-3. **Testing**
-
-    - Add tests for new features — cover the behaviour, not just the happy path
-    - For a bug fix, add a test that **fails before your fix and passes after it**
-    - If you change existing behaviour, update the affected tests and explain why the old assertion
-      was wrong
-    - New content templates must satisfy both build gates and be reachable by a realistic prompt
-    - `src/readme.test.ts` asserts what the README must contain — run it if you edit the README
-    - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree
-    - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so tests never
-      touch your real install. Manual CLI runs **do**.
-
-4. **Commits and PR titles**
-
-    - Use conventional commits with an optional subsystem scope:
-      `feat(agents): detect Cursor installations on Windows`,
-      `fix(pe): lower the PE/MPS-1 popup cooldown default`
-    - Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`
-    - Reference issues with `#issue-number`
-
-5. **Testing evidence** — required on every PR marked ready for review
-
-    - Paste the **actual output** of the [Common Checks](#common-checks) — at minimum build,
-      typecheck, tests, and the leak-guard comparison against `main`
-    - For a bug fix, include the failing-then-passing test name
-    - `Not tested`, `N/A`, and "the tests should pass" are not sufficient
-    - If a command is blocked, state the command, the blocker, and the substitute verification you
-      ran instead
-    - Draft PRs may be incomplete until marked ready for review
-
-6. **AI assistance and ownership**
-
-    - AI coding agents are allowed — Nexpath is built for people who use them and developed with
-      them
-    - Before requesting review, make sure you understand the change, have tested it, and can explain
-      the diff
-    - Maintainers may close PRs without credible contributor ownership, including AI-assisted work
-      the contributor cannot explain
-    - Please don't submit batches of agent-generated or untested PRs, or mass-create issues through
-      automation
-
-7. **Before submitting**
-
-    - Rebase on the latest `upstream/main`
-    - Run everything in [Common Checks](#common-checks) — nothing will run it for you afterwards
-    - Review your diff for debugging code and leftover logs
-    - Describe what the change does, why, how you verified it, and any breaking changes. Add
-      screenshots or a short recording for CLI or popup UI changes.
-    - Link the issue with `Fixes #123`, and open the PR against `main` on
-      [`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath)
-
-## Questions
-
-**If anything here is unclear, ask — that is not a bother, it is the point.**
-
-- **[Discussions](https://github.com/hi0001234d/nexpath/discussions)** — open-ended questions,
-  design conversations, feedback on installing or using Nexpath
-- **[Issues](https://github.com/hi0001234d/nexpath/issues)** — concrete bugs and specific feature
-  proposals
-- **On a draft PR** — if you get stuck mid-implementation
-
-You don't need a fix ready to start a conversation. If the install broke or a section of the README
-confused you, tell us — that is signal we cannot get any other way.
+> AI agents are welcome — Nexpath is built with them. But you own what you submit: you must
+> understand the diff and be able to explain it.
 
 ## Contribution Agreement
 
-By submitting a pull request, you agree that your contributions will be licensed under the same
-license as the project ([Apache 2.0](LICENSE)).
+By submitting a pull request, you agree that your contributions are licensed under the project's
+[Apache 2.0](LICENSE) license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,7 @@ If you are new to the project, read the [README](README.md) first — it covers 
 how to install it, and how it handles your data. This guide covers only what you need in order
 to *change* it.
 
-## TL;DR
-
-There are lots of ways to contribute:
+## Ways to Contribute
 
 - **Code Contributions:** Fix bugs, improve the pipeline, add agent support
 - **End-to-End Agent Testing:** Verify Nexpath against agents we have not certified yet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Nexpath
 
-Read the [README](README.md) first — it covers what Nexpath does and how to install it. This guide
-covers how to change it.
+Read the [README](https://github.com/hi0001234d/nexpath?tab=readme-ov-file) first — it covers what
+Nexpath does and how to install it. This guide covers how to change it.
 
 ## Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,8 @@
 We're glad you're here. Whether you're fixing a bug, certifying a new agent, or improving the
 docs, every contribution makes Nexpath more trustworthy.
 
-If you are new to the project, read the [README](README.md) first — it covers what Nexpath does,
-how to install it, and how it handles your data. This guide covers only what you need in order
-to *change* it.
+New here? Read the [README](README.md) first — it covers what Nexpath does, how to install it,
+and how it handles your data. This guide covers what you need in order to *change* it.
 
 ## Ways to Contribute
 
@@ -19,12 +18,9 @@ to *change* it.
 The Nexpath community is in
 [GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions).
 
-One thing sets the tone for everything below: Nexpath exists to stop unverified work from
-shipping, so we hold contributions to the same bar. **Verify before you open a PR.**
-
 ## Reporting Bugs or Issues
 
-Bug reports make Nexpath better for everyone. Before creating a new issue, please
+Before creating a new issue, please
 [search existing ones](https://github.com/hi0001234d/nexpath/issues) to avoid duplicates. When
 you're ready, head to the [issues page](https://github.com/hi0001234d/nexpath/issues/new/choose).
 
@@ -42,12 +38,10 @@ A great bug report contains:
 - **What actually happened** — exact error text, not a paraphrase
 - **Diagnostics** — the output of `nexpath status`, and `nexpath log` if the issue is about
   advisory or popup behaviour. Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
-- **Notes** — why you think it might be happening, and what you already tried
 
-**Before pasting diagnostics, read them.** `nexpath status` prints a full config dump and
-`nexpath log` prints recent pipeline activity, which may include your own prompts. Nexpath's
-redaction covers common secret formats, but that is not a guarantee for everything in a config
-dump — redact anything private before posting it publicly.
+`nexpath status` prints a full config dump and `nexpath log` prints recent pipeline activity,
+which may include your own prompts — read both before pasting them publicly and redact anything
+private.
 
 ## Before Contributing
 
@@ -63,40 +57,29 @@ correction, a minor wording improvement, or a type-only fix that doesn't change 
 - Wait for approval from core maintainers before starting implementation
 - Once approved, feel free to begin working on a PR
 
-**PRs without approved issues may be closed.**
-
-This is not bureaucracy — Nexpath's pipeline has a lot of interlocking gates, and a change that
-looks local can move behaviour three stages downstream. A short conversation up front saves you
-from rewriting work that was never going to land.
+**PRs without approved issues may be closed.** Nexpath's pipeline has a lot of interlocking
+gates, and a change that looks local can move behaviour three stages downstream.
 
 ## Deciding What to Work On
 
 Looking for a good first contribution? Check out issues labeled
 [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
-[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted). These are curated
-for new contributors and areas where we'd love some help.
+[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted).
 
-Beyond the issue tracker, these are the areas where contribution is most useful right now:
+Beyond the issue tracker, these areas need help most right now:
 
-1. **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
-   Code is certified end-to-end today; the README's support table lists the rest. Certifying
-   another agent means installing Nexpath against it, running real prompts through it, and
-   reporting exactly what happened. Unlike the unit suite this cannot be automated — it needs a
-   real agent, a real OS, and a real person watching.
-
-2. **Cross-platform verification** — Nexpath touches OS-level credential storage and writes
-   local state, so it breaks in platform-specific ways. Reports from Windows are especially
-   useful, since that is where we have the least coverage.
-
-3. **Pipeline correctness** — the prompt-enhancement pipeline (`src/prompt-enhancement/`) and
-   the decision-session layer (`src/decision-session/`) carry most of the product behaviour and
-   most of the test suite.
+- **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
+  Code is certified end-to-end today; the README's support table lists the rest. Install Nexpath
+  against another agent, run real prompts through it, and report exactly what happened.
+- **Cross-platform verification** — Nexpath touches OS-level credential storage and writes local
+  state, so it breaks in platform-specific ways. Windows reports are especially useful.
+- **Pipeline correctness** — `src/prompt-enhancement/` and `src/decision-session/` carry most of
+  the product behaviour and most of the test suite.
 
 ## Prerequisites
 
-- **Node.js 18+** — required for all packages. Development is done on Node 20+; Node 22 is known
-  to work. Declared as `"engines": { "node": ">=18" }`.
-- **npm 9+** — ships with Node 18 and newer.
+- **Node.js 18+** — development is done on Node 20+; Node 22 is known to work
+- **npm 9+** — ships with Node 18 and newer
 - **git**
 
 Nothing else is required for the core CLI. TypeScript, `tsx`, and `vitest` all come from
@@ -133,16 +116,10 @@ npm test
 enforces two hard gates over the shipped content-template registry and aborts the build on
 failure:
 
-```
-✓ content-template build gate passed (all records floored + schema-valid)
-✓ prompt-enhancement selectability gate passed (every intent routes from its proposal - no absorb, no skip)
-```
-
 - **Content-template gate** — every shipped record must be schema-valid and must have a level-1
   floor. A record missing its floor fails the build.
 - **Selectability gate** — every prompt-enhancement intent must be reachable by a realistic
-  prompt through the production router. An intent no prompt can reach is a dead template, and
-  the build refuses to ship it.
+  prompt through the production router. An intent no prompt can reach is a dead template.
 
 If you added or edited a content template and the build aborts, fix the record — do not bypass
 the gate.
@@ -155,24 +132,21 @@ npm run typecheck:ext    # browser extension (tsconfig.ext-browser.json)
 ```
 
 Both must produce no output. The root `tsconfig.json` deliberately excludes `src/ext-vscode` and
-`src/ext-browser`, so `npm run typecheck` alone does **not** cover the browser extension. If you
-touched `src/ext-browser/`, the second command is mandatory.
+`src/ext-browser`, so if you touched `src/ext-browser/`, the second command is mandatory.
 
 ### Tests
 
 `npm test` runs `vitest run` across the whole tree. It takes a minute or two.
 
-**Known failures on a public clone — read this.** On a clean clone, `npm test` exits **1**. Two
-test files fail:
+**Known failures on a public clone.** On a clean clone, `npm test` exits **1**. Two test files
+fail:
 
 - `src/prompt-enhancement/dev-plan-table-integrity.test.ts`
 - `src/prompt-enhancement/hv1-env-supply.test.ts`
 
 Both read planning documents from a private submodule that is **not part of the public
-repository**, so they fail with `ENOENT` for reasons unrelated to your change.
-
-**These two files are the only accepted failures.** To get a clean signal, exclude exactly those
-two and nothing else:
+repository**, so they fail with `ENOENT` for reasons unrelated to your change. **These two files
+are the only accepted failures.** To get a clean signal, exclude exactly those two:
 
 ```bash
 npx vitest run \
@@ -182,27 +156,23 @@ npx vitest run \
   --exclude "src/ext-vscode/**"
 ```
 
-On an unmodified `main`, that run reports zero failures.
-
-**Every remaining file must pass.** If any file other than the two named above fails, your
-change broke something. Do not add files to the exclude list to make a run go green — that is
-exactly the kind of unverified shipping Nexpath exists to prevent.
+On an unmodified `main`, that run reports zero failures. **Every remaining file must pass.** Do
+not add files to the exclude list to make a run go green.
 
 ### Leak guard
 
 `npm run pe:leak-guard` is a read-only scan that fails if any public-going prompt-enhancement
 file contains a confidentiality leak token (internal names, internal phase codes, private
-paths). It performs no git history rewrite and no push.
+paths).
 
-**Current status:** this script does not come back clean on `main`. The existing findings are
-known, tracked, and **not caused by your change.** Run it before and after your change and
-confirm your diff **adds no new findings** — if the list grows, the new entries are yours.
+It does not come back clean on `main` today. The existing findings are known and tracked. Run it
+before and after your change and confirm your diff **adds no new findings**.
 
 ### Sub-package checks
 
 `src/ext-vscode/` is excluded from the root typecheck, the root build, **and** the root test run
 (`vitest.config.ts`) — it's a separate npm package with a native dependency not installed at the
-root. The root gate does not cover it:
+root:
 
 ```bash
 cd src/ext-vscode
@@ -216,9 +186,6 @@ npm run build
 that's what `npm run typecheck:ext` is for. To build it: `npm run build:ext`.
 
 ## Writing and Submitting Code
-
-Anyone can contribute code to Nexpath, but we ask that you follow these guidelines so your
-contributions can be smoothly integrated:
 
 1. **Keep Pull Requests Focused**
 
@@ -242,21 +209,17 @@ contributions can be smoothly integrated:
    - For a bug fix, add a test that **fails before your fix and passes after it**, and say so in
      the PR
    - If your change alters existing behaviour, update the affected tests and explain in the PR
-     why the old assertion was wrong. Do not silently delete an assertion to make a run go green.
-   - New content templates must satisfy both build gates (schema + level-1 floor) and be
-     reachable by a realistic prompt, or the build will reject them
-   - `src/readme.test.ts` asserts what the README must contain and must not leak — run it if you
-     edit the README
-   - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree. The
-     existing suite is unusually explicit about what each test proves — matching that style makes
-     review much faster.
+     why the old assertion was wrong
+   - New content templates must satisfy both build gates and be reachable by a realistic prompt
+   - `src/readme.test.ts` asserts what the README must contain — run it if you edit the README
+   - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree
    - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so running
      tests never touches your real install. Manual CLI runs **do**.
 
 4. **Run the Checks**
 
-   - Run everything in [Common Checks](#common-checks) before you push
-   - All checks must pass locally, because nothing will run them for you afterwards
+   - Run everything in [Common Checks](#common-checks) before you push — nothing will run them
+     for you afterwards
 
 5. **Commit Guidelines**
 
@@ -267,8 +230,7 @@ contributions can be smoothly integrated:
 6. **Before Submitting**
 
    - Rebase your branch on the latest `upstream/main`
-   - Ensure your branch builds successfully
-   - Double-check the test run against the expected counts above
+   - Confirm the build, both typechecks, and the test run are clean
    - Review your changes for any debugging code or leftover logs
 
 7. **Pull Request Description**
@@ -279,9 +241,6 @@ contributions can be smoothly integrated:
    - Add screenshots for CLI or popup UI changes
 
 ## Pull Request Expectations
-
-Contributor guidance exists to protect maintainer review time and keep reviews focused on work
-that is ready to evaluate.
 
 - **UI Changes:** Include screenshots or a short recording (before/after)
 - **Logic Changes:** Explain how you verified it works
@@ -295,8 +254,8 @@ Every PR marked ready for review must include testing evidence. A bare `Not test
 not sufficient, and neither is "the tests should pass."
 
 Paste the actual output of the commands in [Common Checks](#common-checks) — at minimum the
-build, the typecheck, the test run with its file and test counts, and the leak-guard comparison
-against `main`. For a bug fix, include the failing-then-passing test name.
+build, the typecheck, the test run, and the leak-guard comparison against `main`. For a bug fix,
+include the failing-then-passing test name.
 
 If you cannot complete a relevant command, include all three of the following in the PR:
 
@@ -304,39 +263,28 @@ If you cannot complete a relevant command, include all three of the following in
 - The blocker or failure that prevented completion
 - The substitute verification you performed instead
 
-Agent limitations, local resource constraints, or an agent prompt that says to skip tests do not
-waive this requirement — they just change what you write down. Draft PRs may be incomplete until
-they are marked ready for review.
+Draft PRs may be incomplete until they are marked ready for review.
 
 ### Contribution Ownership and AI Assistance
 
 AI coding agents are allowed — Nexpath is built for people who use them, and this repo is
-developed with them. But contributors own the work they submit.
+developed with them. But contributors own the work they submit: before requesting review, make
+sure you personally understand the change, have tested it, and can explain the diff.
 
-Before requesting review, make sure you personally understand the change, have tested it
-appropriately, can explain the diff, and understand how it interacts with the rest of the
-pipeline.
-
-Maintainers may close PRs that appear to be submitted without credible contributor ownership or
-understanding, including AI-assisted work the contributor cannot explain or has not meaningfully
-reviewed.
+Maintainers may close PRs that appear to be submitted without credible contributor ownership,
+including AI-assisted work the contributor cannot explain.
 
 ### Tracker Use and Automation
 
-Do not submit batches of agent-generated, untested, or weakly reviewed PRs. Prioritize
-high-impact issues instead of opening many speculative fixes.
-
-For issues, do not mass-create tickets through automation. Search existing issues first, open
-issues only when you have enough context for someone to act, and prioritize the most important
-reports instead of filing every possible finding.
+Do not submit batches of agent-generated, untested, or weakly reviewed PRs, and do not
+mass-create issues through automation. Search existing issues first, and prioritize high-impact
+work over many speculative fixes.
 
 ### Issue and PR Lifecycle
 
-To keep the backlog manageable, inactive issues and PRs may be closed after a period of
-inactivity. This isn't a judgment on quality — older items lose context over time. Feel free to
-reopen or create a new issue or PR if you're still working on something.
-
-Please respond to review comments rather than force-pushing silently over them.
+Inactive issues and PRs may be closed to keep the backlog manageable — feel free to reopen or
+open a new one if you're still working on something. Please respond to review comments rather
+than force-pushing silently over them.
 
 ## PR Titles
 
@@ -345,8 +293,6 @@ Use conventional commit style PR titles, with an optional scope naming the subsy
 - `feat(agents): detect Cursor installations on Windows`
 - `fix(pe): lower the PE/MPS-1 popup cooldown default`
 - `docs: clarify the known-failing test files`
-- `chore: bump TypeScript to 5.8`
-- `refactor(store): extract the prune path`
 - `test(pe-host): cover the display-decision pre-spawn gate`
 
 Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
@@ -356,22 +302,15 @@ Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
 **If anything here is unclear, ask — that is not a bother, it is the point.**
 
 - **[GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions)** — open-ended
-  questions, design conversations, "is this a bug or am I holding it wrong?", and feedback on
-  your experience installing or using Nexpath. There is a feedback template set up for this.
+  questions, design conversations, and feedback on installing or using Nexpath
 - **[GitHub Issues](https://github.com/hi0001234d/nexpath/issues)** — concrete bugs and specific
-  feature proposals.
-- **On a PR** — if you get stuck mid-implementation, open a draft PR and ask there. Showing the
-  code you are stuck on gets a much better answer than describing it.
+  feature proposals
+- **On a PR** — if you get stuck mid-implementation, open a draft PR and ask there
 
-You do not need to have a fix ready to start a conversation. If you tried Nexpath and could not
-tell what it does, or the install broke, or a section of the README confused you — tell us. That
-is signal we cannot get any other way, and it is a real contribution.
+You do not need to have a fix ready to start a conversation. If the install broke or a section
+of the README confused you, tell us — that is signal we cannot get any other way.
 
 ## Contribution Agreement
 
 By submitting a pull request, you agree that your contributions will be licensed under the same
 license as the project ([Apache 2.0](LICENSE)).
-
-Contributing to Nexpath isn't just about writing code — it's about being part of a community
-trying to make AI-assisted development something you can actually ship with confidence. Let's
-build something reliable together.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Two things that trip people up:
   `npm install && npm run typecheck && npm run test && npm run build`.
 
 `npm test` also exits 1 on a public clone: two files read a private submodule and fail with
-`ENOENT`. They are the only accepted failures — exclude exactly those two to see whether your own
-change passes, and never add anything else to the list:
+`ENOENT`. They are the only accepted failures. Exclude exactly those two — and nothing else — to
+see whether your own change passes:
 
 ```bash
 npx vitest run \
@@ -61,6 +61,15 @@ npx vitest run \
   --exclude "**/node_modules/**" \
   --exclude "src/ext-vscode/**"
 ```
+
+On an unmodified branch that run is green, and the summary it prints is what your PR should show:
+
+```
+ Test Files  350 passed (350)
+      Tests  9337 passed | 1 todo (9338)
+```
+
+Anything red beyond those two files is your change.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,24 +43,15 @@ npm run typecheck:ext  # required if you touched src/ext-browser/
 npm test               # vitest, whole tree
 ```
 
-Two things that trip people up:
+Three things that trip people up:
 
 - **Build gates** — a content template that is schema-invalid, missing its level-1 floor, or
   unreachable by a realistic prompt aborts the build. Fix the record; don't bypass the gate.
 - **`src/ext-vscode/`** — a separate package, excluded from every root check. Run its own
   `npm install && npm run typecheck && npm run test && npm run build`.
-
-`npm test` also exits 1 on a public clone: two files read a private submodule and fail with
-`ENOENT`. They are the only accepted failures. Exclude exactly those two — and nothing else — to
-see whether your own change passes:
-
-```bash
-npx vitest run \
-  --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
-  --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
-  --exclude "**/node_modules/**" \
-  --exclude "src/ext-vscode/**"
-```
+- **`npm test` exits 1 on a public clone** — `dev-plan-table-integrity.test.ts` and
+  `hv1-env-supply.test.ts` read a private submodule and fail with `ENOENT`. Those two are the only
+  accepted failures; everything else red is your change.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,6 @@ covers how to change it.
 - Output of `nexpath status` — plus `nexpath log` for advisory or popup issues
   (`NEXPATH_DEBUG=1` for verbose stderr)
 
-> 🔐 Found a security vulnerability?
-> [Report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new), not in a
-> public issue.
->
 > ⚠️ `nexpath status` dumps your config and `nexpath log` may contain your prompts — redact before
 > pasting.
 
@@ -35,9 +31,6 @@ covers how to change it.
 - Open an issue first — except typos, small bug fixes, and type-only changes
 - State the problem, your approach, and why it belongs in Nexpath
 - Wait for maintainer approval. **PRs without an approved issue may be closed.**
-- New here? Start with
-  [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
-  [`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted)
 
 ## Common Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,74 +1,73 @@
 # Contributing to Nexpath
-
-Read the [README](https://github.com/hi0001234d/nexpath?tab=readme-ov-file) first — it covers what
-Nexpath does and how to install it. This guide covers how to change it.
-
+ 
+Read the [README](__https://github.com/hi0001234d/nexpath?tab=readme-ov-file__) first — it covers what
+Nexpath does and how to install and run it. This guide covers how to contribute changes.
+ 
 ## Ways to Contribute
-
-- **End-to-end agent testing** — run Nexpath against an agent the README lists as uncertified and
-  report what happened. No codebase knowledge needed.
+ 
+- **Reports** — [Issues](__https://github.com/hi0001234d/nexpath/issues__) for bugs and features,
+  [Discussions](__https://github.com/hi0001234d/nexpath/discussions__) for everything else
 - **Code** — bug fixes, pipeline work, new agent support
 - **Docs** — the README, this guide, or the CLI help text
-- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
-  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
-
+- **Reports** — [Issues](__https://github.com/hi0001234d/nexpath/issues__) for bugs and features,
+  [Discussions](__https://github.com/hi0001234d/nexpath/discussions__) for everything else
+ 
 ## Reporting Bugs
-
-[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first, then
-[open a new one](https://github.com/hi0001234d/nexpath/issues/new) with:
-
+ 
+[Search existing issues](__https://github.com/hi0001234d/nexpath/issues__) first to avoid duplicates, then
+[open a new one](__https://github.com/hi0001234d/nexpath/issues/new__) with:
+ 
 - OS, Node version, Nexpath version, and which AI coding agent
 - The exact prompt or command that reproduces it
 - What you expected, and the actual error text
 - Output of `nexpath status` — plus `nexpath log` for advisory or popup issues
   (`NEXPATH_DEBUG=1` for verbose stderr)
-
+ 
 > ⚠️ `nexpath status` dumps your config and `nexpath log` may contain your prompts — redact before
 > pasting.
-
+ 
 ## Before You Start
-
-- Open an issue first — except typos, small bug fixes, and type-only changes
+ 
+- Open an issue first for features and non-trivial bug fixes; typos, small bug fixes, and type-only changes can be submitted directly
 - State the problem, your approach, and why it belongs in Nexpath
-- Wait for maintainer approval. **PRs without an approved issue may be closed.**
-
+- For features and non-trivial changes, wait for maintainer approval before opening a PR. **PRs without an approved issue may be closed.**
+ 
 ## Common Checks
-
+ 
 Nexpath runs **no CI on pull requests** — your local run is the only gate.
-
+ 
 ```bash
 npm run build          # prebuild gates: content-template + selectability
 npm run typecheck      # core CLI + server
 npm run typecheck:ext  # required if you touched src/ext-browser/
 npm test               # vitest, whole tree
 ```
-
+ 
 Three things that trip people up:
-
+ 
 - **Build gates** — a content template that is schema-invalid, missing its level-1 floor, or
   unreachable by a realistic prompt aborts the build. Fix the record; don't bypass the gate.
-- **`src/ext-vscode/`** — a separate package, excluded from every root check. Run its own
+- **`src/ext-vscode/`** — a separate package, excluded from the root checks. Run its own
   `npm install && npm run typecheck && npm run test && npm run build`.
 - **`npm test` exits 1 on a public clone** — `dev-plan-table-integrity.test.ts` and
   `hv1-env-supply.test.ts` read a private submodule and fail with `ENOENT`. Those two are the only
   accepted failures; everything else red is your change.
-
+ 
 ## Pull Requests
-
-- One feature or fix per PR, split into logical commits
+ 
+- One feature or fix per PR; keep commits focused and logical
 - Conventional commit titles — `fix(pe): lower the popup cooldown default`
 - Relative imports need the `.js` extension (`NodeNext` ESM) — the most common first-build failure
 - `strict` is on: no `any`, no stray `console.log`
 - Never commit secrets, API keys, real home paths, or internal planning terminology
-- Tests live next to the code as `<module>.test.ts` — a bug fix needs one that fails before the fix
-  and passes after
-- Rebase on the latest `main`, target `main`, and link the issue with `Fixes #123`
+- Tests live next to the code as `<module>.test.ts` — add or update tests when behavior changes; a bug fix needs one that fails before the fix and passes after
+- Rebase on the latest `main`, target `main`, and link the issue with `Fixes #123` when applicable
 - **Paste real command output as testing evidence.** "Should pass" is not evidence. If a check is
   blocked, say which one, why, and what you ran instead.
 - **You own what you submit** — AI agents are welcome, but you must understand the diff and be able
   to explain it
-
+ 
 ## Contribution Agreement
-
+ 
 By submitting a pull request, you agree that your contributions are licensed under the project's
-[Apache 2.0](LICENSE) license.
+[Apache 2.0](LICENSE) license. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Contributing to Nexpath
  
-Read the [README](__https://github.com/hi0001234d/nexpath?tab=readme-ov-file__) first — it covers what
+Read the [README](https://github.com/hi0001234d/nexpath?tab=readme-ov-file) first — it covers what
 Nexpath does and how to install and run it. This guide covers how to contribute changes.
  
 ## Ways to Contribute
  
-- **Reports** — [Issues](__https://github.com/hi0001234d/nexpath/issues__) for bugs and features,
-  [Discussions](__https://github.com/hi0001234d/nexpath/discussions__) for everything else
+- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
+  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
 - **Code** — bug fixes, pipeline work, new agent support
 - **Docs** — the README, this guide, or the CLI help text
-- **Reports** — [Issues](__https://github.com/hi0001234d/nexpath/issues__) for bugs and features,
-  [Discussions](__https://github.com/hi0001234d/nexpath/discussions__) for everything else
+- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
+  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
  
 ## Reporting Bugs
  
-[Search existing issues](__https://github.com/hi0001234d/nexpath/issues__) first to avoid duplicates, then
-[open a new one](__https://github.com/hi0001234d/nexpath/issues/new__) with:
+[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first to avoid duplicates, then
+[open a new one](https://github.com/hi0001234d/nexpath/issues/new) with:
  
 - OS, Node version, Nexpath version, and which AI coding agent
 - The exact prompt or command that reproduces it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,6 @@ The Nexpath community is in
 One thing sets the tone for everything below: Nexpath exists to stop unverified work from
 shipping, so we hold contributions to the same bar. **Verify before you open a PR.**
 
----
-
 ## Reporting Bugs or Issues
 
 Bug reports make Nexpath better for everyone. Before creating a new issue, please
@@ -51,8 +49,6 @@ A great bug report contains:
 redaction covers common secret formats, but that is not a guarantee for everything in a config
 dump — redact anything private before posting it publicly.
 
----
-
 ## Before Contributing
 
 All contributions must begin with a GitHub Issue, unless the change is a small bug fix, a typo
@@ -72,8 +68,6 @@ correction, a minor wording improvement, or a type-only fix that doesn't change 
 This is not bureaucracy — Nexpath's pipeline has a lot of interlocking gates, and a change that
 looks local can move behaviour three stages downstream. A short conversation up front saves you
 from rewriting work that was never going to land.
-
----
 
 ## Deciding What to Work On
 
@@ -98,8 +92,6 @@ Beyond the issue tracker, these are the areas where contribution is most useful 
    the decision-session layer (`src/decision-session/`) carry most of the product behaviour and
    most of the test suite.
 
----
-
 ## Prerequisites
 
 - **Node.js 18+** — required for all packages. Development is done on Node 20+; Node 22 is known
@@ -118,8 +110,6 @@ later:
 ```bash
 git remote add upstream https://github.com/hi0001234d/nexpath.git
 ```
-
----
 
 ## Common Checks
 
@@ -225,8 +215,6 @@ npm run build
 `src/ext-browser/` is different: its tests **do** run in the root suite, but its types do not —
 that's what `npm run typecheck:ext` is for. To build it: `npm run build:ext`.
 
----
-
 ## Writing and Submitting Code
 
 Anyone can contribute code to Nexpath, but we ask that you follow these guidelines so your
@@ -290,8 +278,6 @@ contributions can be smoothly integrated:
    - List any breaking changes
    - Add screenshots for CLI or popup UI changes
 
----
-
 ## Pull Request Expectations
 
 Contributor guidance exists to protect maintainer review time and keep reviews focused on work
@@ -352,8 +338,6 @@ reopen or create a new issue or PR if you're still working on something.
 
 Please respond to review comments rather than force-pushing silently over them.
 
----
-
 ## PR Titles
 
 Use conventional commit style PR titles, with an optional scope naming the subsystem:
@@ -366,8 +350,6 @@ Use conventional commit style PR titles, with an optional scope naming the subsy
 - `test(pe-host): cover the display-decision pre-spawn gate`
 
 Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
-
----
 
 ## Questions
 
@@ -384,8 +366,6 @@ Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
 You do not need to have a fix ready to start a conversation. If you tried Nexpath and could not
 tell what it does, or the install broke, or a section of the README confused you — tell us. That
 is signal we cannot get any other way, and it is a real contribution.
-
----
 
 ## Contribution Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ and how it handles your data. This guide covers what you need in order to *chang
 
 Before creating a new issue, please
 [search existing ones](https://github.com/hi0001234d/nexpath/issues) to avoid duplicates. When
-you're ready, head to the [issues page](https://github.com/hi0001234d/nexpath/issues/new/choose).
+you're ready, [open a new issue](https://github.com/hi0001234d/nexpath/issues/new).
 
 > 🔐 **Important:** If you discover a security vulnerability, please use the
 > [GitHub security tool to report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new)
@@ -47,8 +47,8 @@ correction, a minor wording improvement, or a type-only fix that doesn't change 
 
 For features and larger contributions:
 
-- Check [existing issues](https://github.com/hi0001234d/nexpath/issues) and
-  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for similar ideas
+- Check [existing issues](https://github.com/hi0001234d/nexpath/issues) and Discussions for
+  similar ideas
 - If your idea is new, open an issue describing the problem, your proposed approach, and why it
   belongs in Nexpath
 - Wait for approval from core maintainers before starting implementation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,8 @@ and how it handles your data. This guide covers what you need in order to *chang
 - **Documentation:** Improve the README, this guide, or the CLI help text
 - **Bug Reports:** Report issues you encounter
 - **Feature Requests:** Suggest new features or improvements
-- **Community Support:** Help other users in the community
-
-The Nexpath community is in
-[GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions).
+- **Community Support:** Help other users in
+  [GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions)
 
 ## Reporting Bugs or Issues
 
@@ -39,34 +37,29 @@ A great bug report contains:
 - **Diagnostics** — the output of `nexpath status`, and `nexpath log` if the issue is about
   advisory or popup behaviour. Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
 
-`nexpath status` prints a full config dump and `nexpath log` prints recent pipeline activity,
-which may include your own prompts — read both before pasting them publicly and redact anything
-private.
+`nexpath status` dumps your full config and `nexpath log` may include your own prompts — read
+both before pasting them publicly and redact anything private.
 
 ## Before Contributing
 
 All contributions must begin with a GitHub Issue, unless the change is a small bug fix, a typo
 correction, a minor wording improvement, or a type-only fix that doesn't change functionality.
 
-**For features and larger contributions:**
+For features and larger contributions:
 
-- First check [existing issues](https://github.com/hi0001234d/nexpath/issues) and
+- Check [existing issues](https://github.com/hi0001234d/nexpath/issues) and
   [Discussions](https://github.com/hi0001234d/nexpath/discussions) for similar ideas
 - If your idea is new, open an issue describing the problem, your proposed approach, and why it
   belongs in Nexpath
 - Wait for approval from core maintainers before starting implementation
-- Once approved, feel free to begin working on a PR
 
 **PRs without approved issues may be closed.** Nexpath's pipeline has a lot of interlocking
 gates, and a change that looks local can move behaviour three stages downstream.
 
-## Deciding What to Work On
-
-Looking for a good first contribution? Check out issues labeled
+Looking for a first contribution? Start with
 [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
-[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted).
-
-Beyond the issue tracker, these areas need help most right now:
+[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted). Beyond the tracker,
+these areas need help most:
 
 - **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
   Code is certified end-to-end today; the README's support table lists the rest. Install Nexpath
@@ -76,7 +69,7 @@ Beyond the issue tracker, these areas need help most right now:
 - **Pipeline correctness** — `src/prompt-enhancement/` and `src/decision-session/` carry most of
   the product behaviour and most of the test suite.
 
-## Prerequisites
+## Development Setup
 
 - **Node.js 18+** — development is done on Node 20+; Node 22 is known to work
 - **npm 9+** — ships with Node 18 and newer
@@ -92,15 +85,14 @@ later:
 
 ```bash
 git remote add upstream https://github.com/hi0001234d/nexpath.git
+npm install
 ```
 
 ## Common Checks
 
-**Read this section before you open a PR.**
-
-Nexpath does **not** run tests on pull requests. The two GitHub Actions workflows
-(`publish-extension.yml`, `publish-ext-browser.yml`) only fire on release tags — they are
-publish pipelines, not CI. **Your local run is the only gate that exists.**
+**Read this section before you open a PR.** Nexpath does **not** run tests on pull requests —
+the two GitHub Actions workflows only fire on release tags, so **your local run is the only gate
+that exists.**
 
 From the repo root:
 
@@ -113,8 +105,7 @@ npm test
 ### Build
 
 `npm run build` is not just `tsc`. The `prebuild` step runs `scripts/check-build-gate.ts`, which
-enforces two hard gates over the shipped content-template registry and aborts the build on
-failure:
+aborts the build on two hard gates:
 
 - **Content-template gate** — every shipped record must be schema-valid and must have a level-1
   floor. A record missing its floor fails the build.
@@ -138,15 +129,13 @@ Both must produce no output. The root `tsconfig.json` deliberately excludes `src
 
 `npm test` runs `vitest run` across the whole tree. It takes a minute or two.
 
-**Known failures on a public clone.** On a clean clone, `npm test` exits **1**. Two test files
-fail:
+On a clean public clone it exits **1**, because two test files read planning documents from a
+private submodule and fail with `ENOENT` for reasons unrelated to your change:
 
 - `src/prompt-enhancement/dev-plan-table-integrity.test.ts`
 - `src/prompt-enhancement/hv1-env-supply.test.ts`
 
-Both read planning documents from a private submodule that is **not part of the public
-repository**, so they fail with `ENOENT` for reasons unrelated to your change. **These two files
-are the only accepted failures.** To get a clean signal, exclude exactly those two:
+**These two are the only accepted failures.** To get a clean signal, exclude exactly those two:
 
 ```bash
 npx vitest run \
@@ -156,8 +145,8 @@ npx vitest run \
   --exclude "src/ext-vscode/**"
 ```
 
-On an unmodified `main`, that run reports zero failures. **Every remaining file must pass.** Do
-not add files to the exclude list to make a run go green.
+On an unmodified `main`, that run reports zero failures. Every remaining file must pass — do not
+add files to the exclude list to make a run go green.
 
 ### Leak guard
 
@@ -165,12 +154,12 @@ not add files to the exclude list to make a run go green.
 file contains a confidentiality leak token (internal names, internal phase codes, private
 paths).
 
-It does not come back clean on `main` today. The existing findings are known and tracked. Run it
-before and after your change and confirm your diff **adds no new findings**.
+It does not come back clean on `main` today; those findings are known and tracked. Run it before
+and after your change and confirm your diff **adds no new findings**.
 
 ### Sub-package checks
 
-`src/ext-vscode/` is excluded from the root typecheck, the root build, **and** the root test run
+`src/ext-vscode/` is excluded from the root typecheck, build, **and** test run
 (`vitest.config.ts`) — it's a separate npm package with a native dependency not installed at the
 root:
 
@@ -216,39 +205,25 @@ that's what `npm run typecheck:ext` is for. To build it: `npm run build:ext`.
    - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so running
      tests never touches your real install. Manual CLI runs **do**.
 
-4. **Run the Checks**
+4. **Commits and PR Titles**
 
-   - Run everything in [Common Checks](#common-checks) before you push — nothing will run them
-     for you afterwards
-
-5. **Commit Guidelines**
-
-   - Write clear, descriptive commit messages
-   - Use conventional commit format (e.g. `feat:`, `fix:`, `docs:`)
+   - Use conventional commit format with an optional scope naming the subsystem:
+     `feat(agents): detect Cursor installations on Windows`,
+     `fix(pe): lower the PE/MPS-1 popup cooldown default`, `docs: clarify the known-failing tests`
+   - Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`
    - Reference relevant issues using `#issue-number`
 
-6. **Before Submitting**
+5. **Before Submitting**
 
    - Rebase your branch on the latest `upstream/main`
-   - Confirm the build, both typechecks, and the test run are clean
-   - Review your changes for any debugging code or leftover logs
+   - Run everything in [Common Checks](#common-checks) — nothing will run it for you afterwards
+   - Review your changes for debugging code or leftover logs
+   - Describe in the PR what your changes do, why, how you verified them, and any breaking
+     changes. Add screenshots or a short recording for CLI or popup UI changes.
+   - Link the issue with `Fixes #123` or `Closes #123`, and open the PR against `main` on
+     [`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath)
 
-7. **Pull Request Description**
-
-   - Clearly describe what your changes do and why
-   - Include how you verified them
-   - List any breaking changes
-   - Add screenshots for CLI or popup UI changes
-
-## Pull Request Expectations
-
-- **UI Changes:** Include screenshots or a short recording (before/after)
-- **Logic Changes:** Explain how you verified it works
-
-Link the issue with `Fixes #123` or `Closes #123`, and open the PR against `main` on
-[`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath).
-
-### Testing Evidence
+## Testing Evidence
 
 Every PR marked ready for review must include testing evidence. A bare `Not tested` or `N/A` is
 not sufficient, and neither is "the tests should pass."
@@ -265,37 +240,15 @@ If you cannot complete a relevant command, include all three of the following in
 
 Draft PRs may be incomplete until they are marked ready for review.
 
-### Contribution Ownership and AI Assistance
+## AI Assistance and Ownership
 
 AI coding agents are allowed — Nexpath is built for people who use them, and this repo is
 developed with them. But contributors own the work they submit: before requesting review, make
 sure you personally understand the change, have tested it, and can explain the diff.
 
 Maintainers may close PRs that appear to be submitted without credible contributor ownership,
-including AI-assisted work the contributor cannot explain.
-
-### Tracker Use and Automation
-
-Do not submit batches of agent-generated, untested, or weakly reviewed PRs, and do not
-mass-create issues through automation. Search existing issues first, and prioritize high-impact
-work over many speculative fixes.
-
-### Issue and PR Lifecycle
-
-Inactive issues and PRs may be closed to keep the backlog manageable — feel free to reopen or
-open a new one if you're still working on something. Please respond to review comments rather
-than force-pushing silently over them.
-
-## PR Titles
-
-Use conventional commit style PR titles, with an optional scope naming the subsystem:
-
-- `feat(agents): detect Cursor installations on Windows`
-- `fix(pe): lower the PE/MPS-1 popup cooldown default`
-- `docs: clarify the known-failing test files`
-- `test(pe-host): cover the display-decision pre-spawn gate`
-
-Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
+including AI-assisted work the contributor cannot explain. Please don't submit batches of
+agent-generated or untested PRs, or mass-create issues through automation.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,12 @@ covers how to change it.
 
 ## Ways to Contribute
 
-- **End-to-end agent testing** — run Nexpath against agents we have not certified yet
+- **End-to-end agent testing** — run Nexpath against an agent the README lists as uncertified and
+  report what happened. No codebase knowledge needed.
 - **Code** — bug fixes, pipeline work, new agent support
 - **Docs** — the README, this guide, or the CLI help text
 - **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
   [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
-
-> Only Claude Code is certified end-to-end today. Testing another agent from the README's support
-> table is the highest-value contribution, and needs no codebase knowledge.
 
 ## Reporting Bugs
 
@@ -41,22 +39,6 @@ covers how to change it.
   [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
   [`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted)
 
-## Development Setup
-
-Node.js 18+ (20+ recommended), npm 9+, and git. Everything else comes from `devDependencies`.
-
-Fork the repo, then:
-
-```bash
-git clone https://github.com/<your-username>/nexpath.git
-cd nexpath
-npm install
-git remote add upstream https://github.com/hi0001234d/nexpath.git
-```
-
-Build and link steps are in the
-[README](README.md#add-nexpath-to-your-development-workflow--installation).
-
 ## Common Checks
 
 Nexpath runs **no CI on pull requests** — your local run is the only gate.
@@ -66,21 +48,18 @@ npm run build          # prebuild gates: content-template + selectability
 npm run typecheck      # core CLI + server
 npm run typecheck:ext  # required if you touched src/ext-browser/
 npm test               # vitest, whole tree
-npm run pe:leak-guard  # confidentiality scan
 ```
 
-Expected behaviour before you debug your own change:
+Two things that trip people up:
 
 - **Build gates** — a content template that is schema-invalid, missing its level-1 floor, or
   unreachable by a realistic prompt aborts the build. Fix the record; don't bypass the gate.
-- **Tests** — two files fail with `ENOENT` on a public clone because they read a private submodule.
-  These are the only accepted failures.
-- **Leak guard** — not clean on `main` today. Run it before and after your change; your diff must
-  add no new findings.
 - **`src/ext-vscode/`** — a separate package, excluded from every root check. Run its own
   `npm install && npm run typecheck && npm run test && npm run build`.
 
-For a clean test signal:
+`npm test` also exits 1 on a public clone: two files read a private submodule and fail with
+`ENOENT`. They are the only accepted failures — exclude exactly those two to see whether your own
+change passes, and never add anything else to the list:
 
 ```bash
 npx vitest run \
@@ -89,8 +68,6 @@ npx vitest run \
   --exclude "**/node_modules/**" \
   --exclude "src/ext-vscode/**"
 ```
-
-Never add files to that exclude list to make a run go green.
 
 ## Pull Requests
 
@@ -101,7 +78,7 @@ Never add files to that exclude list to make a run go green.
 - Never commit secrets, API keys, real home paths, or internal planning terminology
 - Tests live next to the code as `<module>.test.ts` — a bug fix needs one that fails before the fix
   and passes after
-- Rebase on `upstream/main`, target `main`, and link the issue with `Fixes #123`
+- Rebase on the latest `main`, target `main`, and link the issue with `Fixes #123`
 - **Paste real command output as testing evidence.** "Should pass" is not evidence. If a check is
   blocked, say which one, why, and what you ran instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Contributing to Nexpath
  
-Read the [README](https://github.com/hi0001234d/nexpath?tab=readme-ov-file) first — it covers what
+Read the [README](README.md) first — it covers what
 Nexpath does and how to install and run it. This guide covers how to contribute changes.
  
 ## Ways to Contribute
  
-- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
-  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
+- **Reports** — [Issues](../../issues) for bugs and features,
+  [Discussions](../../discussions) for everything else
 - **Code** — bug fixes, pipeline work, new agent support
 - **Docs** — the README, this guide, or the CLI help text
-- **Reports** — [Issues](https://github.com/hi0001234d/nexpath/issues) for bugs and features,
-  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for everything else
+- **Reports** — [Issues](../../issues) for bugs and features,
+  [Discussions](../../discussions) for everything else
  
 ## Reporting Bugs
  
-[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first to avoid duplicates, then
-[open a new one](https://github.com/hi0001234d/nexpath/issues/new) with:
+[Search existing issues](../../issues) first to avoid duplicates, then
+[open a new one](../../issues/new) with:
  
 - OS, Node version, Nexpath version, and which AI coding agent
 - The exact prompt or command that reproduces it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ enforces two hard gates over the shipped content-template registry and aborts th
 failure:
 
 ```
-✓ content-template build gate passed (144 records, all floored + schema-valid)
+✓ content-template build gate passed (all records floored + schema-valid)
 ✓ prompt-enhancement selectability gate passed (every intent routes from its proposal - no absorb, no skip)
 ```
 
@@ -172,11 +172,10 @@ touched `src/ext-browser/`, the second command is mandatory.
 
 ### Tests
 
-`npm test` runs `vitest run` across the whole tree: **352 test files, 9386 tests**, in roughly
-70–90 seconds.
+`npm test` runs `vitest run` across the whole tree. It takes a minute or two.
 
-**Known failures on a public clone — read this.** On a clean clone, `npm test` exits **1** with 8
-failures across 2 files:
+**Known failures on a public clone — read this.** On a clean clone, `npm test` exits **1**. Two
+test files fail:
 
 - `src/prompt-enhancement/dev-plan-table-integrity.test.ts`
 - `src/prompt-enhancement/hv1-env-supply.test.ts`
@@ -195,16 +194,11 @@ npx vitest run \
   --exclude "src/ext-vscode/**"
 ```
 
-Expected on an unmodified `main`:
+On an unmodified `main`, that run reports zero failures.
 
-```
- Test Files  350 passed (350)
-      Tests  9337 passed | 1 todo (9338)
-```
-
-**All 350 must pass.** If any file other than the two named above fails, your change broke
-something. Do not add files to the exclude list to make a run go green — that is exactly the
-kind of unverified shipping Nexpath exists to prevent.
+**Every remaining file must pass.** If any file other than the two named above fails, your
+change broke something. Do not add files to the exclude list to make a run go green — that is
+exactly the kind of unverified shipping Nexpath exists to prevent.
 
 ### Leak guard
 
@@ -212,10 +206,9 @@ kind of unverified shipping Nexpath exists to prevent.
 file contains a confidentiality leak token (internal names, internal phase codes, private
 paths). It performs no git history rewrite and no push.
 
-**Current status:** on `main` today it reports **8 pre-existing findings** (a teammate name left
-in `src/prompt-enhancement/`). This is known and tracked, and is **not caused by your change.**
-Run it before and after your change and confirm your diff **adds no new findings**. If the count
-grows, the new entries are yours.
+**Current status:** this script does not come back clean on `main`. The existing findings are
+known, tracked, and **not caused by your change.** Run it before and after your change and
+confirm your diff **adds no new findings** — if the list grows, the new entries are yours.
 
 ### Sub-package checks
 
@@ -393,9 +386,6 @@ Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
 You do not need to have a fix ready to start a conversation. If you tried Nexpath and could not
 tell what it does, or the install broke, or a section of the README confused you — tell us. That
 is signal we cannot get any other way, and it is a real contribution.
-
-New to pull requests? [makeapullrequest.com](https://makeapullrequest.com/) and
-[firsttimersonly.com](https://www.firsttimersonly.com/) are good primers.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,8 @@ npx vitest run \
 - Rebase on the latest `main`, target `main`, and link the issue with `Fixes #123`
 - **Paste real command output as testing evidence.** "Should pass" is not evidence. If a check is
   blocked, say which one, why, and what you ran instead.
-
-> AI agents are welcome — Nexpath is built with them. But you own what you submit: you must
-> understand the diff and be able to explain it.
+- **You own what you submit** — AI agents are welcome, but you must understand the diff and be able
+  to explain it
 
 ## Contribution Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,15 +62,6 @@ npx vitest run \
   --exclude "src/ext-vscode/**"
 ```
 
-On an unmodified branch that run is green, and the summary it prints is what your PR should show:
-
-```
- Test Files  350 passed (350)
-      Tests  9337 passed | 1 todo (9338)
-```
-
-Anything red beyond those two files is your change.
-
 ## Pull Requests
 
 - One feature or fix per PR, split into logical commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,24 +3,23 @@
 We're glad you're here. Whether you're fixing a bug, certifying a new agent, or improving the
 docs, every contribution makes Nexpath more trustworthy.
 
-New here? Read the [README](README.md) first — it covers what Nexpath does, how to install it,
-and how it handles your data. This guide covers what you need in order to *change* it.
+New here? Read the [README](README.md) first — it covers what Nexpath does and how to install it.
+This guide covers what you need in order to *change* it.
 
 ## Ways to Contribute
 
-- **Code Contributions:** Fix bugs, improve the pipeline, add agent support
-- **End-to-End Agent Testing:** Verify Nexpath against agents we have not certified yet
-- **Documentation:** Improve the README, this guide, or the CLI help text
-- **Bug Reports:** Report issues you encounter
-- **Feature Requests:** Suggest new features or improvements
-- **Community Support:** Help other users in
-  [GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions)
+- **End-to-end agent testing** — verify Nexpath against agents we have not certified yet
+- **Code** — fix bugs, improve the pipeline, add agent support
+- **Documentation** — the README, this guide, or the CLI help text
+- **Bug reports and feature requests** — through
+  [Issues](https://github.com/hi0001234d/nexpath/issues)
+- **Community support** — help other users in
+  [Discussions](https://github.com/hi0001234d/nexpath/discussions)
 
 ## Reporting Bugs or Issues
 
-Before creating a new issue, please
-[search existing ones](https://github.com/hi0001234d/nexpath/issues) to avoid duplicates. When
-you're ready, [open a new issue](https://github.com/hi0001234d/nexpath/issues/new).
+[Search existing issues](https://github.com/hi0001234d/nexpath/issues) first to avoid duplicates,
+then [open a new one](https://github.com/hi0001234d/nexpath/issues/new).
 
 > 🔐 **Important:** If you discover a security vulnerability, please use the
 > [GitHub security tool to report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new)
@@ -28,60 +27,55 @@ you're ready, [open a new issue](https://github.com/hi0001234d/nexpath/issues/ne
 
 A great bug report contains:
 
-- **A quick summary** and the background of what you were doing
-- **Your environment** — OS and version, Node version, Nexpath version, and which AI coding
-  agent you were using
-- **Steps to reproduce** — be specific, and give the actual prompt or command if you can
-- **What you expected** to happen
-- **What actually happened** — exact error text, not a paraphrase
-- **Diagnostics** — the output of `nexpath status`, and `nexpath log` if the issue is about
-  advisory or popup behaviour. Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
+- **A quick summary** of what you were doing
+- **Your environment** — OS, Node version, Nexpath version, and which AI coding agent
+- **Steps to reproduce** — the actual prompt or command, not a description of it
+- **Expected vs. actual** — with the exact error text
+- **Diagnostics** — output of `nexpath status`, plus `nexpath log` for advisory or popup issues.
+  Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
 
-`nexpath status` dumps your full config and `nexpath log` may include your own prompts — read
+⚠️ `nexpath status` dumps your full config and `nexpath log` may include your own prompts — read
 both before pasting them publicly and redact anything private.
 
-## Before Contributing
+## Before You Start
 
-All contributions must begin with a GitHub Issue, unless the change is a small bug fix, a typo
-correction, a minor wording improvement, or a type-only fix that doesn't change functionality.
+- All contributions begin with a GitHub Issue — except typos, small bug fixes, minor wording
+  changes, and type-only fixes.
+- For features, check [Issues](https://github.com/hi0001234d/nexpath/issues) and Discussions for
+  similar ideas first.
+- If your idea is new, open an issue with the problem, your approach, and why it belongs in
+  Nexpath.
+- Wait for maintainer approval before implementing. **PRs without approved issues may be
+  closed** — Nexpath's pipeline has interlocking gates, and a local-looking change can move
+  behaviour three stages downstream.
 
-For features and larger contributions:
-
-- Check [existing issues](https://github.com/hi0001234d/nexpath/issues) and Discussions for
-  similar ideas
-- If your idea is new, open an issue describing the problem, your proposed approach, and why it
-  belongs in Nexpath
-- Wait for approval from core maintainers before starting implementation
-
-**PRs without approved issues may be closed.** Nexpath's pipeline has a lot of interlocking
-gates, and a change that looks local can move behaviour three stages downstream.
-
-Looking for a first contribution? Start with
+New contributors: start with
 [`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
 [`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted). Beyond the tracker,
 these areas need help most:
 
 - **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
-  Code is certified end-to-end today; the README's support table lists the rest. Install Nexpath
-  against another agent, run real prompts through it, and report exactly what happened.
-- **Cross-platform verification** — Nexpath touches OS-level credential storage and writes local
-  state, so it breaks in platform-specific ways. Windows reports are especially useful.
+  Code is certified today; the README's support table lists the rest. Install Nexpath against
+  another agent, run real prompts through it, and report exactly what happened.
+- **Cross-platform verification** — Nexpath touches OS credential storage and writes local state,
+  so it breaks in platform-specific ways. Windows reports are especially useful.
 - **Pipeline correctness** — `src/prompt-enhancement/` and `src/decision-session/` carry most of
   the product behaviour and most of the test suite.
 
 ## Development Setup
 
-- **Node.js 18+** — development is done on Node 20+; Node 22 is known to work
+Requirements:
+
+- **Node.js 18+** — development happens on Node 20+; Node 22 is known to work
 - **npm 9+** — ships with Node 18 and newer
 - **git**
 
-Nothing else is required for the core CLI. TypeScript, `tsx`, and `vitest` all come from
+Nothing else is needed for the core CLI — TypeScript, `tsx`, and `vitest` come from
 `devDependencies`.
 
 Install steps are in the
-[README](README.md#add-nexpath-to-your-development-workflow--installation). Clone **your fork**
-rather than the canonical repo, and add the original as `upstream` so you can rebase against it
-later:
+[README](README.md#add-nexpath-to-your-development-workflow--installation). Clone **your fork**, not
+the canonical repo, and add the original as `upstream` so you can rebase later:
 
 ```bash
 git remote add upstream https://github.com/hi0001234d/nexpath.git
@@ -90,178 +84,145 @@ npm install
 
 ## Common Checks
 
-**Read this section before you open a PR.** Nexpath does **not** run tests on pull requests —
-the two GitHub Actions workflows only fire on release tags, so **your local run is the only gate
-that exists.**
-
-From the repo root:
+**Read this before you open a PR.** Nexpath does **not** run tests on pull requests — the GitHub
+Actions workflows only fire on release tags, so **your local run is the only gate that exists.**
 
 ```bash
-npm run build
-npm run typecheck
-npm test
+npm run build          # includes the prebuild gates
+npm run typecheck      # core CLI + server
+npm test               # vitest run, whole tree
+npm run pe:leak-guard  # read-only confidentiality scan
 ```
 
-### Build
+**Build** — `prebuild` runs `scripts/check-build-gate.ts` and aborts on two hard gates:
 
-`npm run build` is not just `tsc`. The `prebuild` step runs `scripts/check-build-gate.ts`, which
-aborts the build on two hard gates:
+- **Content-template gate** — every shipped record must be schema-valid and have a level-1 floor.
+- **Selectability gate** — every prompt-enhancement intent must be reachable by a realistic prompt
+  through the production router.
+- If the build aborts on a template you touched, fix the record — do not bypass the gate.
 
-- **Content-template gate** — every shipped record must be schema-valid and must have a level-1
-  floor. A record missing its floor fails the build.
-- **Selectability gate** — every prompt-enhancement intent must be reachable by a realistic
-  prompt through the production router. An intent no prompt can reach is a dead template.
+**Typecheck** — both commands must produce no output:
 
-If you added or edited a content template and the build aborts, fix the record — do not bypass
-the gate.
+- `npm run typecheck` covers the core CLI and server.
+- `npm run typecheck:ext` covers `src/ext-browser/` (excluded from the root `tsconfig.json`) —
+  mandatory if you touched that directory.
 
-### Typecheck
+**Tests** — `npm test` takes a minute or two:
 
-```bash
-npm run typecheck        # core CLI + server
-npm run typecheck:ext    # browser extension (tsconfig.ext-browser.json)
-```
+- On a clean public clone it exits **1**: two files read planning documents from a private submodule
+  and fail with `ENOENT` for reasons unrelated to your change —
+  `src/prompt-enhancement/dev-plan-table-integrity.test.ts` and
+  `src/prompt-enhancement/hv1-env-supply.test.ts`.
+- **These two are the only accepted failures.** Exclude exactly those for a clean signal:
 
-Both must produce no output. The root `tsconfig.json` deliberately excludes `src/ext-vscode` and
-`src/ext-browser`, so if you touched `src/ext-browser/`, the second command is mandatory.
+  ```bash
+  npx vitest run \
+    --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
+    --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
+    --exclude "**/node_modules/**" \
+    --exclude "src/ext-vscode/**"
+  ```
 
-### Tests
+- On an unmodified `main` that run reports zero failures. Never add files to the exclude list to
+  make a run go green.
 
-`npm test` runs `vitest run` across the whole tree. It takes a minute or two.
+**Leak guard** — `npm run pe:leak-guard` fails on confidentiality leak tokens (internal names,
+phase codes, private paths) in public-going prompt-enhancement files:
 
-On a clean public clone it exits **1**, because two test files read planning documents from a
-private submodule and fail with `ENOENT` for reasons unrelated to your change:
+- It is not clean on `main` today; those findings are known and tracked.
+- Run it before and after your change and confirm your diff **adds no new findings**.
 
-- `src/prompt-enhancement/dev-plan-table-integrity.test.ts`
-- `src/prompt-enhancement/hv1-env-supply.test.ts`
-
-**These two are the only accepted failures.** To get a clean signal, exclude exactly those two:
-
-```bash
-npx vitest run \
-  --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
-  --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
-  --exclude "**/node_modules/**" \
-  --exclude "src/ext-vscode/**"
-```
-
-On an unmodified `main`, that run reports zero failures. Every remaining file must pass — do not
-add files to the exclude list to make a run go green.
-
-### Leak guard
-
-`npm run pe:leak-guard` is a read-only scan that fails if any public-going prompt-enhancement
-file contains a confidentiality leak token (internal names, internal phase codes, private
-paths).
-
-It does not come back clean on `main` today; those findings are known and tracked. Run it before
-and after your change and confirm your diff **adds no new findings**.
-
-### Sub-package checks
-
-`src/ext-vscode/` is excluded from the root typecheck, build, **and** test run
-(`vitest.config.ts`) — it's a separate npm package with a native dependency not installed at the
-root:
+**Sub-packages** — `src/ext-vscode/` is excluded from the root build, typecheck, and test run; it
+is a separate npm package with a native dependency:
 
 ```bash
 cd src/ext-vscode
-npm install
-npm run typecheck
-npm run test
-npm run build
+npm install && npm run typecheck && npm run test && npm run build
 ```
 
-`src/ext-browser/` is different: its tests **do** run in the root suite, but its types do not —
-that's what `npm run typecheck:ext` is for. To build it: `npm run build:ext`.
+`src/ext-browser/` is different — its tests run in the root suite, its types do not. Build it with
+`npm run build:ext`.
 
 ## Writing and Submitting Code
 
-1. **Keep Pull Requests Focused**
+1. **Keep pull requests focused**
 
-   - Limit PRs to a single feature or bug fix
-   - Split larger changes into smaller, related PRs
-   - Break changes into logical commits that can be reviewed independently
+    - One feature or bug fix per PR; split larger work into related PRs
+    - Break changes into logical commits that can be reviewed independently
 
-2. **Code Quality**
+2. **Code quality**
 
-   - This project is `NodeNext` ESM (`"type": "module"`), so relative imports need the `.js`
-     extension even though the source is TypeScript — `import { thing } from './thing.js'`, not
-     `'./thing'`. This is the single most common thing that breaks a first build.
-   - `strict` is on. Reach for precise types and avoid `any`.
-   - Strip stray `console.log` calls before you push
-   - Never commit secrets, API keys, real home paths, personal names, or internal planning
-     terminology
+    - This project is `NodeNext` ESM (`"type": "module"`), so relative imports need the `.js`
+      extension even in TypeScript — `import { thing } from './thing.js'`. This is the single most
+      common thing that breaks a first build.
+    - `strict` is on — use precise types, avoid `any`
+    - Strip stray `console.log` calls before you push
+    - Never commit secrets, API keys, real home paths, personal names, or internal planning
+      terminology
 
 3. **Testing**
 
-   - Add tests for new features — cover the behaviour, not just the happy path
-   - For a bug fix, add a test that **fails before your fix and passes after it**, and say so in
-     the PR
-   - If your change alters existing behaviour, update the affected tests and explain in the PR
-     why the old assertion was wrong
-   - New content templates must satisfy both build gates and be reachable by a realistic prompt
-   - `src/readme.test.ts` asserts what the README must contain — run it if you edit the README
-   - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree
-   - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so running
-     tests never touches your real install. Manual CLI runs **do**.
+    - Add tests for new features — cover the behaviour, not just the happy path
+    - For a bug fix, add a test that **fails before your fix and passes after it**
+    - If you change existing behaviour, update the affected tests and explain why the old assertion
+      was wrong
+    - New content templates must satisfy both build gates and be reachable by a realistic prompt
+    - `src/readme.test.ts` asserts what the README must contain — run it if you edit the README
+    - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree
+    - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so tests never
+      touch your real install. Manual CLI runs **do**.
 
-4. **Commits and PR Titles**
+4. **Commits and PR titles**
 
-   - Use conventional commit format with an optional scope naming the subsystem:
-     `feat(agents): detect Cursor installations on Windows`,
-     `fix(pe): lower the PE/MPS-1 popup cooldown default`, `docs: clarify the known-failing tests`
-   - Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`
-   - Reference relevant issues using `#issue-number`
+    - Use conventional commits with an optional subsystem scope:
+      `feat(agents): detect Cursor installations on Windows`,
+      `fix(pe): lower the PE/MPS-1 popup cooldown default`
+    - Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`
+    - Reference issues with `#issue-number`
 
-5. **Before Submitting**
+5. **Testing evidence** — required on every PR marked ready for review
 
-   - Rebase your branch on the latest `upstream/main`
-   - Run everything in [Common Checks](#common-checks) — nothing will run it for you afterwards
-   - Review your changes for debugging code or leftover logs
-   - Describe in the PR what your changes do, why, how you verified them, and any breaking
-     changes. Add screenshots or a short recording for CLI or popup UI changes.
-   - Link the issue with `Fixes #123` or `Closes #123`, and open the PR against `main` on
-     [`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath)
+    - Paste the **actual output** of the [Common Checks](#common-checks) — at minimum build,
+      typecheck, tests, and the leak-guard comparison against `main`
+    - For a bug fix, include the failing-then-passing test name
+    - `Not tested`, `N/A`, and "the tests should pass" are not sufficient
+    - If a command is blocked, state the command, the blocker, and the substitute verification you
+      ran instead
+    - Draft PRs may be incomplete until marked ready for review
 
-## Testing Evidence
+6. **AI assistance and ownership**
 
-Every PR marked ready for review must include testing evidence. A bare `Not tested` or `N/A` is
-not sufficient, and neither is "the tests should pass."
+    - AI coding agents are allowed — Nexpath is built for people who use them and developed with
+      them
+    - Before requesting review, make sure you understand the change, have tested it, and can explain
+      the diff
+    - Maintainers may close PRs without credible contributor ownership, including AI-assisted work
+      the contributor cannot explain
+    - Please don't submit batches of agent-generated or untested PRs, or mass-create issues through
+      automation
 
-Paste the actual output of the commands in [Common Checks](#common-checks) — at minimum the
-build, the typecheck, the test run, and the leak-guard comparison against `main`. For a bug fix,
-include the failing-then-passing test name.
+7. **Before submitting**
 
-If you cannot complete a relevant command, include all three of the following in the PR:
-
-- The command you attempted or would normally run
-- The blocker or failure that prevented completion
-- The substitute verification you performed instead
-
-Draft PRs may be incomplete until they are marked ready for review.
-
-## AI Assistance and Ownership
-
-AI coding agents are allowed — Nexpath is built for people who use them, and this repo is
-developed with them. But contributors own the work they submit: before requesting review, make
-sure you personally understand the change, have tested it, and can explain the diff.
-
-Maintainers may close PRs that appear to be submitted without credible contributor ownership,
-including AI-assisted work the contributor cannot explain. Please don't submit batches of
-agent-generated or untested PRs, or mass-create issues through automation.
+    - Rebase on the latest `upstream/main`
+    - Run everything in [Common Checks](#common-checks) — nothing will run it for you afterwards
+    - Review your diff for debugging code and leftover logs
+    - Describe what the change does, why, how you verified it, and any breaking changes. Add
+      screenshots or a short recording for CLI or popup UI changes.
+    - Link the issue with `Fixes #123`, and open the PR against `main` on
+      [`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath)
 
 ## Questions
 
 **If anything here is unclear, ask — that is not a bother, it is the point.**
 
-- **[GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions)** — open-ended
-  questions, design conversations, and feedback on installing or using Nexpath
-- **[GitHub Issues](https://github.com/hi0001234d/nexpath/issues)** — concrete bugs and specific
-  feature proposals
-- **On a PR** — if you get stuck mid-implementation, open a draft PR and ask there
+- **[Discussions](https://github.com/hi0001234d/nexpath/discussions)** — open-ended questions,
+  design conversations, feedback on installing or using Nexpath
+- **[Issues](https://github.com/hi0001234d/nexpath/issues)** — concrete bugs and specific feature
+  proposals
+- **On a draft PR** — if you get stuck mid-implementation
 
-You do not need to have a fix ready to start a conversation. If the install broke or a section
-of the README confused you, tell us — that is signal we cannot get any other way.
+You don't need a fix ready to start a conversation. If the install broke or a section of the README
+confused you, tell us — that is signal we cannot get any other way.
 
 ## Contribution Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,409 @@
+# Contributing to Nexpath
+
+We're glad you're here. Whether you're fixing a bug, certifying a new agent, or improving the
+docs, every contribution makes Nexpath more trustworthy.
+
+If you are new to the project, read the [README](README.md) first — it covers what Nexpath does,
+how to install it, and how it handles your data. This guide covers only what you need in order
+to *change* it.
+
+## TL;DR
+
+There are lots of ways to contribute:
+
+- **Code Contributions:** Fix bugs, improve the pipeline, add agent support
+- **End-to-End Agent Testing:** Verify Nexpath against agents we have not certified yet
+- **Documentation:** Improve the README, this guide, or the CLI help text
+- **Bug Reports:** Report issues you encounter
+- **Feature Requests:** Suggest new features or improvements
+- **Community Support:** Help other users in the community
+
+The Nexpath community is in
+[GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions).
+
+One thing sets the tone for everything below: Nexpath exists to stop unverified work from
+shipping, so we hold contributions to the same bar. **Verify before you open a PR.**
+
+---
+
+## Reporting Bugs or Issues
+
+Bug reports make Nexpath better for everyone. Before creating a new issue, please
+[search existing ones](https://github.com/hi0001234d/nexpath/issues) to avoid duplicates. When
+you're ready, head to the [issues page](https://github.com/hi0001234d/nexpath/issues/new/choose).
+
+> 🔐 **Important:** If you discover a security vulnerability, please use the
+> [GitHub security tool to report it privately](https://github.com/hi0001234d/nexpath/security/advisories/new)
+> instead of opening a public issue.
+
+A great bug report contains:
+
+- **A quick summary** and the background of what you were doing
+- **Your environment** — OS and version, Node version, Nexpath version, and which AI coding
+  agent you were using
+- **Steps to reproduce** — be specific, and give the actual prompt or command if you can
+- **What you expected** to happen
+- **What actually happened** — exact error text, not a paraphrase
+- **Diagnostics** — the output of `nexpath status`, and `nexpath log` if the issue is about
+  advisory or popup behaviour. Re-run with `NEXPATH_DEBUG=1` for verbose stderr.
+- **Notes** — why you think it might be happening, and what you already tried
+
+**Before pasting diagnostics, read them.** `nexpath status` prints a full config dump and
+`nexpath log` prints recent pipeline activity, which may include your own prompts. Nexpath's
+redaction covers common secret formats, but that is not a guarantee for everything in a config
+dump — redact anything private before posting it publicly.
+
+---
+
+## Before Contributing
+
+All contributions must begin with a GitHub Issue, unless the change is a small bug fix, a typo
+correction, a minor wording improvement, or a type-only fix that doesn't change functionality.
+
+**For features and larger contributions:**
+
+- First check [existing issues](https://github.com/hi0001234d/nexpath/issues) and
+  [Discussions](https://github.com/hi0001234d/nexpath/discussions) for similar ideas
+- If your idea is new, open an issue describing the problem, your proposed approach, and why it
+  belongs in Nexpath
+- Wait for approval from core maintainers before starting implementation
+- Once approved, feel free to begin working on a PR
+
+**PRs without approved issues may be closed.**
+
+This is not bureaucracy — Nexpath's pipeline has a lot of interlocking gates, and a change that
+looks local can move behaviour three stages downstream. A short conversation up front saves you
+from rewriting work that was never going to land.
+
+---
+
+## Deciding What to Work On
+
+Looking for a good first contribution? Check out issues labeled
+[`good first issue`](https://github.com/hi0001234d/nexpath/labels/good%20first%20issue) or
+[`help wanted`](https://github.com/hi0001234d/nexpath/labels/help%20wanted). These are curated
+for new contributors and areas where we'd love some help.
+
+Beyond the issue tracker, these are the areas where contribution is most useful right now:
+
+1. **End-to-end agent testing** — highest value, no deep codebase knowledge needed. Only Claude
+   Code is certified end-to-end today; the README's support table lists the rest. Certifying
+   another agent means installing Nexpath against it, running real prompts through it, and
+   reporting exactly what happened. Unlike the unit suite this cannot be automated — it needs a
+   real agent, a real OS, and a real person watching.
+
+2. **Cross-platform verification** — Nexpath touches OS-level credential storage and writes
+   local state, so it breaks in platform-specific ways. Reports from Windows are especially
+   useful, since that is where we have the least coverage.
+
+3. **Pipeline correctness** — the prompt-enhancement pipeline (`src/prompt-enhancement/`) and
+   the decision-session layer (`src/decision-session/`) carry most of the product behaviour and
+   most of the test suite.
+
+---
+
+## Prerequisites
+
+- **Node.js 18+** — required for all packages. Development is done on Node 20+; Node 22 is known
+  to work. Declared as `"engines": { "node": ">=18" }`.
+- **npm 9+** — ships with Node 18 and newer.
+- **git**
+
+Nothing else is required for the core CLI. TypeScript, `tsx`, and `vitest` all come from
+`devDependencies`.
+
+Install steps are in the
+[README](README.md#add-nexpath-to-your-development-workflow--installation). Clone **your fork**
+rather than the canonical repo, and add the original as `upstream` so you can rebase against it
+later:
+
+```bash
+git remote add upstream https://github.com/hi0001234d/nexpath.git
+```
+
+---
+
+## Common Checks
+
+**Read this section before you open a PR.**
+
+Nexpath does **not** run tests on pull requests. The two GitHub Actions workflows
+(`publish-extension.yml`, `publish-ext-browser.yml`) only fire on release tags — they are
+publish pipelines, not CI. **Your local run is the only gate that exists.**
+
+From the repo root:
+
+```bash
+npm run build
+npm run typecheck
+npm test
+```
+
+### Build
+
+`npm run build` is not just `tsc`. The `prebuild` step runs `scripts/check-build-gate.ts`, which
+enforces two hard gates over the shipped content-template registry and aborts the build on
+failure:
+
+```
+✓ content-template build gate passed (144 records, all floored + schema-valid)
+✓ prompt-enhancement selectability gate passed (every intent routes from its proposal - no absorb, no skip)
+```
+
+- **Content-template gate** — every shipped record must be schema-valid and must have a level-1
+  floor. A record missing its floor fails the build.
+- **Selectability gate** — every prompt-enhancement intent must be reachable by a realistic
+  prompt through the production router. An intent no prompt can reach is a dead template, and
+  the build refuses to ship it.
+
+If you added or edited a content template and the build aborts, fix the record — do not bypass
+the gate.
+
+### Typecheck
+
+```bash
+npm run typecheck        # core CLI + server
+npm run typecheck:ext    # browser extension (tsconfig.ext-browser.json)
+```
+
+Both must produce no output. The root `tsconfig.json` deliberately excludes `src/ext-vscode` and
+`src/ext-browser`, so `npm run typecheck` alone does **not** cover the browser extension. If you
+touched `src/ext-browser/`, the second command is mandatory.
+
+### Tests
+
+`npm test` runs `vitest run` across the whole tree: **352 test files, 9386 tests**, in roughly
+70–90 seconds.
+
+**Known failures on a public clone — read this.** On a clean clone, `npm test` exits **1** with 8
+failures across 2 files:
+
+- `src/prompt-enhancement/dev-plan-table-integrity.test.ts`
+- `src/prompt-enhancement/hv1-env-supply.test.ts`
+
+Both read planning documents from a private submodule that is **not part of the public
+repository**, so they fail with `ENOENT` for reasons unrelated to your change.
+
+**These two files are the only accepted failures.** To get a clean signal, exclude exactly those
+two and nothing else:
+
+```bash
+npx vitest run \
+  --exclude "src/prompt-enhancement/dev-plan-table-integrity.test.ts" \
+  --exclude "src/prompt-enhancement/hv1-env-supply.test.ts" \
+  --exclude "**/node_modules/**" \
+  --exclude "src/ext-vscode/**"
+```
+
+Expected on an unmodified `main`:
+
+```
+ Test Files  350 passed (350)
+      Tests  9337 passed | 1 todo (9338)
+```
+
+**All 350 must pass.** If any file other than the two named above fails, your change broke
+something. Do not add files to the exclude list to make a run go green — that is exactly the
+kind of unverified shipping Nexpath exists to prevent.
+
+### Leak guard
+
+`npm run pe:leak-guard` is a read-only scan that fails if any public-going prompt-enhancement
+file contains a confidentiality leak token (internal names, internal phase codes, private
+paths). It performs no git history rewrite and no push.
+
+**Current status:** on `main` today it reports **8 pre-existing findings** (a teammate name left
+in `src/prompt-enhancement/`). This is known and tracked, and is **not caused by your change.**
+Run it before and after your change and confirm your diff **adds no new findings**. If the count
+grows, the new entries are yours.
+
+### Sub-package checks
+
+`src/ext-vscode/` is excluded from the root typecheck, the root build, **and** the root test run
+(`vitest.config.ts`) — it's a separate npm package with a native dependency not installed at the
+root. The root gate does not cover it:
+
+```bash
+cd src/ext-vscode
+npm install
+npm run typecheck
+npm run test
+npm run build
+```
+
+`src/ext-browser/` is different: its tests **do** run in the root suite, but its types do not —
+that's what `npm run typecheck:ext` is for. To build it: `npm run build:ext`.
+
+---
+
+## Writing and Submitting Code
+
+Anyone can contribute code to Nexpath, but we ask that you follow these guidelines so your
+contributions can be smoothly integrated:
+
+1. **Keep Pull Requests Focused**
+
+   - Limit PRs to a single feature or bug fix
+   - Split larger changes into smaller, related PRs
+   - Break changes into logical commits that can be reviewed independently
+
+2. **Code Quality**
+
+   - This project is `NodeNext` ESM (`"type": "module"`), so relative imports need the `.js`
+     extension even though the source is TypeScript — `import { thing } from './thing.js'`, not
+     `'./thing'`. This is the single most common thing that breaks a first build.
+   - `strict` is on. Reach for precise types and avoid `any`.
+   - Strip stray `console.log` calls before you push
+   - Never commit secrets, API keys, real home paths, personal names, or internal planning
+     terminology
+
+3. **Testing**
+
+   - Add tests for new features — cover the behaviour, not just the happy path
+   - For a bug fix, add a test that **fails before your fix and passes after it**, and say so in
+     the PR
+   - If your change alters existing behaviour, update the affected tests and explain in the PR
+     why the old assertion was wrong. Do not silently delete an assertion to make a run go green.
+   - New content templates must satisfy both build gates (schema + level-1 floor) and be
+     reachable by a realistic prompt, or the build will reject them
+   - `src/readme.test.ts` asserts what the README must contain and must not leak — run it if you
+     edit the README
+   - Place tests next to the code as `<module>.test.ts`; there is no separate `test/` tree. The
+     existing suite is unusually explicit about what each test proves — matching that style makes
+     review much faster.
+   - The suite redirects the Nexpath home to a temp directory (`vitest.setup.ts`), so running
+     tests never touches your real install. Manual CLI runs **do**.
+
+4. **Run the Checks**
+
+   - Run everything in [Common Checks](#common-checks) before you push
+   - All checks must pass locally, because nothing will run them for you afterwards
+
+5. **Commit Guidelines**
+
+   - Write clear, descriptive commit messages
+   - Use conventional commit format (e.g. `feat:`, `fix:`, `docs:`)
+   - Reference relevant issues using `#issue-number`
+
+6. **Before Submitting**
+
+   - Rebase your branch on the latest `upstream/main`
+   - Ensure your branch builds successfully
+   - Double-check the test run against the expected counts above
+   - Review your changes for any debugging code or leftover logs
+
+7. **Pull Request Description**
+
+   - Clearly describe what your changes do and why
+   - Include how you verified them
+   - List any breaking changes
+   - Add screenshots for CLI or popup UI changes
+
+---
+
+## Pull Request Expectations
+
+Contributor guidance exists to protect maintainer review time and keep reviews focused on work
+that is ready to evaluate.
+
+- **UI Changes:** Include screenshots or a short recording (before/after)
+- **Logic Changes:** Explain how you verified it works
+
+Link the issue with `Fixes #123` or `Closes #123`, and open the PR against `main` on
+[`hi0001234d/nexpath`](https://github.com/hi0001234d/nexpath).
+
+### Testing Evidence
+
+Every PR marked ready for review must include testing evidence. A bare `Not tested` or `N/A` is
+not sufficient, and neither is "the tests should pass."
+
+Paste the actual output of the commands in [Common Checks](#common-checks) — at minimum the
+build, the typecheck, the test run with its file and test counts, and the leak-guard comparison
+against `main`. For a bug fix, include the failing-then-passing test name.
+
+If you cannot complete a relevant command, include all three of the following in the PR:
+
+- The command you attempted or would normally run
+- The blocker or failure that prevented completion
+- The substitute verification you performed instead
+
+Agent limitations, local resource constraints, or an agent prompt that says to skip tests do not
+waive this requirement — they just change what you write down. Draft PRs may be incomplete until
+they are marked ready for review.
+
+### Contribution Ownership and AI Assistance
+
+AI coding agents are allowed — Nexpath is built for people who use them, and this repo is
+developed with them. But contributors own the work they submit.
+
+Before requesting review, make sure you personally understand the change, have tested it
+appropriately, can explain the diff, and understand how it interacts with the rest of the
+pipeline.
+
+Maintainers may close PRs that appear to be submitted without credible contributor ownership or
+understanding, including AI-assisted work the contributor cannot explain or has not meaningfully
+reviewed.
+
+### Tracker Use and Automation
+
+Do not submit batches of agent-generated, untested, or weakly reviewed PRs. Prioritize
+high-impact issues instead of opening many speculative fixes.
+
+For issues, do not mass-create tickets through automation. Search existing issues first, open
+issues only when you have enough context for someone to act, and prioritize the most important
+reports instead of filing every possible finding.
+
+### Issue and PR Lifecycle
+
+To keep the backlog manageable, inactive issues and PRs may be closed after a period of
+inactivity. This isn't a judgment on quality — older items lose context over time. Feel free to
+reopen or create a new issue or PR if you're still working on something.
+
+Please respond to review comments rather than force-pushing silently over them.
+
+---
+
+## PR Titles
+
+Use conventional commit style PR titles, with an optional scope naming the subsystem:
+
+- `feat(agents): detect Cursor installations on Windows`
+- `fix(pe): lower the PE/MPS-1 popup cooldown default`
+- `docs: clarify the known-failing test files`
+- `chore: bump TypeScript to 5.8`
+- `refactor(store): extract the prune path`
+- `test(pe-host): cover the display-decision pre-spawn gate`
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
+
+---
+
+## Questions
+
+**If anything here is unclear, ask — that is not a bother, it is the point.**
+
+- **[GitHub Discussions](https://github.com/hi0001234d/nexpath/discussions)** — open-ended
+  questions, design conversations, "is this a bug or am I holding it wrong?", and feedback on
+  your experience installing or using Nexpath. There is a feedback template set up for this.
+- **[GitHub Issues](https://github.com/hi0001234d/nexpath/issues)** — concrete bugs and specific
+  feature proposals.
+- **On a PR** — if you get stuck mid-implementation, open a draft PR and ask there. Showing the
+  code you are stuck on gets a much better answer than describing it.
+
+You do not need to have a fix ready to start a conversation. If you tried Nexpath and could not
+tell what it does, or the install broke, or a section of the README confused you — tell us. That
+is signal we cannot get any other way, and it is a real contribution.
+
+New to pull requests? [makeapullrequest.com](https://makeapullrequest.com/) and
+[firsttimersonly.com](https://www.firsttimersonly.com/) are good primers.
+
+---
+
+## Contribution Agreement
+
+By submitting a pull request, you agree that your contributions will be licensed under the same
+license as the project ([Apache 2.0](LICENSE)).
+
+Contributing to Nexpath isn't just about writing code — it's about being part of a community
+trying to make AI-assisted development something you can actually ship with confidence. Let's
+build something reliable together.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Use `nexpath config show-key-source` to confirm which layer is currently active.
 
 ## Contributing
 
-Contribution guide coming once the initial implementation is stable.
+[Contribution guide](CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
# Add and Refine Contributor Guide

## Overview

This PR adds a contributor guide to the project and refines it to keep the documentation focused, practical, and easy to scan.

## What’s Included

* Added `CONTRIBUTING.md` with project-specific contribution guidelines.
* Documented the important checks contributors should run before submitting changes.
* Added guidance around pull requests, testing, and AI-assisted contributions.
* Simplified the guide by removing information already covered in the README.
* Restructured the sections into shorter, bullet-driven content.
* Cleaned up outdated or unnecessary references and sample counts.
* Updated links so they work correctly from forks as well as the upstream repository.
* Added a link from the README to the rendered contributing guide.

## Verification

The contributing guide has been reviewed and the documented commands and links have been checked against the current repository setup.

Please review the changes and merge this PR into `main` if everything looks good.
