### PR TITLE
  docs(ext-vscode): surface the demo video in the listing intro — release 0.1.35

### DIFF
--- a/src/ext-vscode/CHANGELOG.md
+++ b/src/ext-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.35 — 2026-08-26
+
+- Listing: the demo video is now linked at the top, next to what NexPath supports.
+
 ## 0.1.34 — 2026-08-25
 
 - Popup selections now deliver within seconds in every case on Windows — a rare condition

--- a/src/ext-vscode/README.md
+++ b/src/ext-vscode/README.md
@@ -7,6 +7,8 @@ engineering layer for AI-powered development: it catches your prompt **at the mo
 submit it**, offers a sharper version with your intent preserved, and sends the version
 you choose — keeping your AI coding workflow disciplined without breaking flow.
 
+**Demo:** [Prompt Enhancement in action, on YouTube](https://youtu.be/pNejtPA5DPU)
+
 **Built for:** Cursor · Windsurf (Devin) — fully supported & end-to-end tested.
 
 ![NexPath prompt enhancement](https://raw.githubusercontent.com/hi0001234d/nexpath/main/src/ext-vscode/media/nexpath-demo.png)
@@ -85,8 +87,6 @@ Not a new tool to learn. A workflow step to adopt.
 - ✓ **No subscriptions** — bring your own API key
 
 **Result:** AI agents generate better code. Reviews go faster. Fewer production bugs.
-
-### Demo: [Prompt Enhancement in action, on YouTube](https://youtu.be/pNejtPA5DPU)
 
 ---
 

--- a/src/ext-vscode/package-lock.json
+++ b/src/ext-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexpath-vscode",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexpath-vscode",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12"

--- a/src/ext-vscode/package.json
+++ b/src/ext-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "nexpath-vscode",
   "displayName": "Nexpath",
   "description": "Strengthen your prompts and catch skipped checks before shipping. NexPath holds your prompt at submit, offers a sharper version with your intent preserved, and sends the one you choose — on Cursor and Windsurf (Devin).",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "publisher": "nexpath",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
## What changed

The demo-video link moved from the bottom of "What You Get" to the intro block, directly
before **Built for:** — so a marketplace visitor sees it with the pitch and the screenshot
instead of having to scroll past six sections. The old `### Demo:` heading is removed, so
that section now flows Result → Getting Started.

## Why the version bump

A published version's listing is immutable — the marketplace only re-renders README and
CHANGELOG on a **new** version. 0.1.34 is live on both registries, so this listing change
ships as **0.1.35**: `package.json` + **both** `package-lock.json` fields bumped together
(46789b5 convention, `npm ci` dry-run consistent) with a matching CHANGELOG entry.

No product code touched — README, CHANGELOG, package.json, package-lock.json only.
Ext suite re-run for safety: 1175/1175.

## Publish note

After merge, start a **NEW** workflow run (Actions → "Run workflow" → branch `main`).
Do **not** use "Re-run jobs" — a re-run replays its original commit, which is how Run #10
kept republishing 0.1.33 after the 0.1.34 bump had already landed on main.