### PR TITLE
Merge Browser Extension 0.1.52 Updates into Staging

### DIFF
--- a/src/cli/commands/config-apikey.test.ts
+++ b/src/cli/commands/config-apikey.test.ts
@@ -137,7 +137,12 @@ describe('configRotateApiKeyAction', () => {
 // ── configShowKeySourceAction ────────────────────────────────────────────────
 
 describe('configShowKeySourceAction', () => {
-  it.each(['env', 'dotenv', 'keychain', 'file', 'none'] as const)(
+  // 'nexpath_token' added when the client seam extended KeySource — this
+  // function only ever prints whatever getKeySource() returns (that is the
+  // whole reason no edit to this file's production code was needed for it),
+  // so the parametrised list is what proves show-key-source actually reports
+  // the new mode, not merely that the type-check compiles.
+  it.each(['env', 'dotenv', 'keychain', 'file', 'nexpath_token', 'none'] as const)(
     'prints the source returned by getKeySource: %s',
     async (source) => {
       vi.mocked(resolver.getKeySource).mockResolvedValueOnce(source);

--- a/src/cli/commands/token.test.ts
+++ b/src/cli/commands/token.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../config/NexpathTokenStore.js', () => ({
+  storeNexpathToken:   vi.fn(),
+  removeNexpathToken:  vi.fn(),
+  readNexpathToken:    vi.fn(),
+  isValidNexpathToken: (v: string) => typeof v === 'string' && v.startsWith('npk_') && v.length >= 40,
+  resolveApiBaseUrl:   vi.fn(() => 'http://localhost:8000/v1'),
+}));
+
+import { configSetTokenAction, configRemoveTokenAction, modeBDisclosureLine } from './token.js';
+import * as tokenStore from '../../config/NexpathTokenStore.js';
+
+function captureOutput(): { lines: string[]; print: (line: string) => void } {
+  const lines: string[] = [];
+  return { lines, print: (l) => lines.push(l) };
+}
+
+const VALID_TOKEN   = 'npk_' + 'a'.repeat(40);
+const INVALID_TOKEN = 'sk-not-a-token';
+
+beforeEach(() => {
+  vi.mocked(tokenStore.storeNexpathToken).mockReset().mockResolvedValue({ source: 'keychain' });
+  vi.mocked(tokenStore.removeNexpathToken).mockReset().mockResolvedValue(undefined);
+  vi.mocked(tokenStore.readNexpathToken).mockReset().mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── configSetTokenAction (FP-4.3: happy path, cancel, malformed) ────────────────
+
+describe('configSetTokenAction', () => {
+  it('happy path: prompts, stores the token, prints the source and the disclosure exactly once', async () => {
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => VALID_TOKEN });
+
+    expect(tokenStore.storeNexpathToken).toHaveBeenCalledWith(VALID_TOKEN);
+    expect(lines.join('\n')).toContain('Nexpath token stored in keychain');
+
+    const disclosureOccurrences = lines.filter((l) => l.includes('prompt context will be sent')).length;
+    expect(disclosureOccurrences).toBe(1);
+  });
+
+  it('reports file fallback when storeNexpathToken returns source="file"', async () => {
+    vi.mocked(tokenStore.storeNexpathToken).mockResolvedValueOnce({ source: 'file' });
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => VALID_TOKEN });
+    expect(lines.join('\n')).toContain('Nexpath token stored in file');
+  });
+
+  it('cancel: a null from passwordFn stores nothing', async () => {
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => null });
+
+    expect(tokenStore.storeNexpathToken).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('Cancelled');
+  });
+
+  it('an empty string from passwordFn is treated as a cancel', async () => {
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => '' });
+    expect(tokenStore.storeNexpathToken).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('Cancelled');
+  });
+
+  it('a malformed token propagates the store\'s rejection rather than being silently accepted', async () => {
+    vi.mocked(tokenStore.storeNexpathToken).mockRejectedValueOnce(new Error('Invalid Nexpath token format'));
+    await expect(
+      configSetTokenAction({ output: () => {}, passwordFn: async () => INVALID_TOKEN }),
+    ).rejects.toThrow(/Invalid Nexpath token/);
+  });
+
+  it('⛔ D-6: never claims "nothing leaves your machine" — it would be untrue in Mode B', async () => {
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => VALID_TOKEN });
+    const text = lines.join('\n').toLowerCase();
+    expect(text).not.toContain('nothing leaves your machine');
+  });
+
+  it('the disclosure names the actually-configured host, not a hardcoded string', async () => {
+    vi.mocked(tokenStore.resolveApiBaseUrl).mockReturnValueOnce('https://configured-for-this-test.example/v1');
+    const { lines, print } = captureOutput();
+    await configSetTokenAction({ output: print, passwordFn: async () => VALID_TOKEN });
+    expect(lines.join('\n')).toContain('https://configured-for-this-test.example/v1');
+  });
+});
+
+// ── configRemoveTokenAction ──────────────────────────────────────────────────────
+
+describe('configRemoveTokenAction', () => {
+  it('reports removal when a token was actually present', async () => {
+    vi.mocked(tokenStore.readNexpathToken).mockResolvedValueOnce(VALID_TOKEN);
+    const { lines, print } = captureOutput();
+    await configRemoveTokenAction({ output: print });
+
+    expect(tokenStore.removeNexpathToken).toHaveBeenCalled();
+    expect(lines.join('\n')).toContain('Nexpath token removed');
+  });
+
+  it('reports nothing-stored when there was no token, even if an OpenAI key exists elsewhere', async () => {
+    vi.mocked(tokenStore.readNexpathToken).mockResolvedValueOnce(null);
+    const { lines, print } = captureOutput();
+    await configRemoveTokenAction({ output: print });
+    expect(lines.join('\n')).toContain('No Nexpath token was stored');
+  });
+});
+
+// ── modeBDisclosureLine ────────────────────────────────────────────────────────
+
+describe('modeBDisclosureLine', () => {
+  it('states plainly that prompt context leaves the machine, and that no prompt text is stored', () => {
+    const line = modeBDisclosureLine().toLowerCase();
+    expect(line).toContain('prompt context will be sent');
+    expect(line).toContain('stores no prompt text');
+  });
+});

--- a/src/cli/commands/token.ts
+++ b/src/cli/commands/token.ts
@@ -1,0 +1,76 @@
+import { password, isCancel } from '@clack/prompts';
+import {
+  storeNexpathToken,
+  removeNexpathToken,
+  readNexpathToken,
+  isValidNexpathToken,
+  resolveApiBaseUrl,
+} from '../../config/NexpathTokenStore.js';
+
+// Mirrors config.ts's API-key command shape exactly.
+
+export type TokenPasswordFn = () => Promise<string | null>;
+
+const defaultTokenPasswordFn: TokenPasswordFn = async () => {
+  const input = await password({
+    message:  'Nexpath token:',
+    validate: (value) => {
+      if (!isValidNexpathToken(value)) return 'Invalid Nexpath token format (expected npk_...)';
+      return undefined;
+    },
+  });
+  if (isCancel(input)) return null;
+  return String(input);
+};
+
+export interface ConfigTokenOpts {
+  projectRoot?: string;
+  passwordFn?:  TokenPasswordFn;
+  output?:      (line: string) => void;
+}
+
+const defaultPrint = (line: string): void => { console.log(line); };
+
+// Mode B disclosure: a factual statement of what actually happens, not a
+// marketing line, and pending final wording approval from the project's public
+// docs. ⛔ Never claims "nothing leaves your machine": in Mode B, prompt
+// context genuinely does leave the machine, and saying otherwise would be
+// untrue. The host is read from whatever is actually configured
+// (resolveApiBaseUrl), not a hardcoded string, so the sentence is always
+// accurate to the real destination rather than a placeholder that could drift
+// from it.
+export function modeBDisclosureLine(): string {
+  const host = resolveApiBaseUrl();
+  return `With no OpenAI API key configured, prompt context will be sent to ${host} to be answered. This service stores no prompt text.`;
+}
+
+export async function configSetTokenAction(opts: ConfigTokenOpts = {}): Promise<void> {
+  const print      = opts.output     ?? defaultPrint;
+  const passwordFn = opts.passwordFn ?? defaultTokenPasswordFn;
+
+  const token = await passwordFn();
+  if (token === null || token === '') {
+    print('Cancelled — no Nexpath token stored.');
+    return;
+  }
+
+  const result = await storeNexpathToken(token);
+  print(`✓ Nexpath token stored in ${result.source}`);
+  print(modeBDisclosureLine());
+}
+
+export async function configRemoveTokenAction(opts: ConfigTokenOpts = {}): Promise<void> {
+  const print = opts.output ?? defaultPrint;
+
+  // ⚠️ Checked directly via readNexpathToken(), not getKeySource(): a token can
+  // be stored while shadowed by a higher-priority OpenAI key (env/dotenv/
+  // keychain/file), in which case getKeySource() would report that layer
+  // instead and this message would wrongly say "nothing was stored".
+  const hadToken = (await readNexpathToken()) !== null;
+  await removeNexpathToken();
+  if (hadToken) {
+    print('✓ Nexpath token removed.');
+  } else {
+    print('No Nexpath token was stored.');
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,6 +9,10 @@ import {
   configShowKeySourceAction,
   configRemoveApiKeyAction,
 } from './commands/config.js';
+import {
+  configSetTokenAction,
+  configRemoveTokenAction,
+} from './commands/token.js';
 import { runMigrations } from '../store/schema.js';
 import { logAction } from './commands/log.js';
 import { storeDeleteAction, storeEnableAction, storeDisableAction, storePruneAction } from './commands/store.js';
@@ -190,6 +194,20 @@ export function createProgram(): Command {
     .description('Remove the stored OpenAI API key from both the keychain and the fallback file')
     .action(async () => {
       await configRemoveApiKeyAction();
+    });
+
+  configCmd
+    .command('set-token')
+    .description('Prompt for a Nexpath token and store it securely (keychain → fallback file)')
+    .action(async () => {
+      await configSetTokenAction();
+    });
+
+  configCmd
+    .command('remove-token')
+    .description('Remove the stored Nexpath token from both the keychain and the fallback file')
+    .action(async () => {
+      await configRemoveTokenAction();
     });
 
   // ── Content-template authoring command ─────────────────────────────────────────

--- a/src/config/ApiKeyResolver.ts
+++ b/src/config/ApiKeyResolver.ts
@@ -3,13 +3,19 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { config as loadDotenv } from 'dotenv';
 import { getPassword, setPassword, deletePassword } from 'cross-keychain';
+import { readNexpathToken, resolveApiBaseUrl } from './NexpathTokenStore.js';
 
 export const KEYCHAIN_SERVICE = 'nexpath';
 export const KEYCHAIN_ACCOUNT = 'openai_api_key';
 export const FALLBACK_PATH    = join(homedir(), '.nexpath', 'config.json');
 export const API_KEY_REGEX    = /^sk-[A-Za-z0-9_-]{20,}$/;
 
-export type KeySource = 'env' | 'dotenv' | 'keychain' | 'file' | 'none';
+// The fifth and last resolution layer. `nexpath_token` means Mode B — no
+// OpenAI key anywhere, a Nexpath token stored instead. This is the single
+// place both env vars get set, so nothing that calls `resolveOpenAIKey` or
+// `getKeySource` — the only two entry points that reach an LLM call — needs
+// to change.
+export type KeySource = 'env' | 'dotenv' | 'keychain' | 'file' | 'nexpath_token' | 'none';
 
 export interface ResolveOptions {
   fallbackPath?: string;
@@ -43,6 +49,26 @@ export async function resolveOpenAIKey(projectRoot: string, opts: ResolveOptions
     return fileKey;
   }
 
+  // The fifth and last layer: only reached when none of the 4 above found an
+  // OpenAI key. The own-key-always-wins guarantee is structural here, not a
+  // separate check — every earlier layer already returned before this runs.
+  // No key + a stored token means the token takes over instead.
+  // ⚠️ fallbackPath must be forwarded — without it this silently reads the
+  // real home-directory file regardless of what the caller passed in, which
+  // would only ever surface as a bug in an isolated test or a custom-path
+  // caller, never in ordinary use where the two defaults happen to coincide.
+  const token = await readNexpathToken({ fallbackPath });
+  if (token) {
+    process.env.OPENAI_API_KEY = token;
+    // Never clobber a base URL the user configured themselves — e.g. pointed
+    // at their own proxy for testing. This only sets it when it is genuinely
+    // unset.
+    if (!process.env.OPENAI_BASE_URL) {
+      process.env.OPENAI_BASE_URL = resolveApiBaseUrl();
+    }
+    return token;
+  }
+
   return null;
 }
 
@@ -53,6 +79,7 @@ export async function getKeySource(projectRoot: string, opts: ResolveOptions = {
   if (tryProjectDotenv(projectRoot))       return 'dotenv';
   if (await tryKeychain())                 return 'keychain';
   if (await tryFallbackFile(fallbackPath)) return 'file';
+  if (await readNexpathToken({ fallbackPath })) return 'nexpath_token';
   return 'none';
 }
 

--- a/src/config/NexpathTokenStore.ts
+++ b/src/config/NexpathTokenStore.ts
@@ -1,0 +1,114 @@
+import { promises as fs } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { getPassword, setPassword, deletePassword } from 'cross-keychain';
+
+// Mirrors ApiKeyResolver.ts's own plumbing exactly (same keychain service, same
+// fallback file), but under a distinct account and JSON key, so an OpenAI key and
+// a Nexpath token can be stored side by side without colliding.
+export const KEYCHAIN_SERVICE = 'nexpath';
+export const KEYCHAIN_ACCOUNT = 'nexpath_token';
+export const FALLBACK_PATH    = join(homedir(), '.nexpath', 'config.json');
+
+// ⛔ A Nexpath token must never be checked against ApiKeyResolver's
+// API_KEY_REGEX (the `sk-` shape) — the two credential formats must never be
+// confused with each other, in either direction. Checked here and nowhere else.
+export const TOKEN_PREFIX     = 'npk_';
+export const TOKEN_MIN_LENGTH = 40; // "npk_" (4) + the server's 32-byte urlsafe body
+
+export interface TokenStoreOptions {
+  fallbackPath?: string;
+}
+
+export function isValidNexpathToken(value: string): boolean {
+  return typeof value === 'string'
+    && value.startsWith(TOKEN_PREFIX)
+    && value.length >= TOKEN_MIN_LENGTH
+    && !/\s/.test(value);
+}
+
+export async function storeNexpathToken(token: string, opts: TokenStoreOptions = {}): Promise<{ source: 'keychain' | 'file' }> {
+  if (!isValidNexpathToken(token)) {
+    throw new Error(`Invalid Nexpath token format (expected "${TOKEN_PREFIX}" + at least ${TOKEN_MIN_LENGTH - TOKEN_PREFIX.length} characters)`);
+  }
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  try {
+    await setPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, token);
+    return { source: 'keychain' };
+  } catch {
+    await writeFallbackToken(fallbackPath, token);
+    return { source: 'file' };
+  }
+}
+
+export async function readNexpathToken(opts: TokenStoreOptions = {}): Promise<string | null> {
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  try {
+    const token = await getPassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    if (token && isValidNexpathToken(token)) return token;
+  } catch {
+    /* fall through to the file */
+  }
+
+  try {
+    const raw    = await fs.readFile(fallbackPath, 'utf8');
+    const parsed = JSON.parse(raw) as { nexpath_token?: string };
+    const token  = parsed.nexpath_token;
+    if (token && isValidNexpathToken(token)) return token;
+  } catch {
+    /* no fallback file, or unreadable — treat as absent */
+  }
+
+  return null;
+}
+
+export async function removeNexpathToken(opts: TokenStoreOptions = {}): Promise<void> {
+  const fallbackPath = opts.fallbackPath ?? FALLBACK_PATH;
+
+  try { await deletePassword(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT); } catch { /* silent, mirrors removeApiKey */ }
+  try {
+    // The fallback file may also hold an OpenAI key under a different JSON key
+    // (ApiKeyResolver's own field), so remove only our own key rather than the
+    // whole file.
+    const raw = await fs.readFile(fallbackPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if ('nexpath_token' in parsed) {
+      delete parsed.nexpath_token;
+      await fs.writeFile(fallbackPath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
+    }
+  } catch {
+    /* no fallback file, or unreadable — nothing to remove */
+  }
+}
+
+async function writeFallbackToken(fallbackPath: string, token: string): Promise<void> {
+  await fs.mkdir(dirname(fallbackPath), { recursive: true });
+
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = JSON.parse(await fs.readFile(fallbackPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    /* no existing file, or unreadable — start fresh rather than clobber silently
+       something we can't parse; a corrupt file is surfaced by the write below
+       replacing it with a valid one holding just our own key. */
+  }
+
+  const payload = JSON.stringify({ ...existing, nexpath_token: token }, null, 2);
+  await fs.writeFile(fallbackPath, payload, { mode: 0o600 });
+  await fs.chmod(fallbackPath, 0o600);
+}
+
+// ── The API base the token is redeemed against ──────────────────────────────────
+//
+// ⚠️ The production domain does not exist yet. Rather than invent one, this is
+// an explicit, env-overridable value whose local-development default matches
+// the server's own default for local runs. Setting `NEXPATH_API_BASE_URL` once
+// a real domain exists is a one-line deploy change, not a client rewrite.
+export const DEFAULT_API_BASE_URL = 'http://localhost:8000/v1';
+
+export function resolveApiBaseUrl(): string {
+  const configured = process.env.NEXPATH_API_BASE_URL;
+  return configured && configured.trim() !== '' ? configured : DEFAULT_API_BASE_URL;
+}

--- a/src/config/api-key-resolver.mode.test.ts
+++ b/src/config/api-key-resolver.mode.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// FP-4.2 — the four-cell matrix (key only / token only / both / neither), the
+// "never clobber a pre-existing OPENAI_BASE_URL" guarantee, and the SDK contract
+// pin (RISK-16). This file is the proof that Mode A stays byte-identical: it
+// asserts exact process.env state, not behaviour inferred from a mock.
+
+vi.mock('cross-keychain', () => ({
+  getPassword:    vi.fn(),
+  setPassword:    vi.fn(),
+  deletePassword: vi.fn(),
+}));
+
+import { resolveOpenAIKey, getKeySource } from './ApiKeyResolver.js';
+import * as keychain from 'cross-keychain';
+
+const VALID_OPENAI_KEY = 'sk-abcdefghij1234567890ABCDEFGHIJ';
+const VALID_TOKEN      = 'npk_' + 'a'.repeat(40);
+
+let tmpDir:      string;
+let projectRoot: string;
+let fallbackPath: string;
+let savedEnv:    Record<string, string | undefined>;
+
+const ENV_KEYS = ['OPENAI_API_KEY', 'OPENAI_BASE_URL', 'NEXPATH_API_BASE_URL'] as const;
+
+beforeEach(() => {
+  tmpDir       = mkdtempSync(join(tmpdir(), 'nexpath-mode-matrix-'));
+  projectRoot  = join(tmpDir, 'project');
+  fallbackPath = join(tmpDir, 'config.json');
+  mkdirSync(projectRoot, { recursive: true });
+
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  vi.mocked(keychain.getPassword).mockReset();
+  vi.mocked(keychain.setPassword).mockReset();
+  vi.mocked(keychain.deletePassword).mockReset();
+  // No OpenAI key in the keychain by default in this file — every test that
+  // wants one puts it in the fallback file instead, so the two credential
+  // stores (openai_api_key vs nexpath_token) are exercised independently.
+  vi.mocked(keychain.getPassword).mockRejectedValue(new Error('empty keychain'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else                              process.env[key] = savedEnv[key];
+  }
+});
+
+function writeOpenAIKeyToFallback(): void {
+  writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_OPENAI_KEY }), 'utf8');
+}
+
+function writeTokenToFallback(): void {
+  writeFileSync(fallbackPath, JSON.stringify({ nexpath_token: VALID_TOKEN }), 'utf8');
+}
+
+function writeBothToFallback(): void {
+  writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: VALID_OPENAI_KEY, nexpath_token: VALID_TOKEN }), 'utf8');
+}
+
+// ── The four-cell matrix ──────────────────────────────────────────────────────
+
+describe('FP-4.2 mode matrix — resolveOpenAIKey (process.env side effects)', () => {
+  it('key only → Mode A: OPENAI_API_KEY set, OPENAI_BASE_URL untouched', async () => {
+    writeOpenAIKeyToFallback();
+
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it('token only → Mode B: both OPENAI_API_KEY and OPENAI_BASE_URL set', async () => {
+    writeTokenToFallback();
+
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBe(VALID_TOKEN);
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_TOKEN);
+    expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:8000/v1');
+  });
+
+  it('both present → L2/RISK-4: the own key wins, server not contacted, no OPENAI_BASE_URL written', async () => {
+    writeBothToFallback();
+
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it('neither present → today\'s behaviour untouched: no env var written', async () => {
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBeNull();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+});
+
+// ── The same matrix again through getKeySource, queried fresh — never chained
+// after resolveOpenAIKey in the same test, because resolveOpenAIKey's own
+// process.env side effect would then make every source read back as "env"
+// regardless of which layer actually produced it. This mirrors how the
+// existing getKeySource tests in ApiKeyResolver.test.ts are written. ────────
+
+describe('FP-4.2 mode matrix — getKeySource (queried fresh, independently)', () => {
+  it('key only → file', async () => {
+    writeOpenAIKeyToFallback();
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('file');
+  });
+
+  it('token only → nexpath_token', async () => {
+    writeTokenToFallback();
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('nexpath_token');
+  });
+
+  it('both present → file (the own key\'s layer, not the token)', async () => {
+    writeBothToFallback();
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('file');
+  });
+
+  it('neither present → none', async () => {
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('none');
+  });
+});
+
+// ── RISK-4: a user's own OPENAI_BASE_URL must never be clobbered ────────────────
+
+describe('a pre-existing OPENAI_BASE_URL is never clobbered', () => {
+  it('Mode B still sets OPENAI_API_KEY but leaves an existing OPENAI_BASE_URL exactly as the user set it', async () => {
+    process.env.OPENAI_BASE_URL = 'https://user-configured-proxy.example/v1';
+    writeTokenToFallback();
+
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+
+    expect(process.env.OPENAI_API_KEY).toBe(VALID_TOKEN);
+    expect(process.env.OPENAI_BASE_URL).toBe('https://user-configured-proxy.example/v1');
+  });
+
+  it('Mode A never touches OPENAI_BASE_URL even if the user has one set', async () => {
+    process.env.OPENAI_BASE_URL = 'https://user-configured-proxy.example/v1';
+    writeOpenAIKeyToFallback();
+
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+
+    expect(process.env.OPENAI_BASE_URL).toBe('https://user-configured-proxy.example/v1');
+  });
+});
+
+// ── L2: own key wins even when it arrives via a different layer than the token ──
+
+describe('own key wins regardless of which layer supplies it', () => {
+  it('env-var key beats a stored token', async () => {
+    process.env.OPENAI_API_KEY = VALID_OPENAI_KEY;
+    writeTokenToFallback();
+
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+    expect(await getKeySource(projectRoot, { fallbackPath })).toBe('env');
+  });
+
+  it('keychain key beats a stored token', async () => {
+    vi.mocked(keychain.getPassword).mockReset();
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_OPENAI_KEY);
+    writeTokenToFallback();
+
+    const resolved = await resolveOpenAIKey(projectRoot, { fallbackPath });
+    expect(resolved).toBe(VALID_OPENAI_KEY);
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+});
+
+// ── SDK contract pin (RISK-16) ────────────────────────────────────────────────
+//
+// The whole design rests on one fact about the installed `openai` package:
+// `new OpenAI()` with no explicit baseURL/apiKey reads OPENAI_BASE_URL and
+// OPENAI_API_KEY from the environment. If a future SDK upgrade ever drops that
+// default, this test fails loudly instead of Mode B silently calling the real
+// OpenAI API with a Nexpath token.
+
+describe('SDK contract pin (RISK-16)', () => {
+  it('a bare `new OpenAI()` resolves baseURL/apiKey from the environment set by Mode B', async () => {
+    writeTokenToFallback();
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+
+    const { default: OpenAI } = await import('openai');
+    const client = new OpenAI();
+
+    expect(client.baseURL).toBe('http://localhost:8000/v1');
+    expect(client.apiKey).toBe(VALID_TOKEN);
+  });
+
+  it('an explicit constructor argument still overrides the environment (unchanged SDK behaviour)', async () => {
+    writeTokenToFallback();
+    await resolveOpenAIKey(projectRoot, { fallbackPath });
+
+    const { default: OpenAI } = await import('openai');
+    const client = new OpenAI({ baseURL: 'https://explicit-override.example/v1' });
+
+    expect(client.baseURL).toBe('https://explicit-override.example/v1');
+  });
+});

--- a/src/config/nexpath-token-store.test.ts
+++ b/src/config/nexpath-token-store.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, statSync, accessSync, constants } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function expectFileLockedToOwner(path: string): void {
+  expect(existsSync(path)).toBe(true);
+  if (process.platform === 'win32') {
+    expect(() => accessSync(path, constants.R_OK | constants.W_OK)).not.toThrow();
+  } else {
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  }
+}
+
+vi.mock('cross-keychain', () => ({
+  getPassword:    vi.fn(),
+  setPassword:    vi.fn(),
+  deletePassword: vi.fn(),
+}));
+
+import {
+  storeNexpathToken,
+  readNexpathToken,
+  removeNexpathToken,
+  isValidNexpathToken,
+  resolveApiBaseUrl,
+  DEFAULT_API_BASE_URL,
+  KEYCHAIN_SERVICE,
+  KEYCHAIN_ACCOUNT,
+  TOKEN_PREFIX,
+} from './NexpathTokenStore.js';
+import * as keychain from 'cross-keychain';
+
+const VALID_TOKEN   = 'npk_' + 'a'.repeat(40);
+const INVALID_TOKEN  = 'sk-not-a-nexpath-token-at-all-0000000000';
+
+let tmpDir:       string;
+let fallbackPath: string;
+let savedEnv:     string | undefined;
+
+beforeEach(() => {
+  tmpDir       = mkdtempSync(join(tmpdir(), 'nexpath-token-store-'));
+  fallbackPath = join(tmpDir, 'config.json');
+  savedEnv     = process.env.NEXPATH_API_BASE_URL;
+  delete process.env.NEXPATH_API_BASE_URL;
+  vi.mocked(keychain.getPassword).mockReset();
+  vi.mocked(keychain.setPassword).mockReset();
+  vi.mocked(keychain.deletePassword).mockReset();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (savedEnv === undefined) delete process.env.NEXPATH_API_BASE_URL;
+  else                        process.env.NEXPATH_API_BASE_URL = savedEnv;
+});
+
+// ── Validation — never the OpenAI-key shape (RISK-2) ─────────────────────────────
+
+describe('isValidNexpathToken', () => {
+  it('accepts npk_ + 40 chars', () => {
+    expect(isValidNexpathToken(VALID_TOKEN)).toBe(true);
+  });
+
+  it('rejects an sk- shaped key — the two formats must never be interchangeable', () => {
+    expect(isValidNexpathToken(INVALID_TOKEN)).toBe(false);
+    expect(isValidNexpathToken('sk-abcdefghij1234567890ABCDEFGHIJ')).toBe(false);
+  });
+
+  it('rejects too-short values', () => {
+    expect(isValidNexpathToken('npk_short')).toBe(false);
+  });
+
+  it('rejects an unprefixed value even if long enough', () => {
+    expect(isValidNexpathToken('a'.repeat(40))).toBe(false);
+  });
+
+  it('rejects whitespace', () => {
+    expect(isValidNexpathToken('npk_' + 'a'.repeat(20) + ' ' + 'a'.repeat(19))).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidNexpathToken('')).toBe(false);
+  });
+});
+
+// ── Round trip: store / read / remove ───────────────────────────────────────────
+
+describe('storeNexpathToken / readNexpathToken / removeNexpathToken', () => {
+  it('a stored token round-trips (keychain path)', async () => {
+    vi.mocked(keychain.setPassword).mockResolvedValue(undefined);
+    vi.mocked(keychain.getPassword).mockResolvedValue(VALID_TOKEN);
+
+    const result = await storeNexpathToken(VALID_TOKEN, { fallbackPath });
+    expect(result.source).toBe('keychain');
+    expect(keychain.setPassword).toHaveBeenCalledWith(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, VALID_TOKEN);
+
+    const read = await readNexpathToken({ fallbackPath });
+    expect(read).toBe(VALID_TOKEN);
+  });
+
+  it('falls back to the 0600 file when the keychain is unavailable, and survives a restart', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain on this host'));
+    vi.mocked(keychain.getPassword).mockRejectedValue(new Error('no keychain on this host'));
+
+    const result = await storeNexpathToken(VALID_TOKEN, { fallbackPath });
+    expect(result.source).toBe('file');
+    expectFileLockedToOwner(fallbackPath);
+
+    // "survives a process restart": read again with fresh mocks, same file.
+    const read = await readNexpathToken({ fallbackPath });
+    expect(read).toBe(VALID_TOKEN);
+  });
+
+  it('rejects an invalid token before ever touching storage', async () => {
+    await expect(storeNexpathToken(INVALID_TOKEN, { fallbackPath })).rejects.toThrow(/Invalid Nexpath token/);
+    expect(keychain.setPassword).not.toHaveBeenCalled();
+    expect(existsSync(fallbackPath)).toBe(false);
+  });
+
+  it('reading with nothing stored anywhere returns null', async () => {
+    vi.mocked(keychain.getPassword).mockRejectedValue(new Error('not found'));
+    expect(await readNexpathToken({ fallbackPath })).toBeNull();
+  });
+
+  it('removing clears both the keychain and the file', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain'));
+    await storeNexpathToken(VALID_TOKEN, { fallbackPath });
+    expectFileLockedToOwner(fallbackPath);
+
+    vi.mocked(keychain.deletePassword).mockResolvedValue(undefined);
+    await removeNexpathToken({ fallbackPath });
+
+    vi.mocked(keychain.getPassword).mockRejectedValue(new Error('gone'));
+    expect(await readNexpathToken({ fallbackPath })).toBeNull();
+  });
+
+  it('removing when nothing was stored does not throw', async () => {
+    vi.mocked(keychain.deletePassword).mockRejectedValue(new Error('nothing to delete'));
+    await expect(removeNexpathToken({ fallbackPath })).resolves.not.toThrow();
+  });
+
+  it('a corrupt fallback file is not fatal to a fresh store — it is replaced, not appended to blindly', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain'));
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(join(tmpDir), { recursive: true });
+    writeFileSync(fallbackPath, 'not valid json at all', 'utf8');
+
+    await expect(storeNexpathToken(VALID_TOKEN, { fallbackPath })).resolves.toEqual({ source: 'file' });
+  });
+});
+
+// ── The two keys must coexist in the same fallback file without colliding ────────
+
+describe('coexistence with an OpenAI key in the same fallback file', () => {
+  it('storing a Nexpath token does not erase an existing openai_api_key entry', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain'));
+    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs');
+    mkdirSync(join(tmpDir), { recursive: true });
+    writeFileSync(fallbackPath, JSON.stringify({ openai_api_key: 'sk-existing-key-000000000000000' }), 'utf8');
+
+    await storeNexpathToken(VALID_TOKEN, { fallbackPath });
+
+    const onDisk = JSON.parse(readFileSync(fallbackPath, 'utf8'));
+    expect(onDisk.openai_api_key).toBe('sk-existing-key-000000000000000');
+    expect(onDisk.nexpath_token).toBe(VALID_TOKEN);
+  });
+
+  it('removing the Nexpath token leaves an existing openai_api_key entry untouched', async () => {
+    vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain'));
+    vi.mocked(keychain.deletePassword).mockResolvedValue(undefined);
+    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs');
+    mkdirSync(join(tmpDir), { recursive: true });
+    writeFileSync(
+      fallbackPath,
+      JSON.stringify({ openai_api_key: 'sk-existing-key-000000000000000', nexpath_token: VALID_TOKEN }),
+      'utf8',
+    );
+
+    await removeNexpathToken({ fallbackPath });
+
+    const onDisk = JSON.parse(readFileSync(fallbackPath, 'utf8'));
+    expect(onDisk.openai_api_key).toBe('sk-existing-key-000000000000000');
+    expect(onDisk.nexpath_token).toBeUndefined();
+  });
+});
+
+// ── The API base (DEP-FP-04 does not exist yet) ─────────────────────────────────
+
+describe('resolveApiBaseUrl', () => {
+  it('defaults to the local-development address matching the server\'s own default', () => {
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+    expect(DEFAULT_API_BASE_URL).toBe('http://localhost:8000/v1');
+  });
+
+  it('is overridden by NEXPATH_API_BASE_URL — this is where the real domain lands, one line, at DEP-FP-04', () => {
+    process.env.NEXPATH_API_BASE_URL = 'https://api.example-configured.test/v1';
+    expect(resolveApiBaseUrl()).toBe('https://api.example-configured.test/v1');
+  });
+
+  it('an empty override is treated as unset rather than as a blank base URL', () => {
+    process.env.NEXPATH_API_BASE_URL = '   ';
+    expect(resolveApiBaseUrl()).toBe(DEFAULT_API_BASE_URL);
+  });
+});

--- a/src/config/nexpath-token-store.test.ts
+++ b/src/config/nexpath-token-store.test.ts
@@ -31,6 +31,7 @@ import {
   TOKEN_PREFIX,
   TOKEN_MIN_LENGTH,
 } from './NexpathTokenStore.js';
+import { API_KEY_REGEX, isValidApiKey } from './ApiKeyResolver.js';
 import * as keychain from 'cross-keychain';
 
 const VALID_TOKEN   = 'npk_' + 'a'.repeat(40);
@@ -70,6 +71,27 @@ describe('constants', () => {
 
   it('KEYCHAIN_SERVICE matches ApiKeyResolver\'s, so both plumb through the same keychain entry', () => {
     expect(KEYCHAIN_SERVICE).toBe('nexpath');
+  });
+});
+
+// ── FP-4.1's own closure condition, taken literally ─────────────────────────────
+// "a stored token ... is never matched against the OpenAI-key regex." Every
+// other test proves the token round-trips through its own path; none of them
+// prove the cross-cutting claim this closure condition actually makes — that
+// the two validators genuinely never overlap, in either direction (RISK-2).
+
+describe('the two credential formats never validate against each other (RISK-2)', () => {
+  it('a valid Nexpath token fails the OpenAI-key regex directly', () => {
+    const token = TOKEN_PREFIX + 'a'.repeat(TOKEN_MIN_LENGTH - TOKEN_PREFIX.length);
+    expect(isValidNexpathToken(token)).toBe(true);
+    expect(API_KEY_REGEX.test(token)).toBe(false);
+    expect(isValidApiKey(token)).toBe(false);
+  });
+
+  it('a valid OpenAI key fails isValidNexpathToken', () => {
+    const key = 'sk-abcdefghij1234567890ABCDEFGHIJ';
+    expect(isValidApiKey(key)).toBe(true);
+    expect(isValidNexpathToken(key)).toBe(false);
   });
 });
 

--- a/src/config/nexpath-token-store.test.ts
+++ b/src/config/nexpath-token-store.test.ts
@@ -29,6 +29,7 @@ import {
   KEYCHAIN_SERVICE,
   KEYCHAIN_ACCOUNT,
   TOKEN_PREFIX,
+  TOKEN_MIN_LENGTH,
 } from './NexpathTokenStore.js';
 import * as keychain from 'cross-keychain';
 
@@ -57,6 +58,21 @@ afterEach(() => {
 
 // ── Validation — never the OpenAI-key shape (RISK-2) ─────────────────────────────
 
+// ── Constants — mirrors ApiKeyResolver.test.ts's own "the value is what I claim
+// it is" assertion, which existed for KEYCHAIN_SERVICE but had no equivalent
+// here for KEYCHAIN_ACCOUNT: every other test only observes it indirectly, as
+// an argument a mock was called with, never as a value in its own right. ────
+
+describe('constants', () => {
+  it('KEYCHAIN_ACCOUNT is "nexpath_token" — distinct from ApiKeyResolver\'s "openai_api_key"', () => {
+    expect(KEYCHAIN_ACCOUNT).toBe('nexpath_token');
+  });
+
+  it('KEYCHAIN_SERVICE matches ApiKeyResolver\'s, so both plumb through the same keychain entry', () => {
+    expect(KEYCHAIN_SERVICE).toBe('nexpath');
+  });
+});
+
 describe('isValidNexpathToken', () => {
   it('accepts npk_ + 40 chars', () => {
     expect(isValidNexpathToken(VALID_TOKEN)).toBe(true);
@@ -69,6 +85,18 @@ describe('isValidNexpathToken', () => {
 
   it('rejects too-short values', () => {
     expect(isValidNexpathToken('npk_short')).toBe(false);
+  });
+
+  it('the length boundary is exactly TOKEN_MIN_LENGTH, pinned rather than approximate', () => {
+    // 'npk_short' above is nowhere near the real boundary — a change to
+    // TOKEN_MIN_LENGTH from 40 down to, say, 10 would still pass it, and
+    // nothing else here checks the actual configured cutoff.
+    const oneUnder = TOKEN_PREFIX + 'a'.repeat(TOKEN_MIN_LENGTH - TOKEN_PREFIX.length - 1);
+    const exact    = TOKEN_PREFIX + 'a'.repeat(TOKEN_MIN_LENGTH - TOKEN_PREFIX.length);
+    expect(oneUnder.length).toBe(TOKEN_MIN_LENGTH - 1);
+    expect(exact.length).toBe(TOKEN_MIN_LENGTH);
+    expect(isValidNexpathToken(oneUnder)).toBe(false);
+    expect(isValidNexpathToken(exact)).toBe(true);
   });
 
   it('rejects an unprefixed value even if long enough', () => {

--- a/src/config/nexpath-token-store.test.ts
+++ b/src/config/nexpath-token-store.test.ts
@@ -151,6 +151,20 @@ describe('storeNexpathToken / readNexpathToken / removeNexpathToken', () => {
     expect(await readNexpathToken({ fallbackPath })).toBeNull();
   });
 
+  it('a keychain hit that is not a valid token is ignored, falling through to the file', async () => {
+    // The keychain resolving is not, by itself, proof of a usable token — it
+    // could hold something else entirely (a stale value, a different app's
+    // reuse of the same account name). `token && isValidNexpathToken(token)`
+    // has two clauses; every other test here only exercises `token` being
+    // absent, never `token` being present but shaped wrong.
+    vi.mocked(keychain.getPassword).mockResolvedValue('not-a-nexpath-token-at-all');
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(fallbackPath, JSON.stringify({ nexpath_token: VALID_TOKEN }), 'utf8');
+
+    expect(await readNexpathToken({ fallbackPath })).toBe(VALID_TOKEN);
+  });
+
   it('removing clears both the keychain and the file', async () => {
     vi.mocked(keychain.setPassword).mockRejectedValue(new Error('no keychain'));
     await storeNexpathToken(VALID_TOKEN, { fallbackPath });
@@ -166,6 +180,22 @@ describe('storeNexpathToken / readNexpathToken / removeNexpathToken', () => {
   it('removing when nothing was stored does not throw', async () => {
     vi.mocked(keychain.deletePassword).mockRejectedValue(new Error('nothing to delete'));
     await expect(removeNexpathToken({ fallbackPath })).resolves.not.toThrow();
+  });
+
+  it('removing leaves a file untouched when it exists but never held a token', async () => {
+    // Distinct from "no file at all": the file is present, JSON-parseable, and
+    // simply has no `nexpath_token` key — e.g. an OpenAI-key-only file. The
+    // `if ('nexpath_token' in parsed)` branch has otherwise only been exercised
+    // by tests where the key IS present.
+    vi.mocked(keychain.deletePassword).mockRejectedValue(new Error('nothing to delete'));
+    const { mkdirSync, writeFileSync, readFileSync } = await import('node:fs');
+    mkdirSync(tmpDir, { recursive: true });
+    const original = JSON.stringify({ openai_api_key: 'sk-untouched-000000000000000000' });
+    writeFileSync(fallbackPath, original, 'utf8');
+
+    await removeNexpathToken({ fallbackPath });
+
+    expect(readFileSync(fallbackPath, 'utf8')).toBe(original);
   });
 
   it('a corrupt fallback file is not fatal to a fresh store — it is replaced, not appended to blindly', async () => {

--- a/src/ext-browser/CHANGELOG.md
+++ b/src/ext-browser/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the browser extension. Versions track the `version` field in
 `manifest.chrome.json` / `manifest.firefox.json`.
 
+## 0.1.52
+
+Faster delivery, and no clipboard permission prompt on Chrome.
+
+### Changed
+- **The suggestion arrives sooner.** The check that confirms your prompt was sent now samples
+  densely for the first second instead of waiting out a fixed interval, so a send that worked is
+  recognised almost immediately. The overall time limit is unchanged.
+- **Chrome no longer asks to see your clipboard.** Delivery on Bolt now uses a direct text
+  insertion rather than a synthetic paste event. The paste event was what made the site reach for
+  the clipboard, which is what raised the browser's permission bubble.
+- **Replit delivery goes through the editor itself.** The improved prompt is applied as a single
+  editor transaction, so it no longer has to be split into pieces to fit a paste size limit, and
+  arrives in one step regardless of length. The previous method remains as a fallback.
+
+### Fixed
+- A prompt could be sent twice when a site cleared its composer in the last moment of the settle
+  window.
+- A multi-line prompt could be reported as "not delivered" when it had in fact arrived, because the
+  check read the composer's raw text rather than what it actually renders.
+
+### Notes
+- Permissions, supported sites and privacy behaviour are unchanged from 0.1.51.
+- An OpenAI API key is still required.
+
 ## 0.1.51
 
 The suggestion now arrives **before** the prompt is sent, not after the agent replies.

--- a/src/ext-browser/content/agents/bolt-inject.ts
+++ b/src/ext-browser/content/agents/bolt-inject.ts
@@ -20,8 +20,8 @@ const INPUT_SELECTOR = '.tiptap.ProseMirror';
 // (Firefox live 2026-08-25: text landed, synthetic Enter ignored).
 const SUBMIT_BUTTON_SELECTOR = 'button[aria-label="Send message"]';
 
-export async function injectPromptText(text: string): Promise<void> {
-  await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
+export async function injectPromptText(text: string): Promise<boolean> {
+  return await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
     // Bolt's composer is TipTap/ProseMirror, which renders each line of a
     // multi-line prompt as its own <p>. `textContent` runs those together with
     // no separator, so the landing check could never recognise an enhanced

--- a/src/ext-browser/content/agents/bolt-inject.ts
+++ b/src/ext-browser/content/agents/bolt-inject.ts
@@ -21,5 +21,12 @@ const INPUT_SELECTOR = '.tiptap.ProseMirror';
 const SUBMIT_BUTTON_SELECTOR = 'button[aria-label="Send message"]';
 
 export async function injectPromptText(text: string): Promise<void> {
-  await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR);
+  await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
+    // Bolt's composer is TipTap/ProseMirror, which renders each line of a
+    // multi-line prompt as its own <p>. `textContent` runs those together with
+    // no separator, so the landing check could never recognise an enhanced
+    // prompt that HAD arrived — measured live on Bolt at 300 … 50,000
+    // characters (2026-08-27). See landing-check.ts for the full reasoning.
+    useRenderedLandingText: true,
+  });
 }

--- a/src/ext-browser/content/agents/bolt-inject.ts
+++ b/src/ext-browser/content/agents/bolt-inject.ts
@@ -28,5 +28,12 @@ export async function injectPromptText(text: string): Promise<void> {
     // prompt that HAD arrived — measured live on Bolt at 300 … 50,000
     // characters (2026-08-27). See landing-check.ts for the full reasoning.
     useRenderedLandingText: true,
+    // Deliver through the page world's `execCommand('insertText')` before the
+    // paste event. Bolt's own paste handler is what reaches for
+    // `navigator.clipboard.read()` and raises Chrome's "See text and images
+    // copied to the clipboard" prompt; not dispatching a paste at all is what
+    // removes it. Measured on Bolt's real composer: 2,400 chars, 2 ms, exact,
+    // zero clipboard calls (2026-08-27). The paste stays as the fallback.
+    useDirectInsertFirst: true,
   });
 }

--- a/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+/**
+ * The WIRE CONTRACT between the inject kit and the page-world bridge.
+ *
+ * This exists because of a hole found by deleting the two flag lines from
+ * `requestMainWorldInject`'s postMessage and re-running the suite: all 1,232
+ * tests still passed. The two halves were each well covered and nothing checked
+ * the wire between them — the bridge's own tests put the flags into the request
+ * themselves, and the kit's tests stub the bridge and never look at the payload.
+ * A refactor could therefore have dropped the flags, left CI green, and silently
+ * restored the very behaviour they were added to fix.
+ *
+ * So these tests assert only one thing: what actually goes over postMessage.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { injectViaSimulatedPaste } from './inject-kit.js';
+
+let stopCapture: (() => void) | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  stopCapture?.();
+  stopCapture = null;
+});
+
+function makeComposer(): HTMLElement {
+  const input = document.createElement('div');
+  input.className = 'tiptap ProseMirror';
+  document.body.appendChild(input);
+  Object.defineProperty(input, 'getClientRects', { value: () => [{}] });
+  return input;
+}
+
+/**
+ * Record every `nexpath:inject-request` that reaches the page, and answer it as
+ * a live bridge would so the delivery completes instead of waiting out its
+ * timeout.
+ */
+function captureBridgeRequests(): Array<Record<string, unknown>> {
+  const requests: Array<Record<string, unknown>> = [];
+  const onMsg = (ev: MessageEvent): void => {
+    const m = ev.data as { type?: string; requestId?: string } | null;
+    if (m?.type !== 'nexpath:inject-request') return;
+    requests.push(m as Record<string, unknown>);
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'nexpath:inject-result', requestId: m.requestId, landed: true },
+      source: window as unknown as MessageEventSource,
+    }));
+  };
+  window.addEventListener('message', onMsg);
+  stopCapture = () => window.removeEventListener('message', onMsg);
+  return requests;
+}
+
+describe('inject-kit → page-world bridge: what actually goes over the wire', () => {
+  it('⭐ carries BOTH opt-in flags when the caller sets them (Bolt)', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'ENHANCED BODY', undefined, {
+      useRenderedLandingText: true,
+      useDirectInsertFirst: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      type: 'nexpath:inject-request',
+      selector: '.tiptap.ProseMirror',
+      text: 'ENHANCED BODY',
+      useRenderedLandingText: true,
+      useDirectInsertFirst: true,
+    });
+  });
+
+  it('carries the read flag alone when only that is set (Replit — its order flag is deliberately off)', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'ENHANCED BODY', undefined, {
+      useRenderedLandingText: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      useRenderedLandingText: true,
+      useDirectInsertFirst: false,
+    });
+  });
+
+  it('carries neither flag when the caller sets no options (Lovable)', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'ENHANCED BODY');
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      useRenderedLandingText: false,
+      useDirectInsertFirst: false,
+    });
+  });
+});

--- a/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
@@ -171,6 +171,36 @@ describe('the chunked bridge skip', () => {
     expect(requests[0]).toMatchObject({ text: OVER_LIMIT, useEditorApiInsert: true });
   });
 
+  it('⭐ tells the bridge the body is OVER the limit — losing this re-opens the composer wipe', async () => {
+    // The bridge reads this to decide whether it may fall back to a whole-body
+    // paste. Read as false for an over-limit body it would attempt exactly the
+    // paste this composer drops, after a select-all — deleting the user's own
+    // prompt and putting nothing in its place.
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', OVER_LIMIT, undefined, {
+      pasteChunkChars: 800,
+      useRenderedLandingText: true,
+      useEditorApiInsert: true,
+    });
+
+    expect(requests[0]).toMatchObject({ bodyExceedsPasteLimit: true });
+  });
+
+  it('and tells it the opposite for a body within the limit', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'short body', undefined, {
+      pasteChunkChars: 800,
+      useRenderedLandingText: true,
+      useEditorApiInsert: true,
+    });
+
+    expect(requests[0]).toMatchObject({ bodyExceedsPasteLimit: false });
+  });
+
   it('still applies without that route — the shipped skip is untouched', async () => {
     // Fake timers: with the bridge skipped this runs the whole isolated-world
     // chain, whose landing budgets are sized in seconds.

--- a/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.bridge-request.test.ts
@@ -23,6 +23,24 @@ beforeEach(() => {
     value: { writeText: vi.fn().mockResolvedValue(undefined) },
     configurable: true,
   });
+  // Needed by the tests where the bridge is SKIPPED and the isolated-world paste
+  // chain runs instead; jsdom implements neither of these.
+  if (typeof globalThis.DataTransfer === 'undefined') {
+    vi.stubGlobal('DataTransfer', class {
+      private data = new Map<string, string>();
+      setData(format: string, data: string): void { this.data.set(format, data); }
+      getData(format: string): string { return this.data.get(format) ?? ''; }
+    });
+  }
+  if (typeof globalThis.ClipboardEvent === 'undefined') {
+    vi.stubGlobal('ClipboardEvent', class extends Event {
+      clipboardData: unknown;
+      constructor(type: string, init: { clipboardData?: unknown } & EventInit = {}) {
+        super(type, init);
+        this.clipboardData = init.clipboardData;
+      }
+    });
+  }
 });
 
 afterEach(() => {
@@ -104,6 +122,85 @@ describe('inject-kit → page-world bridge: what actually goes over the wire', (
     expect(requests[0]).toMatchObject({
       useRenderedLandingText: false,
       useDirectInsertFirst: false,
+      useEditorApiInsert: false,
     });
+  });
+
+  it('carries the editor-API flag when the caller sets it (Replit)', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'ENHANCED BODY', undefined, {
+      useRenderedLandingText: true,
+      useEditorApiInsert: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      useRenderedLandingText: true,
+      useEditorApiInsert: true,
+      useDirectInsertFirst: false,
+    });
+  });
+});
+
+/**
+ * Whether the bridge is asked AT ALL for a size-limited composer.
+ *
+ * The bridge is skipped when the body has to be chunked, because the bridge
+ * PASTES in one piece and that is exactly what such a composer drops. The
+ * editor-API route does not paste, so the skip must not apply to it — and this
+ * is load-bearing rather than cosmetic: a real enhanced prompt (2.1-2.5k) is
+ * always over the chunk limit, so before this the one site that needs that route
+ * never reached it on a single real delivery.
+ */
+describe('the chunked bridge skip', () => {
+  const OVER_LIMIT = 'x'.repeat(2_500);
+
+  it('⭐ no longer applies when the editor-API route is requested', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', OVER_LIMIT, undefined, {
+      pasteChunkChars: 800,
+      useRenderedLandingText: true,
+      useEditorApiInsert: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ text: OVER_LIMIT, useEditorApiInsert: true });
+  });
+
+  it('still applies without that route — the shipped skip is untouched', async () => {
+    // Fake timers: with the bridge skipped this runs the whole isolated-world
+    // chain, whose landing budgets are sized in seconds.
+    vi.useFakeTimers();
+    try {
+      makeComposer();
+      const requests = captureBridgeRequests();
+
+      const done = injectViaSimulatedPaste('.tiptap.ProseMirror', OVER_LIMIT, undefined, {
+        pasteChunkChars: 800,
+        useRenderedLandingText: true,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await done;
+
+      expect(requests).toEqual([]);   // the bridge was never asked
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a body UNDER the limit reaches the bridge either way', async () => {
+    makeComposer();
+    const requests = captureBridgeRequests();
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', 'short body', undefined, {
+      pasteChunkChars: 800,
+      useRenderedLandingText: true,
+    });
+
+    expect(requests).toHaveLength(1);
   });
 });

--- a/src/ext-browser/content/agents/inject-kit.landing.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.landing.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+/**
+ * The multi-line landing defect, driven through the REAL inject kit.
+ *
+ * Team-lead report 2026-08-27: on Bolt and Replit the enhanced prompt took ~20 s
+ * to appear and then the user's ORIGINAL prompt was sent instead. Root cause:
+ * the landing check read the composer with `textContent`, which runs a
+ * multi-line prompt's block elements together with NO separator, so a prompt
+ * that had arrived intact was judged missing — burning both landing budgets and
+ * degrading to the clipboard fallback, after which the gate released the
+ * original.
+ *
+ * These tests drive `injectViaSimulatedPaste` against a composer shaped like the
+ * real ones (one block element per line) and pin BOTH halves of the gate:
+ * opted in (Bolt, Replit) the landed text is recognised; left out (Lovable) the
+ * shipped behaviour is preserved exactly, byte for byte.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { injectViaSimulatedPaste } from './inject-kit.js';
+import { hasTextLanded, readLandingText } from './landing-check.js';
+
+const MULTILINE = [
+  'Scope:',
+  '- Export a single invoice to PDF',
+  '',
+  'Acceptance criteria:',
+  '1. The export button appears on the invoice detail page',
+].join('\n');
+
+let writeText: ReturnType<typeof vi.fn>;
+let removeBridge: (() => void) | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+  // jsdom implements neither DataTransfer nor ClipboardEvent.
+  if (typeof globalThis.DataTransfer === 'undefined') {
+    vi.stubGlobal('DataTransfer', class {
+      private data = new Map<string, string>();
+      setData(format: string, data: string): void { this.data.set(format, data); }
+      getData(format: string): string { return this.data.get(format) ?? ''; }
+    });
+  }
+  if (typeof globalThis.ClipboardEvent === 'undefined') {
+    vi.stubGlobal('ClipboardEvent', class extends Event {
+      clipboardData: unknown;
+      constructor(type: string, init: { clipboardData?: unknown } & EventInit = {}) {
+        super(type, init);
+        this.clipboardData = init.clipboardData;
+      }
+    });
+  }
+});
+
+afterEach(() => {
+  removeBridge?.();
+  removeBridge = null;
+  vi.useRealTimers();
+});
+
+/**
+ * Give an element the `innerText` a browser would compute: block children joined
+ * by newlines. jsdom does not implement it at all, so without this the reader
+ * would silently take its `textContent` fallback and prove nothing.
+ */
+function withBrowserInnerText(el: HTMLElement): HTMLElement {
+  Object.defineProperty(el, 'innerText', {
+    configurable: true,
+    get: () => Array.from(el.querySelectorAll('p'), (p) => p.textContent ?? '').join('\n'),
+  });
+  return el;
+}
+
+/** A composer that turns a paste into one block element per line. */
+function makeBlockComposer(accept: 'all' | 'first-line-only' = 'all'): HTMLElement {
+  const input = withBrowserInnerText(document.createElement('div'));
+  input.className = 'tiptap ProseMirror';
+  document.body.appendChild(input);
+  Object.defineProperty(input, 'getClientRects', { value: () => [{}] });
+  input.addEventListener('paste', (ev) => {
+    const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+    const pasted = dt ? dt.getData('text/plain') : '';
+    const lines = accept === 'all' ? pasted.split('\n') : [pasted.split('\n')[0] ?? ''];
+    input.replaceChildren();
+    for (const line of lines) {
+      const p = document.createElement('p');
+      p.textContent = line;
+      input.appendChild(p);
+    }
+  });
+  return input;
+}
+
+/** Answer the page-world bridge the way a page with no live bridge would. */
+function stubBridgeAsUnavailable(): void {
+  const onMsg = (ev: MessageEvent): void => {
+    const m = ev.data as { type?: string; requestId?: string };
+    if (m?.type !== 'nexpath:inject-request') return;
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'nexpath:inject-result', requestId: m.requestId, landed: false },
+      source: window as unknown as MessageEventSource,
+    }));
+  };
+  window.addEventListener('message', onMsg);
+  removeBridge = () => window.removeEventListener('message', onMsg);
+}
+
+describe('the defect is in the READ, not in the delivery', () => {
+  it('same composer, same landed text: the raw read says no, the rendered read says yes', () => {
+    const input = makeBlockComposer();
+    for (const line of MULTILINE.split('\n')) {
+      const p = document.createElement('p');
+      p.textContent = line;
+      input.appendChild(p);
+    }
+    // Every word is present, in order, correct — and the raw read still fails,
+    // because nothing separates one block from the next.
+    expect(hasTextLanded(input.textContent ?? '', MULTILINE)).toBe(false);
+    expect(hasTextLanded(readLandingText(input), MULTILINE)).toBe(true);
+  });
+});
+
+describe('injectViaSimulatedPaste — useRenderedLandingText', () => {
+  it('OPTED IN (Bolt/Replit): a multi-line prompt that landed is recognised, and submitted', async () => {
+    vi.useFakeTimers();
+    const input = makeBlockComposer();
+    const keys: string[] = [];
+    input.addEventListener('keydown', (e) => { keys.push((e as KeyboardEvent).key); });
+    stubBridgeAsUnavailable();
+
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', MULTILINE, undefined, {
+      useRenderedLandingText: true,
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    await done;
+
+    // The text is in the composer, one block per line...
+    expect(input.querySelectorAll('p').length).toBe(MULTILINE.split('\n').length);
+    // ...and the kit agreed, so it submitted rather than degrading.
+    expect(keys).toContain('Enter');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('LEFT OUT (Lovable): unchanged — the raw read still decides, and still degrades', async () => {
+    vi.useFakeTimers();
+    const input = makeBlockComposer();
+    stubBridgeAsUnavailable();
+
+    // No options at all: exactly how lovable-inject.ts calls this kit today.
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', MULTILINE);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await done;
+
+    // Shipped behaviour, preserved on purpose: the text IS in the composer, the
+    // raw read cannot see it, and the kit degrades to the clipboard. Lovable is
+    // migrated in its own change, not this one.
+    expect(input.querySelectorAll('p').length).toBeGreaterThan(1);
+    expect(writeText).toHaveBeenCalledWith(MULTILINE);
+  });
+
+  it('OPTED IN does not weaken the guard: a partial insert still degrades', async () => {
+    vi.useFakeTimers();
+    const input = makeBlockComposer('first-line-only');
+    stubBridgeAsUnavailable();
+
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', MULTILINE, undefined, {
+      useRenderedLandingText: true,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await done;
+
+    expect(writeText).toHaveBeenCalledWith(MULTILINE);
+  });
+
+  it('OPTED IN still refuses blank text — the composer is left untouched', async () => {
+    const input = makeBlockComposer();
+    const p = document.createElement('p');
+    p.textContent = 'the user was still typing this';
+    input.appendChild(p);
+
+    await injectViaSimulatedPaste('.tiptap.ProseMirror', '   \n  ', undefined, {
+      useRenderedLandingText: true,
+    });
+
+    expect(input.textContent).toBe('the user was still typing this');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/ext-browser/content/agents/inject-kit.submit-settle.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.submit-settle.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+/**
+ * The post-insert settle, and the delivery outcome the kit now reports.
+ *
+ * With the insertion itself measured in single-digit milliseconds, the flat
+ * `await sleep(SUBMIT_SETTLE_MS)` between pressing Enter and the button fallback
+ * was the largest remaining cost on every delivery — paid in full even when the
+ * site had cleared its composer within a frame.
+ *
+ * Two things are pinned here, and the second is why polling is SAFER than the
+ * single read it replaces rather than only faster:
+ *
+ *   1. The settle ends as soon as the composer is observed clear.
+ *   2. It takes TWO CONSECUTIVE clear reads to end it. A rich editor can report
+ *      empty for one frame mid-reconcile; acting on that skips the button
+ *      fallback and the prompt is never sent. The flat sleep sampled once, at
+ *      the ceiling, with no second look.
+ *
+ * And the ceiling itself is unchanged: a composer that still holds the text at
+ * `SUBMIT_SETTLE_MS` reaches the button exactly as before.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { injectViaSimulatedPaste } from './inject-kit.js';
+
+let removeBridge: (() => void) | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+  if (typeof globalThis.DataTransfer === 'undefined') {
+    vi.stubGlobal('DataTransfer', class {
+      private data = new Map<string, string>();
+      setData(format: string, data: string): void { this.data.set(format, data); }
+      getData(format: string): string { return this.data.get(format) ?? ''; }
+    });
+  }
+  if (typeof globalThis.ClipboardEvent === 'undefined') {
+    vi.stubGlobal('ClipboardEvent', class extends Event {
+      clipboardData: unknown;
+      constructor(type: string, init: { clipboardData?: unknown } & EventInit = {}) {
+        super(type, init);
+        this.clipboardData = init.clipboardData;
+      }
+    });
+  }
+});
+
+afterEach(() => {
+  removeBridge?.();
+  removeBridge = null;
+  vi.useRealTimers();
+});
+
+const BODY = 'ENHANCED BODY';
+
+/**
+ * A composer whose readable text is driven by a callback, so a test can model
+ * what the editor reports on each individual read. Both reads the kit can make
+ * (`innerText`, then `textContent`) are driven from the same source, so a
+ * "cleared" read really is cleared.
+ */
+function makeComposer(read: () => string): HTMLElement {
+  const input = document.createElement('div');
+  input.className = 'tiptap ProseMirror';
+  document.body.appendChild(input);
+  Object.defineProperty(input, 'getClientRects', { value: () => [{}] });
+  Object.defineProperty(input, 'innerText', { configurable: true, get: read });
+  Object.defineProperty(input, 'textContent', { configurable: true, get: read });
+  return input;
+}
+
+/** Answer the page-world bridge as a live one would: the text landed. */
+function stubBridgeAsLanded(): void {
+  const onMsg = (ev: MessageEvent): void => {
+    const m = ev.data as { type?: string; requestId?: string };
+    if (m?.type !== 'nexpath:inject-request') return;
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'nexpath:inject-result', requestId: m.requestId, landed: true },
+      source: window as unknown as MessageEventSource,
+    }));
+  };
+  window.addEventListener('message', onMsg);
+  removeBridge = () => window.removeEventListener('message', onMsg);
+}
+
+function makeButton(): ReturnType<typeof vi.fn> {
+  const button = document.createElement('button');
+  button.setAttribute('aria-label', 'Send message');
+  const clicked = vi.fn();
+  button.addEventListener('click', clicked);
+  document.body.appendChild(button);
+  return clicked;
+}
+
+const SEND = 'button[aria-label="Send message"]';
+
+describe('the settle is a ceiling, not a sleep', () => {
+  it('⭐ resolves as soon as the site clears the composer, not after the full settle', async () => {
+    vi.useFakeTimers();
+    let sent = false;
+    makeComposer(() => (sent ? '' : BODY));
+    makeButton();
+    stubBridgeAsLanded();
+    // The site submits on the synthetic Enter, as all three agents do.
+    document.querySelector('.tiptap.ProseMirror')!
+      .addEventListener('keydown', (ev) => { if ((ev as KeyboardEvent).key === 'Enter') sent = true; });
+
+    let settled = false;
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, SEND, {
+      useRenderedLandingText: true,
+    }).then(() => { settled = true; });
+
+    // Two poll intervals is all a cleared composer needs. Under the flat sleep
+    // this was still pending here.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(settled).toBe(true);
+    await done;
+  });
+
+  it('still waits the FULL settle before the button fallback when Enter does not submit', async () => {
+    vi.useFakeTimers();
+    makeComposer(() => BODY);            // the text never leaves
+    const clicked = makeButton();
+    stubBridgeAsLanded();
+
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, SEND, {
+      useRenderedLandingText: true,
+    });
+
+    await vi.advanceTimersByTimeAsync(700);
+    expect(clicked).not.toHaveBeenCalled();     // the ceiling is unchanged
+    await vi.advanceTimersByTimeAsync(300);
+    await done;
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('⭐ a SINGLE transient clear does not end the settle — the button fallback still fires', async () => {
+    vi.useFakeTimers();
+    // Empty on exactly one read, as an editor mid-reconcile reports. Acting on
+    // that would skip the button and the prompt would never be sent.
+    let reads = 0;
+    makeComposer(() => (++reads === 2 ? '' : BODY));
+    const clicked = makeButton();
+    stubBridgeAsLanded();
+
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, SEND, {
+      useRenderedLandingText: true,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await done;
+
+    expect(clicked).toHaveBeenCalledTimes(1);
+    expect(reads).toBeGreaterThan(3);          // it kept looking after the blip
+  });
+});
+
+describe('the kit reports whether it actually delivered', () => {
+  it('⭐ returns TRUE when the text was delivered', async () => {
+    makeComposer(() => BODY);
+    stubBridgeAsLanded();
+
+    const delivered = await injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, undefined, {
+      useRenderedLandingText: true,
+    });
+
+    expect(delivered).toBe(true);
+  });
+
+  it('⭐ returns FALSE when it degraded to the clipboard — the gate no longer has to guess', async () => {
+    vi.useFakeTimers();
+    makeComposer(() => '');              // nothing ever lands
+    // No bridge: the whole chain runs and ends at the clipboard fallback.
+
+    const run = injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, undefined, {
+      useRenderedLandingText: true,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(await run).toBe(false);
+  });
+
+  it('returns FALSE when no composer matched at all', async () => {
+    expect(await injectViaSimulatedPaste('.no-such-composer', BODY)).toBe(false);
+  });
+
+  it('returns FALSE for blank text, and still leaves the composer untouched', async () => {
+    const input = makeComposer(() => 'the user was still typing this');
+    expect(await injectViaSimulatedPaste('.tiptap.ProseMirror', '  \n ')).toBe(false);
+    expect(input.textContent).toBe('the user was still typing this');
+  });
+});

--- a/src/ext-browser/content/agents/inject-kit.submit-settle.test.ts
+++ b/src/ext-browser/content/agents/inject-kit.submit-settle.test.ts
@@ -137,6 +137,27 @@ describe('the settle is a ceiling, not a sleep', () => {
     expect(clicked).toHaveBeenCalledTimes(1);
   });
 
+  it('⭐ a site that clears in the LAST poll window is not double-submitted', async () => {
+    // The two-read rule exists to end the settle EARLY. At the ceiling the
+    // shipped rule stands: the flat sleep took ONE reading here and returned if
+    // the composer was clear. A site that clears inside the final window yields
+    // a single clear read — refusing it would fire the button fallback on a
+    // prompt that has already been sent.
+    vi.useFakeTimers();
+    const clearAt = Date.now() + 780;             // between the 15th and 16th poll
+    makeComposer(() => (Date.now() >= clearAt ? '' : BODY));
+    const clicked = makeButton();
+    stubBridgeAsLanded();
+
+    const done = injectViaSimulatedPaste('.tiptap.ProseMirror', BODY, SEND, {
+      useRenderedLandingText: true,
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+    await done;
+
+    expect(clicked).not.toHaveBeenCalled();
+  });
+
   it('⭐ a SINGLE transient clear does not end the settle — the button fallback still fires', async () => {
     vi.useFakeTimers();
     // Empty on exactly one read, as an editor mid-reconcile reports. Acting on

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -285,6 +285,7 @@ function requestMainWorldInject(
   text: string,
   useRendered: boolean,
   directInsertFirst: boolean,
+  editorApiInsert: boolean,
 ): Promise<boolean> {
   return new Promise((resolve) => {
     const requestId = `nx-inject-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -313,6 +314,7 @@ function requestMainWorldInject(
         // generation presents during an update.
         useRenderedLandingText: useRendered,
         useDirectInsertFirst: directInsertFirst,
+        useEditorApiInsert: editorApiInsert,
       },
       window.location.origin,
     );
@@ -424,6 +426,34 @@ export interface InjectOptions {
    * must not change in this milestone. Absent ⇒ the shipped paste-first order.
    */
   useDirectInsertFirst?: boolean;
+
+  /**
+   * In the PAGE-WORLD bridge, deliver through the composer's OWN editor instance
+   * (a CodeMirror 6 `EditorView` transaction) instead of an event.
+   *
+   * ── WHY THIS EXISTS ────────────────────────────────────────────────────────
+   * Neither other route serves Replit. Its CodeMirror 6 composer refuses
+   * `execCommand('insertText')` — measured live on a real Repl (2026-08-27:
+   * returns false, inserts nothing), which is why `useDirectInsertFirst` is not
+   * set there. And its paste path has a size limit, which is what forced
+   * `pasteChunkChars` — a character-count rule the delivery should not need.
+   *
+   * A transaction has neither problem. Measured on that same live composer:
+   * 55 / 2,500 / 8,000 characters all landed with the document matching exactly,
+   * in 2-6 ms, with no paste event, no clipboard, and no size rule.
+   *
+   * ── WHAT IT CHANGES ON THIS SIDE ───────────────────────────────────────────
+   * The bridge is normally skipped for a size-limited composer, because the
+   * bridge pastes in one piece. This route does not paste at all, so that skip
+   * no longer applies to it — see the bridge loop below. Everything else is
+   * unchanged: if the page has no editor view, or the transaction does not take,
+   * the bridge answers false and the existing chunked chain runs exactly as it
+   * does today.
+   *
+   * Opt-in per agent, like the flags above. Absent ⇒ the bridge never looks for
+   * an editor view, and a size-limited composer keeps skipping the bridge.
+   */
+  useEditorApiInsert?: boolean;
 }
 
 export async function injectViaSimulatedPaste(
@@ -453,14 +483,25 @@ export async function injectViaSimulatedPaste(
   // the raw-`textContent` read this kit has always used (see InjectOptions).
   const useRendered = options.useRenderedLandingText === true;
   const directInsertFirst = options.useDirectInsertFirst === true;
+  const editorApiInsert = options.useEditorApiInsert === true;
 
   // Preferred path: the page-world bridge (first-class events for rich editors).
-  // SKIPPED for a size-limited composer: the bridge pastes in one piece, which is
-  // exactly what that composer drops.
+  // SKIPPED for a size-limited composer, because the bridge PASTES in one piece,
+  // which is exactly what that composer drops.
+  //
+  // That reasoning is about the paste, so it stops applying when the caller has
+  // asked for the editor-API route, which does not paste at all: it replaces the
+  // document in one transaction, at any length (see useEditorApiInsert). Without
+  // this, the one site that needs that route would never reach it — a real
+  // enhanced prompt is always over the chunk limit, so the skip fired every time.
+  //
+  // Nothing is risked by trying: a page with no editor view answers false and the
+  // chunked chain below runs exactly as it does today.
   const selectorList = Array.isArray(inputSelector) ? inputSelector : [inputSelector];
   const chunked = options.pasteChunkChars !== undefined && text.length > options.pasteChunkChars;
-  for (const selector of chunked ? [] : selectorList) {
-    if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst)) {
+  const skipBridge = chunked && !editorApiInsert;
+  for (const selector of skipBridge ? [] : selectorList) {
+    if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst, editorApiInsert)) {
       logInjectOutcome('landed via main-world bridge');
       await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
       return;

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -382,7 +382,18 @@ async function submitInjectedPrompt(
     } else if (++clearReads >= SUBMIT_SETTLE_CLEAR_READS) {
       return;                                          // gone, twice — the Enter submit worked
     }
-    if (Date.now() >= deadline) break;
+    if (Date.now() >= deadline) {
+      // The ceiling, where the flat sleep took its ONE reading and returned if
+      // the composer was clear. Decide the same way on the reading just taken.
+      //
+      // Without this, a site that clears inside the last poll window produces a
+      // single clear read, which the two-read rule refuses — and the button
+      // fallback then fires on a prompt that has ALREADY been sent. The extra
+      // evidence is there to end the settle EARLY; at the ceiling the shipped
+      // rule stands.
+      if (clearReads > 0) return;
+      break;
+    }
   }
   const button = document.querySelector<HTMLButtonElement>(submitButtonSelector);
   if (button && !button.disabled) {

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -286,6 +286,7 @@ function requestMainWorldInject(
   useRendered: boolean,
   directInsertFirst: boolean,
   editorApiInsert: boolean,
+  bodyExceedsPasteLimit: boolean,
 ): Promise<boolean> {
   return new Promise((resolve) => {
     const requestId = `nx-inject-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -315,6 +316,7 @@ function requestMainWorldInject(
         useRenderedLandingText: useRendered,
         useDirectInsertFirst: directInsertFirst,
         useEditorApiInsert: editorApiInsert,
+        bodyExceedsPasteLimit,
       },
       window.location.origin,
     );
@@ -501,7 +503,7 @@ export async function injectViaSimulatedPaste(
   const chunked = options.pasteChunkChars !== undefined && text.length > options.pasteChunkChars;
   const skipBridge = chunked && !editorApiInsert;
   for (const selector of skipBridge ? [] : selectorList) {
-    if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst, editorApiInsert)) {
+    if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst, editorApiInsert, chunked)) {
       logInjectOutcome('landed via main-world bridge');
       await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
       return;

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -326,6 +326,34 @@ function requestMainWorldInject(
 /** How long the synthetic Enter gets to clear the composer before the button
  * fallback fires. Agents clear their composer immediately on a real send. */
 const SUBMIT_SETTLE_MS = 800;
+/**
+ * How often the settle is re-read.
+ *
+ * The settle used to be a flat `await sleep(SUBMIT_SETTLE_MS)` — paid IN FULL on
+ * every delivery, including the overwhelmingly common case where the site
+ * cleared its composer within a frame or two of the Enter. With the insertion
+ * itself now measured in single-digit milliseconds, that one sleep was the
+ * largest remaining cost on the whole path.
+ *
+ * Polling changes only WHEN the answer is read, never what the answer is: the
+ * ceiling above is untouched, so a composer that still holds the text at
+ * `SUBMIT_SETTLE_MS` reaches the button fallback exactly as before.
+ */
+const SUBMIT_SETTLE_POLL_MS = 50;
+/**
+ * How many consecutive "the composer is clear" reads end the settle.
+ *
+ * Two, not one — and this is the reason polling is SAFER here than the single
+ * read it replaces, rather than merely faster. A rich editor can momentarily
+ * report empty mid-reconcile, and CodeMirror 6 renders only its viewport, so an
+ * isolated read can say "cleared" about a composer that still holds the prompt.
+ * Acting on that skips the button fallback and the prompt is never sent.
+ *
+ * The flat sleep sampled exactly ONCE, at the ceiling, and was equally exposed
+ * to a bad sample — with no second look. Requiring two in a row is strictly more
+ * evidence than the shipped behaviour asked for, at a cost of one poll interval.
+ */
+const SUBMIT_SETTLE_CLEAR_READS = 2;
 
 /**
  * Auto-submit the landed prompt. Synthetic Enter first (Chrome-proven on all
@@ -344,8 +372,18 @@ async function submitInjectedPrompt(
 ): Promise<void> {
   dispatchSubmit(input);
   if (!submitButtonSelector) return;
-  await new Promise((resolve) => setTimeout(resolve, SUBMIT_SETTLE_MS));
-  if (!hasLanded(input, text, useRendered)) return; // composer cleared — the Enter submit worked
+  // Wait for the composer to clear, up to — never simply FOR — the settle.
+  const deadline = Date.now() + SUBMIT_SETTLE_MS;
+  let clearReads = 0;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, SUBMIT_SETTLE_POLL_MS));
+    if (hasLanded(input, text, useRendered)) {
+      clearReads = 0;                                  // still there — start over
+    } else if (++clearReads >= SUBMIT_SETTLE_CLEAR_READS) {
+      return;                                          // gone, twice — the Enter submit worked
+    }
+    if (Date.now() >= deadline) break;
+  }
   const button = document.querySelector<HTMLButtonElement>(submitButtonSelector);
   if (button && !button.disabled) {
     logInjectOutcome('auto-submit via button click', 'synthetic Enter did not submit');
@@ -463,7 +501,7 @@ export async function injectViaSimulatedPaste(
   text: string,
   submitButtonSelector?: string,
   options: InjectOptions = {},
-): Promise<void> {
+): Promise<boolean> {
   // Blank text can never be a legitimate injection, and letting it through was
   // actively destructive: the paste path select-alls first, so an empty insert
   // WIPES whatever the user had in the composer, and the old landing check
@@ -471,13 +509,13 @@ export async function injectViaSimulatedPaste(
   // click the site's send button. Refuse it at the door and say so.
   if (text.trim().length === 0) {
     logInjectOutcome('refused', 'empty inject text — composer left untouched');
-    return;
+    return false;
   }
   const input = resolveComposer(inputSelector);
   if (!input) {
     logInjectOutcome('clipboard fallback', `no composer matched ${JSON.stringify(inputSelector)}`);
     await clipboardFallback(text);
-    return;
+    return false;
   }
 
   // Resolved ONCE for this delivery and threaded through every landing read, so
@@ -506,7 +544,7 @@ export async function injectViaSimulatedPaste(
     if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst, editorApiInsert, chunked)) {
       logInjectOutcome('landed via main-world bridge');
       await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
-      return;
+      return true;
     }
     if (document.querySelector(selector)) break; // selector matches; bridge tried and failed — don't retry others
   }
@@ -516,7 +554,7 @@ export async function injectViaSimulatedPaste(
   if (await waitForLanding(input, text, landingBudget, useRendered)) {
     logInjectOutcome('landed via simulated paste');
     await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
-    return;
+    return true;
   }
 
   // Firefox: the synthetic paste is inert (see insertViaExecCommand). Retry the
@@ -531,7 +569,7 @@ export async function injectViaSimulatedPaste(
   if (await waitForLanding(input, text, landingBudget, useRendered)) {
     logInjectOutcome('landed via execCommand');
     await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
-    return;
+    return true;
   }
 
   // LAST CHANCE before degrading. An earlier attempt may have been accepted
@@ -541,9 +579,10 @@ export async function injectViaSimulatedPaste(
   if (hasLanded(input, text, useRendered)) {
     logInjectOutcome('landed late — submitting rather than degrading');
     await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
-    return;
+    return true;
   }
 
   logInjectOutcome('clipboard fallback', `paste did not land in <${input.tagName.toLowerCase()} class="${(input.className || '').toString().slice(0, 60)}">`);
   await clipboardFallback(text);
+  return false;
 }

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -280,7 +280,12 @@ function logInjectOutcome(outcome: string, detail = ''): void {
  * reply; a missing bridge (stale page generation) times out to false and the
  * caller's own fallback chain takes over — this path can only improve delivery.
  */
-function requestMainWorldInject(selector: string, text: string): Promise<boolean> {
+function requestMainWorldInject(
+  selector: string,
+  text: string,
+  useRendered: boolean,
+  directInsertFirst: boolean,
+): Promise<boolean> {
   return new Promise((resolve) => {
     const requestId = `nx-inject-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const timer = setTimeout(() => {
@@ -296,7 +301,21 @@ function requestMainWorldInject(selector: string, text: string): Promise<boolean
       resolve(msg.landed === true);
     };
     window.addEventListener('message', onReply);
-    window.postMessage({ type: 'nexpath:inject-request', requestId, selector, text }, window.location.origin);
+    window.postMessage(
+      {
+        type: 'nexpath:inject-request',
+        requestId,
+        selector,
+        text,
+        // Both are read as `=== true` on the page side, so an older bridge that
+        // does not know these fields simply ignores them and behaves as it
+        // always has — the shape a page still running the previous extension
+        // generation presents during an update.
+        useRenderedLandingText: useRendered,
+        useDirectInsertFirst: directInsertFirst,
+      },
+      window.location.origin,
+    );
   });
 }
 
@@ -374,6 +393,37 @@ export interface InjectOptions {
    * proven live. Absent ⇒ exactly today's behaviour, for every caller.
    */
   useRenderedLandingText?: boolean;
+
+  /**
+   * In the PAGE-WORLD bridge, try `execCommand('insertText')` BEFORE the paste
+   * event rather than after it.
+   *
+   * ── WHAT THIS FIXES ────────────────────────────────────────────────────────
+   * Both routes deliver the same text; only one of them dispatches a `paste`
+   * event at the site. On Chrome a site whose paste handler cannot read the
+   * event's clipboardData falls back to `navigator.clipboard.read()`, and Chrome
+   * asks the user "<site> wants to — See text and images copied to the
+   * clipboard". That bubble takes focus off the page, which is why delivery
+   * appeared to resume only once the user answered it. Firefox never shows the
+   * prompt because a script-constructed ClipboardEvent's clipboardData is
+   * dropped there, so the site's paste handler never runs and the insertion
+   * happens through execCommand — the route this flag selects on purpose.
+   *
+   * Measured on Bolt's real composer in Chrome (2026-08-27): the page-world
+   * insertText landed a 2,400-character multi-line prompt exactly, in 2 ms, with
+   * zero clipboard calls and no paste handler fired. Both routes are still
+   * attempted, so an editor that ignores the command (measured: Replit's
+   * CodeMirror 6) simply falls through to the paste, exactly as today.
+   *
+   * ── WHY IT IS SEPARATE FROM `useRenderedLandingText` ───────────────────────
+   * They are independent concerns — that flag picks the READ, this one picks the
+   * INSERTION ORDER — and keeping them apart keeps the rollback granular: this
+   * can be turned off without giving up the landing-check fix.
+   *
+   * Opt-in per agent for the same reason as the flag above: Lovable's delivery
+   * must not change in this milestone. Absent ⇒ the shipped paste-first order.
+   */
+  useDirectInsertFirst?: boolean;
 }
 
 export async function injectViaSimulatedPaste(
@@ -402,6 +452,7 @@ export async function injectViaSimulatedPaste(
   // one insertion can never be judged by two different rules. Absent ⇒ false ⇒
   // the raw-`textContent` read this kit has always used (see InjectOptions).
   const useRendered = options.useRenderedLandingText === true;
+  const directInsertFirst = options.useDirectInsertFirst === true;
 
   // Preferred path: the page-world bridge (first-class events for rich editors).
   // SKIPPED for a size-limited composer: the bridge pastes in one piece, which is
@@ -409,7 +460,7 @@ export async function injectViaSimulatedPaste(
   const selectorList = Array.isArray(inputSelector) ? inputSelector : [inputSelector];
   const chunked = options.pasteChunkChars !== undefined && text.length > options.pasteChunkChars;
   for (const selector of chunked ? [] : selectorList) {
-    if (await requestMainWorldInject(selector, text)) {
+    if (await requestMainWorldInject(selector, text, useRendered, directInsertFirst)) {
       logInjectOutcome('landed via main-world bridge');
       await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
       return;

--- a/src/ext-browser/content/agents/inject-kit.ts
+++ b/src/ext-browser/content/agents/inject-kit.ts
@@ -18,7 +18,7 @@
  * file — the toast/clipboard fallback below is reusable for it as-is.
  */
 
-import { hasTextLanded } from './landing-check.js';
+import { hasTextLanded, readLandingText } from './landing-check.js';
 
 export function showToast(message: string): void {
   const host = document.createElement('div');
@@ -186,11 +186,16 @@ function insertViaExecCommand(input: HTMLElement, text: string): void {
   }
 }
 
-function hasLanded(input: HTMLElement, text: string): boolean {
+function hasLanded(input: HTMLElement, text: string, useRendered: boolean): boolean {
   // Whole-text containment, not a 20-char prefix — see landing-check.ts for the
   // two false "successes" the prefix test produced (empty text, shared prefix),
   // both of which ended in auto-submitting the wrong thing.
-  return hasTextLanded(input.textContent ?? '', text);
+  //
+  // `useRendered` picks WHICH read of the composer that containment is asked
+  // about: the rendered text, or the raw `textContent` this kit has always used.
+  // See `InjectOptions.useRenderedLandingText` for why that is a per-agent
+  // choice rather than a straight replacement.
+  return hasTextLanded(useRendered ? readLandingText(input) : (input.textContent ?? ''), text);
 }
 
 /**
@@ -245,10 +250,15 @@ export function landingBudgetFor(text: string): number {
  * page for a multi-KB body. Polling keeps fast editors fast and only slow ones
  * wait.
  */
-async function waitForLanding(input: HTMLElement, text: string, budgetMs: number): Promise<boolean> {
+async function waitForLanding(
+  input: HTMLElement,
+  text: string,
+  budgetMs: number,
+  useRendered: boolean,
+): Promise<boolean> {
   const deadline = Date.now() + budgetMs;
   for (;;) {
-    if (hasLanded(input, text)) return true;
+    if (hasLanded(input, text, useRendered)) return true;
     if (Date.now() >= deadline) return false;
     await new Promise((resolve) => setTimeout(resolve, 75));
   }
@@ -306,12 +316,13 @@ const SUBMIT_SETTLE_MS = 800;
 async function submitInjectedPrompt(
   input: HTMLElement,
   text: string,
-  submitButtonSelector?: string,
+  submitButtonSelector: string | undefined,
+  useRendered: boolean,
 ): Promise<void> {
   dispatchSubmit(input);
   if (!submitButtonSelector) return;
   await new Promise((resolve) => setTimeout(resolve, SUBMIT_SETTLE_MS));
-  if (!hasLanded(input, text)) return; // composer cleared — the Enter submit worked
+  if (!hasLanded(input, text, useRendered)) return; // composer cleared — the Enter submit worked
   const button = document.querySelector<HTMLButtonElement>(submitButtonSelector);
   if (button && !button.disabled) {
     logInjectOutcome('auto-submit via button click', 'synthetic Enter did not submit');
@@ -337,6 +348,32 @@ export interface InjectOptions {
    * single-paste path is untouched.
    */
   pasteChunkChars?: number;
+
+  /**
+   * Check whether an insertion landed against the composer's RENDERED text
+   * (`readLandingText` → `innerText`) instead of its raw `textContent`.
+   *
+   * ── WHAT THIS FIXES ────────────────────────────────────────────────────────
+   * `textContent` runs a multi-line prompt's block elements together with no
+   * separator, so the landing check could never pass for one — at ANY prompt
+   * length (measured live on Bolt at 300 … 50,000 characters, 2026-08-27). The
+   * full reasoning, and the live numbers, are in landing-check.ts.
+   *
+   * The cost of that miss was not cosmetic: the check failing burned the whole
+   * landing budget, then burned it again on the execCommand retry, degraded to
+   * the clipboard fallback, and the gate then spent its own send-verification
+   * window looking for text it had been told was never delivered — ending with
+   * the user's ORIGINAL prompt being sent and the enhanced one discarded.
+   *
+   * ── WHY IT IS OPT-IN AND NOT SIMPLY THE NEW BEHAVIOUR ──────────────────────
+   * It is a correctness fix and it applies equally to all three agents. It is
+   * gated only because Lovable's delivery must not change in this milestone
+   * (owner instruction, 2026-08-27) and Lovable reaches this kit through the
+   * response-stop inject path. Bolt and Replit opt in here; Lovable is left
+   * BYTE-IDENTICAL and can be migrated as its own change once the other two are
+   * proven live. Absent ⇒ exactly today's behaviour, for every caller.
+   */
+  useRenderedLandingText?: boolean;
 }
 
 export async function injectViaSimulatedPaste(
@@ -361,6 +398,11 @@ export async function injectViaSimulatedPaste(
     return;
   }
 
+  // Resolved ONCE for this delivery and threaded through every landing read, so
+  // one insertion can never be judged by two different rules. Absent ⇒ false ⇒
+  // the raw-`textContent` read this kit has always used (see InjectOptions).
+  const useRendered = options.useRenderedLandingText === true;
+
   // Preferred path: the page-world bridge (first-class events for rich editors).
   // SKIPPED for a size-limited composer: the bridge pastes in one piece, which is
   // exactly what that composer drops.
@@ -369,7 +411,7 @@ export async function injectViaSimulatedPaste(
   for (const selector of chunked ? [] : selectorList) {
     if (await requestMainWorldInject(selector, text)) {
       logInjectOutcome('landed via main-world bridge');
-      await submitInjectedPrompt(input, text, submitButtonSelector);
+      await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
       return;
     }
     if (document.querySelector(selector)) break; // selector matches; bridge tried and failed — don't retry others
@@ -377,9 +419,9 @@ export async function injectViaSimulatedPaste(
 
   const landingBudget = landingBudgetFor(text);
   dispatchSimulatedPaste(input, text, options.pasteChunkChars);
-  if (await waitForLanding(input, text, landingBudget)) {
+  if (await waitForLanding(input, text, landingBudget, useRendered)) {
     logInjectOutcome('landed via simulated paste');
-    await submitInjectedPrompt(input, text, submitButtonSelector);
+    await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
     return;
   }
 
@@ -392,9 +434,9 @@ export async function injectViaSimulatedPaste(
   // work (it is the Firefox path for plain textareas), but it is not a fallback
   // a size-limited composer can rely on.
   insertViaExecCommand(input, text);
-  if (await waitForLanding(input, text, landingBudget)) {
+  if (await waitForLanding(input, text, landingBudget, useRendered)) {
     logInjectOutcome('landed via execCommand');
-    await submitInjectedPrompt(input, text, submitButtonSelector);
+    await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
     return;
   }
 
@@ -402,9 +444,9 @@ export async function injectViaSimulatedPaste(
   // after its own budget elapsed — live, that is exactly what happened, and
   // telling the user to paste text that is already in the box is worse than
   // saying nothing. Re-read once more before giving up.
-  if (hasLanded(input, text)) {
+  if (hasLanded(input, text, useRendered)) {
     logInjectOutcome('landed late — submitting rather than degrading');
-    await submitInjectedPrompt(input, text, submitButtonSelector);
+    await submitInjectedPrompt(input, text, submitButtonSelector, useRendered);
     return;
   }
 

--- a/src/ext-browser/content/agents/install-submit-gate.test.ts
+++ b/src/ext-browser/content/agents/install-submit-gate.test.ts
@@ -180,6 +180,55 @@ describe('installSubmitGate — exactly one gate may own a site', () => {
     expect(marks[0]!.text).toBe('the improved prompt');
   });
 
+  /**
+   * An inject that degraded to the clipboard KNOWS it did. This used to report
+   * success regardless, so the gate then spent its whole send-verification
+   * window hunting the composer for text it had already been told was never put
+   * there — seconds of waiting for an answer available immediately.
+   */
+  describe('the delivery outcome the injector reports', () => {
+    /** Every submit-flow event the gate emitted through the worker channel. */
+    const emitted = (): string[] => mockSendMessage.mock.calls
+      .map((c) => c[0] as { type?: string; event?: string })
+      .filter((m) => m.type === 'nexpath:submit-flow-event')
+      .map((m) => m.event ?? '');
+
+    /** A composer whose text the test controls, so a send can be observed. */
+    function controllableComposer(initial: string) {
+      let text = initial;
+      return {
+        composer: { readComposerText: () => text },
+        set: (t: string) => { text = t; },
+      };
+    }
+
+    it('⭐ FALSE is taken at its word — failed immediately, without a verification window', async () => {
+      const { composer } = controllableComposer('ship this to production now');
+      // Degraded to the clipboard: the replacement was never put in the composer.
+      const injectPromptText = vi.fn().mockResolvedValue(false);
+      installSubmitGate({ agent: 'bolt', submitButtonSelector: '#send', injectPromptText });
+      await settle();
+      mockSendMessage.mockResolvedValue({ decision: { kind: 'block', replacement: 'the improved prompt' } });
+
+      lastInterceptor()(makeEvent(), 'ship this to production now', INPUT, composer);
+      await vi.waitFor(() => expect(emitted()).toContain('submit_hold_substitution_failed'));
+      expect(emitted()).not.toContain('submit_replacement_sent');
+    });
+
+    it('reporting NOTHING is read as success — an injector that says nothing keeps today\'s behaviour', async () => {
+      const { composer, set } = controllableComposer('ship this to production now');
+      // Delivered and sent, and says nothing about it — the shipped shape.
+      const injectPromptText = vi.fn(async () => { set(''); });
+      installSubmitGate({ agent: 'bolt', submitButtonSelector: '#send', injectPromptText });
+      await settle();
+      mockSendMessage.mockResolvedValue({ decision: { kind: 'block', replacement: 'the improved prompt' } });
+
+      lastInterceptor()(makeEvent(), 'ship this to production now', INPUT, composer);
+      await vi.waitFor(() => expect(emitted()).toContain('submit_replacement_sent'));
+      expect(emitted()).not.toContain('submit_hold_substitution_failed');
+    });
+  });
+
   describe('re-issuing the original (live: "Use original" left the prompt stuck)', () => {
     function composerWith(text: string): HTMLElement {
       const el = document.createElement('div');

--- a/src/ext-browser/content/agents/install-submit-gate.ts
+++ b/src/ext-browser/content/agents/install-submit-gate.ts
@@ -42,8 +42,14 @@ export interface InstallSubmitGateOptions {
   agent: string;
   /** The site's real send control, clicked to submit what is in the composer. */
   submitButtonSelector: string;
-  /** The agent's own inject-and-send helper (simulated paste + submit). */
-  injectPromptText: (text: string) => Promise<void>;
+  /**
+   * The agent's own inject-and-send helper (simulated paste + submit).
+   *
+   * Returns FALSE when it could not deliver and degraded to the clipboard.
+   * `void` is accepted, and read as success, so an agent that does not report an
+   * outcome behaves exactly as it always has — see `deliverReplacement`.
+   */
+  injectPromptText: (text: string) => Promise<boolean | void>;
 }
 
 export function installSubmitGate(opts: InstallSubmitGateOptions): void {
@@ -180,8 +186,14 @@ export function installSubmitGate(opts: InstallSubmitGateOptions): void {
         // response-stop inject path uses; the worker's cross-page dedup
         // collapses the echo.
         sendToSw({ type: 'nexpath:prompt-injected', projectRoot: projectRootOf(), text });
-        await opts.injectPromptText(text);
-        return true;
+        // An inject that degraded to the clipboard KNOWS it did. This used to
+        // return true regardless, so the gate then spent its whole
+        // send-verification window hunting the composer for text it had already
+        // been told was never put there — eight seconds of waiting for an answer
+        // that was available immediately. Only an explicit `false` is treated as
+        // failure, so an injector that reports nothing is read as success and
+        // keeps today's behaviour exactly.
+        return await opts.injectPromptText(text) !== false;
       },
       // The original is still sitting in the composer — we cancelled the user's
       // own submit, so re-issuing means pressing the site's send control. The

--- a/src/ext-browser/content/agents/landing-check.readLandingText.test.ts
+++ b/src/ext-browser/content/agents/landing-check.readLandingText.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/**
+ * `readLandingText` — the composer read a landing check has to use.
+ *
+ * These tests pin the defect the reader exists for: on every composer this kit
+ * targets, a MULTI-LINE prompt is rendered as separate BLOCK elements, and
+ * `textContent` concatenates those blocks with no separator at all. The text
+ * being looked for has had its newlines normalised to spaces, so the two can
+ * never match — at any prompt length.
+ *
+ * The strings below are not invented: they are the shapes measured live on
+ * Bolt's real ProseMirror composer in Chrome on 2026-08-27, where `textContent`
+ * failed at 300 / 2,500 / 8,000 / 20,000 and 50,000 characters while the text
+ * sat perfectly in the composer, and `innerText` matched at every one.
+ */
+import { describe, expect, it } from 'vitest';
+import { hasTextLanded, readLandingText } from './landing-check.js';
+
+/** A ProseMirror/CodeMirror-shaped composer: one block element per line. */
+function blockComposer(lines: readonly string[]): HTMLElement {
+  const el = document.createElement('div');
+  for (const line of lines) {
+    const p = document.createElement('p');
+    p.textContent = line;
+    el.appendChild(p);
+  }
+  return el;
+}
+
+/**
+ * jsdom does not implement `innerText`, so a real browser's value is supplied
+ * explicitly. A browser joins block children with newlines — that is the whole
+ * difference this reader depends on.
+ */
+function withInnerText(el: HTMLElement, value: string): HTMLElement {
+  Object.defineProperty(el, 'innerText', { value, configurable: true });
+  return el;
+}
+
+describe('readLandingText — why textContent cannot be trusted here', () => {
+  const PROMPT = 'Scope:\n- Export a single invoice\n\nAcceptance:\n1. Button appears';
+  const LINES = ['Scope:', '- Export a single invoice', 'Acceptance:', '1. Button appears'];
+
+  it('textContent runs the blocks together, so the landing check FAILS on text that DID land', () => {
+    const composer = blockComposer(LINES);
+    // This is the exact failure: the words are all there, in order, correct.
+    expect(composer.textContent).toBe('Scope:- Export a single invoiceAcceptance:1. Button appears');
+    expect(hasTextLanded(composer.textContent ?? '', PROMPT)).toBe(false);
+  });
+
+  it('the rendered read matches the same landed text', () => {
+    const composer = withInnerText(blockComposer(LINES), LINES.join('\n'));
+    expect(hasTextLanded(readLandingText(composer), PROMPT)).toBe(true);
+  });
+
+  it('fails identically at every size — this is not a timing or length problem', () => {
+    for (const repeats of [1, 20, 200, 2_000]) {
+      const lines = Array.from({ length: repeats }, () => LINES).flat();
+      const body = Array.from({ length: repeats }, () => PROMPT).join('\n');
+      const raw = blockComposer(lines);
+      const rendered = withInnerText(blockComposer(lines), lines.join('\n'));
+      expect(hasTextLanded(raw.textContent ?? '', body)).toBe(false);
+      expect(hasTextLanded(readLandingText(rendered), body)).toBe(true);
+    }
+  });
+
+  it('a SINGLE-line prompt was never affected — which is why this went unnoticed', () => {
+    const single = 'Add a dark mode toggle';
+    const composer = blockComposer([single]);
+    expect(hasTextLanded(composer.textContent ?? '', single)).toBe(true);
+  });
+});
+
+describe('readLandingText — the fallback', () => {
+  it('falls back to textContent when innerText is ABSENT (jsdom, and any partial DOM)', () => {
+    const composer = blockComposer(['one', 'two']);
+    expect('innerText' in composer).toBe(false);
+    expect(readLandingText(composer)).toBe(composer.textContent);
+  });
+
+  it('falls back when innerText is EMPTY but the element holds text (an unrendered composer)', () => {
+    // A display:none composer reports '' from innerText; reporting an empty box
+    // for an element that demonstrably holds text would be a worse answer.
+    const composer = withInnerText(blockComposer(['hidden but present']), '');
+    expect(readLandingText(composer)).toBe('hidden but present');
+  });
+
+  it('prefers innerText whenever it carries text', () => {
+    const composer = withInnerText(blockComposer(['a', 'b']), 'a\nb');
+    expect(readLandingText(composer)).toBe('a\nb');
+  });
+
+  it('a genuinely empty composer reads as empty by either route', () => {
+    const composer = withInnerText(document.createElement('div'), '');
+    expect(readLandingText(composer)).toBe('');
+    // and an empty read is never "landed" — the blank-text guard still holds
+    expect(hasTextLanded(readLandingText(composer), 'anything')).toBe(false);
+  });
+
+  it('tolerates a null textContent without throwing', () => {
+    expect(readLandingText({ textContent: null })).toBe('');
+    expect(readLandingText({})).toBe('');
+  });
+});

--- a/src/ext-browser/content/agents/landing-check.ts
+++ b/src/ext-browser/content/agents/landing-check.ts
@@ -30,6 +30,45 @@ export function normalizeForLanding(value: string): string {
 }
 
 /**
+ * Read a composer's text the way a landing check has to see it.
+ *
+ * ── WHY `innerText` AND NOT `textContent` ────────────────────────────────────
+ * Every composer this kit targets renders a multi-line prompt as separate BLOCK
+ * elements — one `<p>` per line on TipTap/ProseMirror (Bolt, Lovable), one
+ * `.cm-line` per line on CodeMirror 6 (Replit). `textContent` concatenates those
+ * blocks with NO separator at all, while the text being looked for has its
+ * newlines normalised to spaces. The two can never match:
+ *
+ *   inserted     "Scope:\n- Export one invoice"
+ *   textContent  "Scope:- Export one invoice"     ← nothing between the blocks
+ *   needle       "Scope: - Export one invoice"    ← the newline became a space
+ *
+ * Measured live on Bolt's real composer (2026-08-27) at 300 / 2,500 / 8,000 /
+ * 20,000 and 50,000 characters: `textContent` failed at EVERY size while the
+ * text sat perfectly in the composer, and `innerText` matched at every size.
+ * This is NOT a timing problem, and no landing budget can make it pass — which
+ * is what the budget being raised from 900 ms to 6 s was trying to fix.
+ *
+ * The capture half of this codebase already knew: `readComposerText` in bolt.ts,
+ * lovable.ts and replit.ts joins `<p>` / `.cm-line` with '\n' and says exactly
+ * this in its comment ("textContent alone would drop the line breaks of a
+ * multi-line prompt"). The inject half never got the same treatment.
+ *
+ * ── WHY THE FALLBACK ─────────────────────────────────────────────────────────
+ * `innerText` is layout-dependent: it is '' for an element that is not rendered.
+ * Falling back to `textContent` keeps a hidden-composer read honest instead of
+ * reporting an empty box — and it is also what keeps this working under jsdom,
+ * which does not implement `innerText` at all.
+ */
+export function readLandingText(element: {
+  innerText?: string;
+  textContent?: string | null;
+}): string {
+  const rendered = typeof element.innerText === 'string' ? element.innerText : '';
+  return rendered.trim().length > 0 ? rendered : (element.textContent ?? '');
+}
+
+/**
  * True only when `text` is non-blank AND the whole of it (whitespace-normalised)
  * is present in `container`. A blank `text` is never "landed" — refusing it here
  * is what stops an empty injection from reaching the auto-submit.

--- a/src/ext-browser/content/agents/replit-inject.ts
+++ b/src/ext-browser/content/agents/replit-inject.ts
@@ -39,5 +39,12 @@ export async function injectPromptText(text: string): Promise<void> {
   // nothing on this CodeMirror 6 composer, even with the document focused.
   await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
     pasteChunkChars: 800,
+    // Replit's composer is CodeMirror 6, which renders each line of a multi-line
+    // prompt as its own `.cm-line`. `textContent` runs those together with no
+    // separator, so the landing check could never recognise an enhanced prompt
+    // that HAD arrived. Same defect, same fix, as Bolt's ProseMirror — and it is
+    // the same one replit.ts's own `readComposerText` already works around on
+    // the capture side. See landing-check.ts.
+    useRenderedLandingText: true,
   });
 }

--- a/src/ext-browser/content/agents/replit-inject.ts
+++ b/src/ext-browser/content/agents/replit-inject.ts
@@ -26,7 +26,7 @@ const INPUT_SELECTOR = '.cm-content[contenteditable="true"]';
 // Replit's real send control — the Enter-didn't-submit fallback clicks it.
 const SUBMIT_BUTTON_SELECTOR = '[data-cy="ai-prompt-submit"]';
 
-export async function injectPromptText(text: string): Promise<void> {
+export async function injectPromptText(text: string): Promise<boolean> {
   // Replit's composer has a PASTE SIZE LIMIT. Measured live on a real project
   // 2026-08-26: 1,500 characters landed in full; 2,200 and 4,000 landed NOTHING,
   // silently. Real enhanced prompts are 2.1-2.5k, so every one was discarded —
@@ -37,7 +37,7 @@ export async function injectPromptText(text: string): Promise<void> {
   // to accumulate exactly (800 → 1,600 → 2,400). `execCommand('insertText')` is
   // NOT an alternative here: it was measured returning false and inserting
   // nothing on this CodeMirror 6 composer, even with the document focused.
-  await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
+  return await injectViaSimulatedPaste(INPUT_SELECTOR, text, SUBMIT_BUTTON_SELECTOR, {
     pasteChunkChars: 800,
     // Replit's composer is CodeMirror 6, which renders each line of a multi-line
     // prompt as its own `.cm-line`. `textContent` runs those together with no

--- a/src/ext-browser/content/agents/replit-inject.ts
+++ b/src/ext-browser/content/agents/replit-inject.ts
@@ -46,6 +46,21 @@ export async function injectPromptText(text: string): Promise<void> {
     // the same one replit.ts's own `readComposerText` already works around on
     // the capture side. See landing-check.ts.
     useRenderedLandingText: true,
+    // Deliver through CodeMirror 6's own `EditorView` transaction in the page
+    // world. Measured live on a real Repl (2026-08-27) — 55 / 2,500 / 8,000
+    // characters each landed with the document matching exactly, in 2-6 ms, with
+    // no paste event, no clipboard, and no size rule.
+    //
+    // This is what lets a full enhanced prompt reach the bridge at all: the
+    // bridge is normally skipped for a size-limited composer, and a real
+    // enhanced prompt is always over `pasteChunkChars`, so the skip fired every
+    // single time. The transaction has no size limit, so the skip no longer
+    // applies to it.
+    //
+    // `pasteChunkChars` above stays exactly as it is — it is now the FALLBACK,
+    // for a page with no editor view or a transaction that did not take, and
+    // that fallback is the path already proven live on this composer.
+    useEditorApiInsert: true,
     // ⛔ `useDirectInsertFirst` is deliberately NOT set here, unlike Bolt.
     //
     // It would make CodeMirror 6 receive a select-all + `execCommand('insertText')`

--- a/src/ext-browser/content/agents/replit-inject.ts
+++ b/src/ext-browser/content/agents/replit-inject.ts
@@ -46,5 +46,12 @@ export async function injectPromptText(text: string): Promise<void> {
     // the same one replit.ts's own `readComposerText` already works around on
     // the capture side. See landing-check.ts.
     useRenderedLandingText: true,
+    // Same reason as Bolt. Note this only reaches the bridge for a prompt SHORT
+    // enough to skip chunking — a chunked body still bypasses the bridge
+    // entirely, which is the next phase's problem, not this one's. And CodeMirror
+    // 6 was measured refusing `execCommand('insertText')` outright, so on Replit
+    // this may simply fall through to the paste it already uses today. Harmless
+    // either way: both routes are attempted, and neither is removed.
+    useDirectInsertFirst: true,
   });
 }

--- a/src/ext-browser/content/agents/replit-inject.ts
+++ b/src/ext-browser/content/agents/replit-inject.ts
@@ -46,12 +46,20 @@ export async function injectPromptText(text: string): Promise<void> {
     // the same one replit.ts's own `readComposerText` already works around on
     // the capture side. See landing-check.ts.
     useRenderedLandingText: true,
-    // Same reason as Bolt. Note this only reaches the bridge for a prompt SHORT
-    // enough to skip chunking — a chunked body still bypasses the bridge
-    // entirely, which is the next phase's problem, not this one's. And CodeMirror
-    // 6 was measured refusing `execCommand('insertText')` outright, so on Replit
-    // this may simply fall through to the paste it already uses today. Harmless
-    // either way: both routes are attempted, and neither is removed.
-    useDirectInsertFirst: true,
+    // ⛔ `useDirectInsertFirst` is deliberately NOT set here, unlike Bolt.
+    //
+    // It would make CodeMirror 6 receive a select-all + `execCommand('insertText')`
+    // on a path where it has only ever received a paste — and the one measurement
+    // we have of CM6 refusing that command was taken from the isolated world, not
+    // from this page-world sequence, and was never verified live. "Returns false
+    // and inserts nothing" is almost certainly harmless, but "almost certainly" is
+    // not a basis for putting a new first touch on the user's composer.
+    //
+    // It also buys little here: the flag only reaches the bridge for a prompt
+    // SHORT enough to skip chunking, and a real enhanced prompt (2.1-2.5k) is
+    // always chunked, so it bypasses the bridge entirely. Replit's own route —
+    // including whether the bridge can carry a chunked body at all — is decided in
+    // its own phase, against a live composer. Until then Replit keeps today's
+    // shipped bridge order exactly, and still gets the landing-check fix above.
   });
 }

--- a/src/ext-browser/content/composer-submit-gate.ts
+++ b/src/ext-browser/content/composer-submit-gate.ts
@@ -104,6 +104,22 @@ export interface ComposerSubmitGate {
  */
 const SEND_VERIFY_TIMEOUT_MS = 8_000;
 const SEND_VERIFY_POLL_MS = 150;
+/**
+ * A tighter cadence for the FIRST second, then the steady one above.
+ *
+ * A send that works clears the composer within a few frames, so the answer is
+ * almost always available long before the first 150 ms tick — and this check
+ * sits directly in front of the user, between their click and the prompt
+ * appearing in the chat. The wide cadence exists for the tail (a site slow to
+ * reconcile), which is exactly where it still applies.
+ *
+ * Ceilings are untouched: same total wall clock, same poll-count bound, same
+ * verdict. Only the moment a SUCCESS becomes observable moves earlier — and a
+ * denser early sample also makes `sawIt` below more likely to catch the text
+ * before it leaves, which is what stops a real send being reported unverified.
+ */
+const SEND_VERIFY_FAST_POLL_MS = 50;
+const SEND_VERIFY_FAST_WINDOW_MS = 1_000;
 
 function submitIdFor(prompt: string): string {
   let h = 5381;
@@ -142,7 +158,14 @@ export function createComposerSubmitGate(deps: ComposerSubmitGateDeps): Composer
     const needle = normalize(text);
     const timeoutMs = deps.verify?.timeoutMs ?? SEND_VERIFY_TIMEOUT_MS;
     const pollMs = deps.verify?.pollMs ?? SEND_VERIFY_POLL_MS;
-    const maxPolls = Math.ceil(timeoutMs / pollMs);
+    // Never SLOWER than a caller explicitly asked for: an injected `pollMs` below
+    // the fast cadence wins, so a test that pins a cadence keeps exactly it.
+    const fastPollMs = Math.min(SEND_VERIFY_FAST_POLL_MS, pollMs);
+    const fastPolls = Math.ceil(Math.min(timeoutMs, SEND_VERIFY_FAST_WINDOW_MS) / fastPollMs);
+    const slowPolls = Math.ceil(Math.max(0, timeoutMs - SEND_VERIFY_FAST_WINDOW_MS) / pollMs);
+    // Both bounds preserved: the same clock ceiling, and still bounded by a poll
+    // COUNT so a stopped clock cannot turn this into an unbounded wait.
+    const maxPolls = fastPolls + slowPolls;
     // `sawIt` is what stops "the text is not there" from meaning "it was sent".
     // If the paste never landed, the text was NEVER in the box, and reporting
     // that as delivered would silently drop the user's turn.
@@ -154,7 +177,7 @@ export function createComposerSubmitGate(deps: ComposerSubmitGateDeps): Composer
       if (norm.length === 0) return true;                  // box cleared ⇒ sent
       if (needle.length > 0 && norm.includes(needle)) sawIt = true;
       else if (sawIt) return true;                          // was there, now gone
-      if (i < maxPolls) await new Promise((r) => setTimeout(r, pollMs));
+      if (i < maxPolls) await new Promise((r) => setTimeout(r, i < fastPolls ? fastPollMs : pollMs));
     }
     return false;
   };

--- a/src/ext-browser/content/composer-submit-gate.verify-cadence.test.ts
+++ b/src/ext-browser/content/composer-submit-gate.verify-cadence.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+/**
+ * The send-verification cadence.
+ *
+ * This check sits directly in front of the user, between their click and the
+ * prompt appearing in the chat, and a send that works clears the composer within
+ * a few frames. On the steady 150 ms cadence the answer was routinely available
+ * long before it was read; the wide cadence exists for the tail — a site slow to
+ * reconcile — which is exactly where it still applies.
+ *
+ * What is pinned here is that the tightening changed only WHEN the answer is
+ * read: the clock ceiling, the poll-count bound, and every verdict are the same.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createComposerSubmitGate, type ComposerDecision } from './composer-submit-gate.js';
+
+beforeEach(() => { vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); });
+
+/** The gate's budget is not what is under test; keep it out of the way. */
+function stubBudget() {
+  return () => ({
+    run: async <T>(fn: () => Promise<T>) => ({ timedOut: false, value: await fn() }),
+    remaining: () => 60_000,
+  }) as unknown as ReturnType<typeof import('../adapters/submit-hold-budget.js').createHoldBudget>;
+}
+
+function makeGate(over: Record<string, unknown> = {}) {
+  const events: string[] = [];
+  let composerText = '';
+  const deps = {
+    agent: 'bolt',
+    isArmed: () => true,
+    decide: async (): Promise<ComposerDecision> => ({ kind: 'block', replacement: REPLACEMENT }),
+    deliverReplacement: async () => true,
+    reissueOriginal: async () => true,
+    readComposerText: () => composerText,
+    emit: (event: string) => { events.push(event); },
+    makeBudget: stubBudget(),
+    ...over,
+  };
+  const gate = createComposerSubmitGate(deps as Parameters<typeof createComposerSubmitGate>[0]);
+  return { gate, events, setComposer: (t: string) => { composerText = t; } };
+}
+
+function makeEvent(): Event {
+  return { preventDefault: vi.fn(), stopImmediatePropagation: vi.fn() } as unknown as Event;
+}
+
+const PROMPT = 'ship this to production now';
+const REPLACEMENT = 'the improved prompt with acceptance criteria';
+
+describe('a send that clears quickly is observed quickly', () => {
+  it('⭐ verifies inside the first 150 ms tick — the old cadence could not have read it yet', async () => {
+    const { gate, events, setComposer } = makeGate();
+    setComposer(REPLACEMENT);                     // delivered, not yet sent
+
+    gate.maybeIntercept(makeEvent(), PROMPT);
+    await vi.advanceTimersByTimeAsync(0);         // let the decision resolve
+    setComposer('');                              // the site clears it
+
+    // Under the steady 150 ms cadence the second read landed at 150 ms, so
+    // nothing could be reported here. The dense early cadence reads at 50 ms.
+    await vi.advanceTimersByTimeAsync(120);
+    expect(events).toContain('submit_replacement_sent');
+  });
+
+  it('a caller-pinned cadence is never made SLOWER than it asked for', async () => {
+    // An explicit pollMs below the fast cadence must win, so a test or a caller
+    // that pins a cadence keeps exactly it.
+    const { gate, events, setComposer } = makeGate({ verify: { timeoutMs: 300, pollMs: 20 } });
+    setComposer(REPLACEMENT);
+
+    gate.maybeIntercept(makeEvent(), PROMPT);
+    await vi.advanceTimersByTimeAsync(0);
+    setComposer('');
+
+    await vi.advanceTimersByTimeAsync(40);
+    expect(events).toContain('submit_replacement_sent');
+  });
+});
+
+describe('the ceiling is unchanged', () => {
+  it('a composer that never clears still fails only at the END of the window', async () => {
+    const { gate, events, setComposer } = makeGate({ verify: { timeoutMs: 1_000, pollMs: 150 } });
+    setComposer(REPLACEMENT);                     // delivered, and it never leaves
+
+    gate.maybeIntercept(makeEvent(), PROMPT);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Well inside the window: no verdict yet.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(events).not.toContain('submit_hold_substitution_failed');
+
+    // Past it: the same failure verdict as before, at the same ceiling.
+    await vi.advanceTimersByTimeAsync(1_200);
+    expect(events).toContain('submit_hold_substitution_failed');
+  });
+});

--- a/src/ext-browser/content/inject-dispatch.ts
+++ b/src/ext-browser/content/inject-dispatch.ts
@@ -12,7 +12,14 @@ import { injectPromptText as injectPromptTextLovable } from './agents/lovable-in
 import { clipboardFallback } from './agents/inject-kit.js';
 import { resolveAgentFromHostname } from './agents/agent-hosts.js';
 
-const INJECTORS: Record<string, (text: string) => Promise<void>> = {
+/**
+ * `Promise<unknown>` because the injectors no longer agree on a return type, and
+ * deliberately so: the two whose delivery outcome is consumed at the submit gate
+ * report it, and the one that is not on that path was left exactly as it was.
+ * Nothing on THIS path reads the value — both callers below fire and forget — so
+ * the loosest type that accepts every injector is the honest one here.
+ */
+const INJECTORS: Record<string, (text: string) => Promise<unknown>> = {
   replit: injectPromptTextReplit,
   bolt: injectPromptTextBolt,
   lovable: injectPromptTextLovable,
@@ -20,7 +27,7 @@ const INJECTORS: Record<string, (text: string) => Promise<void>> = {
 
 /** Inject `text` via the current host's agent injector; unknown hosts degrade
  * to the clipboard fallback rather than silently doing nothing. */
-export function injectPromptText(text: string): Promise<void> {
+export function injectPromptText(text: string): Promise<unknown> {
   const injector = INJECTORS[resolveAgentFromHostname(window.location.hostname)];
   return injector ? injector(text) : clipboardFallback(text);
 }

--- a/src/ext-browser/inject/main-world-bridge.editor-api.test.ts
+++ b/src/ext-browser/inject/main-world-bridge.editor-api.test.ts
@@ -172,14 +172,34 @@ describe('useEditorApiInsert — delivery through the editor\'s own API', () => 
   });
 });
 
-describe('useEditorApiInsert — when the route is unavailable, nothing is touched', () => {
-  it('⭐ no editor view: reports false and dispatches NO paste (the composer keeps the user\'s prompt)', async () => {
+describe('useEditorApiInsert — when the route is unavailable', () => {
+  it('⭐ WITHIN the paste limit: falls through to the shipped paste rather than degrading', async () => {
+    // A page that stops exposing an editor view must land where it landed BEFORE
+    // this route existed — on the bridge's own paste — not on the clipboard. The
+    // paste is exactly as safe here as it always was, because this body fits.
+    const { input, pastes, doc } = makeComposer();     // no cmView at all
+    input.addEventListener('paste', (ev) => {
+      const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+      input.textContent = dt ? dt.getData('text/plain') : '';
+    });
+    stubExecCommand(() => true);
+
+    const single = 'Add a dark mode toggle';
+    const reply = nextResult();
+    request({ requestId: 'api-fall-1', selector: SELECTOR, text: single, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: true });
+    expect(pastes).toEqual([single]);
+    expect(doc()).toBe('');   // and the editor API was never available to use
+  });
+
+  it('⭐ OVER the paste limit: reports false and dispatches NO paste (the composer keeps the user\'s prompt)', async () => {
     const { input, pastes } = makeComposer();          // no cmView at all
     input.textContent = 'the user’s own prompt';
     const exec = stubExecCommand(() => true);
 
     const reply = nextResult();
-    request({ requestId: 'api-4', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+    request({ requestId: 'api-4', selector: SELECTOR, text: BODY, useEditorApiInsert: true, bodyExceedsPasteLimit: true });
 
     expect(await reply).toMatchObject({ landed: false });
     expect(pastes).toEqual([]);
@@ -192,7 +212,7 @@ describe('useEditorApiInsert — when the route is unavailable, nothing is touch
     stubExecCommand(() => true);
 
     const reply = nextResult();
-    request({ requestId: 'api-5', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+    request({ requestId: 'api-5', selector: SELECTOR, text: BODY, useEditorApiInsert: true, bodyExceedsPasteLimit: true });
 
     expect(await reply).toMatchObject({ landed: false });
     expect(pastes).toEqual([]);
@@ -203,7 +223,7 @@ describe('useEditorApiInsert — when the route is unavailable, nothing is touch
     stubExecCommand(() => true);
 
     const reply = nextResult();
-    request({ requestId: 'api-6', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+    request({ requestId: 'api-6', selector: SELECTOR, text: BODY, useEditorApiInsert: true, bodyExceedsPasteLimit: true });
 
     expect(await reply).toMatchObject({ landed: false });
     expect(pastes).toEqual([]);
@@ -215,7 +235,7 @@ describe('useEditorApiInsert — when the route is unavailable, nothing is touch
     stubExecCommand(() => true);
 
     const reply = nextResult();
-    request({ requestId: 'api-7', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+    request({ requestId: 'api-7', selector: SELECTOR, text: BODY, useEditorApiInsert: true, bodyExceedsPasteLimit: true });
 
     expect(await reply).toMatchObject({ landed: false });
     expect(pastes).toEqual([]);

--- a/src/ext-browser/inject/main-world-bridge.editor-api.test.ts
+++ b/src/ext-browser/inject/main-world-bridge.editor-api.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+/**
+ * The page-world bridge's editor-API route — `useEditorApiInsert`.
+ *
+ * This route exists for the one composer neither other route serves. Measured
+ * live on a real Repl (2026-08-27):
+ *
+ *   execCommand('insertText')          returns false, inserts nothing
+ *   paste                              works, but the composer has a SIZE LIMIT
+ *   EditorView transaction             55 / 2,500 / 8,000 chars, doc exact, 2-6 ms
+ *
+ * Two properties below are the ones that matter and are easy to lose in a
+ * refactor:
+ *
+ *   1. It verifies against the editor's DOCUMENT, not the DOM. CodeMirror 6
+ *      virtualises — that live composer rendered 27 of ~337 lines for an 8,000
+ *      character body — so any DOM-based check reports a long prompt as missing
+ *      when it is perfectly present.
+ *
+ *   2. When the route is unavailable it touches NOTHING. The caller that asks
+ *      for it is the one whose composer drops an over-limit paste, so falling
+ *      through to the bridge's whole-body paste would select-all and leave the
+ *      user's own prompt deleted with nothing in its place.
+ */
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(async () => {
+  if (typeof globalThis.DataTransfer === 'undefined') {
+    vi.stubGlobal('DataTransfer', class {
+      private data = new Map<string, string>();
+      setData(format: string, data: string): void { this.data.set(format, data); }
+      getData(format: string): string { return this.data.get(format) ?? ''; }
+    });
+  }
+  if (typeof globalThis.ClipboardEvent === 'undefined') {
+    vi.stubGlobal('ClipboardEvent', class extends Event {
+      clipboardData: unknown;
+      constructor(type: string, init: { clipboardData?: unknown } & EventInit = {}) {
+        super(type, init);
+        this.clipboardData = init.clipboardData;
+      }
+    });
+  }
+  await import('./main-world.js'); // registers the bridge listener
+});
+
+let restoreExec: (() => void) | null = null;
+
+beforeEach(() => { document.body.innerHTML = ''; });
+afterEach(() => { restoreExec?.(); restoreExec = null; document.body.innerHTML = ''; });
+
+function stubExecCommand(impl: (command: string, value: string) => boolean): { calls: string[] } {
+  const calls: string[] = [];
+  const target = document as unknown as { execCommand?: unknown };
+  const original = target.execCommand;
+  target.execCommand = (command: string, _ui: boolean, value: string): boolean => {
+    calls.push(command);
+    return impl(command, value);
+  };
+  restoreExec = () => { target.execCommand = original; };
+  return { calls };
+}
+
+interface FakeViewOptions {
+  /** Some builds expose the view under `cmView.view`, others as `cmView` itself. */
+  wrapped?: boolean;
+  /** Transform what the transaction actually stores (to model a refusal). */
+  store?: (insert: string) => string;
+  /** Make dispatch throw, as a hostile/incompatible build would. */
+  throws?: boolean;
+  /**
+   * How much of the document the DOM shows. CodeMirror 6 renders only the
+   * viewport, so the DOM is routinely a PREFIX of the real document.
+   */
+  renderChars?: number;
+}
+
+function makeComposer(view?: FakeViewOptions): { input: HTMLElement; pastes: string[]; doc: () => string } {
+  const input = document.createElement('div');
+  input.className = 'cm-content';
+  input.setAttribute('contenteditable', 'true');
+  document.body.appendChild(input);
+  Object.defineProperty(input, 'getClientRects', { value: () => [{}] });
+
+  const pastes: string[] = [];
+  input.addEventListener('paste', (ev) => {
+    const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+    pastes.push(dt ? dt.getData('text/plain') : '');
+  });
+
+  let doc = '';
+  if (view) {
+    const editorView = {
+      get state() { return { doc: { length: doc.length, toString: () => doc } }; },
+      dispatch(spec: { changes: { from: number; to: number; insert: string } }): void {
+        if (view.throws) throw new Error('incompatible build');
+        doc = view.store ? view.store(spec.changes.insert) : spec.changes.insert;
+        // Model virtualisation: the DOM shows only part of the document.
+        input.textContent = view.renderChars === undefined ? doc : doc.slice(0, view.renderChars);
+      },
+    };
+    Object.defineProperty(input, 'cmView', {
+      configurable: true,
+      value: view.wrapped ? { view: editorView } : editorView,
+    });
+  }
+
+  return { input, pastes, doc: () => doc };
+}
+
+function request(detail: Record<string, unknown>): void {
+  window.dispatchEvent(new MessageEvent('message', {
+    data: { type: 'nexpath:inject-request', ...detail },
+    source: window as unknown as MessageEventSource,
+  }));
+}
+
+function nextResult(): Promise<{ requestId: string; landed: boolean }> {
+  return new Promise((resolve) => {
+    const onMsg = (ev: MessageEvent): void => {
+      const m = ev.data as { type?: string; requestId?: string; landed?: boolean };
+      if (m?.type !== 'nexpath:inject-result') return;
+      window.removeEventListener('message', onMsg);
+      resolve(m as { requestId: string; landed: boolean });
+    };
+    window.addEventListener('message', onMsg);
+  });
+}
+
+const SELECTOR = '.cm-content[contenteditable="true"]';
+const BODY = 'Scope:\nExport a single invoice\n\nAcceptance:\nButton appears';
+
+describe('useEditorApiInsert — delivery through the editor\'s own API', () => {
+  it('⭐ replaces the document in one transaction, and dispatches NO paste', async () => {
+    const { pastes, doc } = makeComposer({ wrapped: true });
+    const exec = stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-1', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ requestId: 'api-1', landed: true });
+    expect(doc()).toBe(BODY);        // exact, not whitespace-approximate
+    expect(pastes).toEqual([]);      // no paste event at all
+    expect(exec.calls).toEqual([]);  // and no execCommand either
+  });
+
+  it('accepts a view exposed directly as `cmView` as well as under `cmView.view`', async () => {
+    const { doc } = makeComposer({ wrapped: false });
+    stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-2', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: true });
+    expect(doc()).toBe(BODY);
+  });
+
+  it('⭐ reports landed for a body the DOM only PARTLY renders (CM6 virtualises)', async () => {
+    // The live composer rendered 27 of ~337 lines for an 8,000-character body.
+    const long = `${BODY}\n`.repeat(200);
+    const { input, doc } = makeComposer({ wrapped: true, renderChars: 120 });
+    stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-3', selector: SELECTOR, text: long, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: true });
+    expect(doc()).toBe(long);
+    // Proof the DOM could not have answered this: it holds a fraction of the text.
+    expect((input.textContent ?? '').length).toBe(120);
+    expect(input.textContent!.length).toBeLessThan(long.length);
+  });
+});
+
+describe('useEditorApiInsert — when the route is unavailable, nothing is touched', () => {
+  it('⭐ no editor view: reports false and dispatches NO paste (the composer keeps the user\'s prompt)', async () => {
+    const { input, pastes } = makeComposer();          // no cmView at all
+    input.textContent = 'the user’s own prompt';
+    const exec = stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-4', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(pastes).toEqual([]);
+    expect(exec.calls).toEqual([]);
+    expect(input.textContent).toBe('the user’s own prompt');   // untouched
+  });
+
+  it('a dispatch that throws is reported false, and still dispatches no paste', async () => {
+    const { pastes } = makeComposer({ wrapped: true, throws: true });
+    stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-5', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(pastes).toEqual([]);
+  });
+
+  it('a transaction the editor did not fully accept is reported false', async () => {
+    const { pastes } = makeComposer({ wrapped: true, store: (t) => t.slice(0, 10) });
+    stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-6', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(pastes).toEqual([]);
+  });
+
+  it('an unrecognised cmView shape is refused by the guard, not thrown on', async () => {
+    const { input, pastes } = makeComposer();
+    Object.defineProperty(input, 'cmView', { configurable: true, value: { view: { nope: true } } });
+    stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({ requestId: 'api-7', selector: SELECTOR, text: BODY, useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(pastes).toEqual([]);
+  });
+
+  it('blank text is still refused before the editor is even resolved', async () => {
+    const { input, pastes, doc } = makeComposer({ wrapped: true });
+    input.textContent = 'the user was still typing this';
+
+    const reply = nextResult();
+    request({ requestId: 'api-8', selector: SELECTOR, text: '  \n ', useEditorApiInsert: true });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(doc()).toBe('');
+    expect(pastes).toEqual([]);
+    expect(input.textContent).toBe('the user was still typing this');
+  });
+});
+
+describe('the flag defaults OFF — the shipped bridge never looks for an editor view', () => {
+  it('LEFT OUT: pastes as shipped even when the composer exposes a view', async () => {
+    const { input, pastes, doc } = makeComposer({ wrapped: true });
+    // The shipped paste route: apply what is pasted, as a live editor would.
+    input.addEventListener('paste', (ev) => {
+      const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+      input.textContent = dt ? dt.getData('text/plain') : '';
+    });
+    stubExecCommand(() => true);
+
+    const single = 'Add a dark mode toggle';
+    const reply = nextResult();
+    request({ requestId: 'off-api-1', selector: SELECTOR, text: single });
+
+    expect(await reply).toMatchObject({ landed: true });
+    expect(pastes).toEqual([single]);   // the paste route ran
+    expect(doc()).toBe('');             // and the editor API was never used
+  });
+});

--- a/src/ext-browser/inject/main-world-bridge.insert-first.test.ts
+++ b/src/ext-browser/inject/main-world-bridge.insert-first.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+/**
+ * The page-world bridge's insertion ORDER — `useDirectInsertFirst`.
+ *
+ * Both routes the bridge has deliver the same text. They differ in one respect
+ * that is invisible from inside the bridge and very visible to the user: the
+ * paste route dispatches a `paste` event AT THE SITE, and the insertText route
+ * does not.
+ *
+ * On Chrome that is what raises "<site> wants to — See text and images copied to
+ * the clipboard": the site's own paste handler cannot read a synthetic event's
+ * clipboardData and falls back to `navigator.clipboard.read()`. So the assertion
+ * that actually matters below is a NEGATIVE one — that no paste event is
+ * dispatched at all when the direct insert lands.
+ *
+ * Firefox has never shown that prompt for exactly this reason: it drops a
+ * script-constructed ClipboardEvent's clipboardData, so the site's paste handler
+ * never runs and the insertion happens through execCommand instead. This flag
+ * selects that same route on Chrome, deliberately.
+ */
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(async () => {
+  if (typeof globalThis.DataTransfer === 'undefined') {
+    vi.stubGlobal('DataTransfer', class {
+      private data = new Map<string, string>();
+      setData(format: string, data: string): void { this.data.set(format, data); }
+      getData(format: string): string { return this.data.get(format) ?? ''; }
+    });
+  }
+  if (typeof globalThis.ClipboardEvent === 'undefined') {
+    vi.stubGlobal('ClipboardEvent', class extends Event {
+      clipboardData: unknown;
+      constructor(type: string, init: { clipboardData?: unknown } & EventInit = {}) {
+        super(type, init);
+        this.clipboardData = init.clipboardData;
+      }
+    });
+  }
+  await import('./main-world.js'); // registers the bridge listener
+});
+
+let restoreExec: (() => void) | null = null;
+
+afterEach(() => {
+  restoreExec?.();
+  restoreExec = null;
+  document.body.innerHTML = '';
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+/** Replace jsdom's absent/throwing execCommand with a controllable one. */
+function stubExecCommand(impl: (command: string, value: string) => boolean): {
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const target = document as unknown as { execCommand?: unknown };
+  const original = target.execCommand;
+  target.execCommand = (command: string, _ui: boolean, value: string): boolean => {
+    calls.push(command);
+    return impl(command, value);
+  };
+  restoreExec = () => { target.execCommand = original; };
+  return { calls };
+}
+
+/**
+ * A composer shaped like the real ones: an insertion becomes one block element
+ * per line, and `innerText` joins those blocks with newlines the way a browser
+ * does (jsdom implements neither on its own).
+ */
+function makeComposer(): { input: HTMLElement; pastes: string[]; apply: (text: string) => void } {
+  const input = document.createElement('div');
+  input.className = 'tiptap ProseMirror';
+  document.body.appendChild(input);
+  Object.defineProperty(input, 'getClientRects', { value: () => [{}] });
+  Object.defineProperty(input, 'innerText', {
+    configurable: true,
+    get: () => Array.from(input.querySelectorAll('p'), (p) => p.textContent ?? '').join('\n'),
+  });
+
+  const apply = (text: string): void => {
+    input.replaceChildren();
+    for (const line of text.split('\n')) {
+      const p = document.createElement('p');
+      p.textContent = line;
+      input.appendChild(p);
+    }
+  };
+
+  const pastes: string[] = [];
+  input.addEventListener('paste', (ev) => {
+    const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+    pastes.push(dt ? dt.getData('text/plain') : '');
+  });
+
+  return { input, pastes, apply };
+}
+
+function request(detail: Record<string, unknown>): void {
+  window.dispatchEvent(new MessageEvent('message', {
+    data: { type: 'nexpath:inject-request', ...detail },
+    source: window as unknown as MessageEventSource,
+  }));
+}
+
+function nextResult(): Promise<{ requestId: string; landed: boolean }> {
+  return new Promise((resolve) => {
+    const onMsg = (ev: MessageEvent): void => {
+      const m = ev.data as { type?: string; requestId?: string; landed?: boolean };
+      if (m?.type !== 'nexpath:inject-result') return;
+      window.removeEventListener('message', onMsg);
+      resolve(m as { requestId: string; landed: boolean });
+    };
+    window.addEventListener('message', onMsg);
+  });
+}
+
+const BODY = 'Scope:\n- Export a single invoice\n\nAcceptance:\n1. Button appears';
+
+describe('useDirectInsertFirst — the site never sees a paste when the direct insert lands', () => {
+  it('⭐ dispatches NO paste event at all — this is what removes the clipboard prompt', async () => {
+    const { input, pastes, apply } = makeComposer();
+    const exec = stubExecCommand((_c, value) => { apply(value); return true; });
+
+    const reply = nextResult();
+    request({
+      requestId: 'first-1', selector: '.tiptap.ProseMirror', text: BODY,
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+
+    expect(await reply).toMatchObject({ requestId: 'first-1', landed: true });
+    expect(exec.calls).toEqual(['insertText']);
+    expect(pastes).toEqual([]);                       // ← the whole point
+    expect(input.querySelectorAll('p').length).toBe(BODY.split('\n').length);
+  });
+
+  it('falls back to the paste when the editor refuses the command (Replit CM6 was measured doing exactly this)', async () => {
+    const { pastes, apply } = makeComposer();
+    const exec = stubExecCommand(() => false);        // inserts nothing, like CM6
+    // The composer still honours a paste.
+    document.querySelector('.tiptap.ProseMirror')!.addEventListener('paste', (ev) => {
+      const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+      apply(dt ? dt.getData('text/plain') : '');
+    });
+
+    const reply = nextResult();
+    request({
+      requestId: 'first-2', selector: '.tiptap.ProseMirror', text: BODY,
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+
+    expect(await reply).toMatchObject({ requestId: 'first-2', landed: true });
+    expect(exec.calls).toEqual(['insertText']);       // tried first...
+    expect(pastes).toEqual([BODY]);                   // ...then the paste carried it
+  });
+
+  it('reports landed:false when NEITHER route works — the content-side chain still takes over', async () => {
+    makeComposer();
+    stubExecCommand(() => false);
+
+    const reply = nextResult();
+    request({
+      requestId: 'first-3', selector: '.tiptap.ProseMirror', text: BODY,
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+
+    expect(await reply).toMatchObject({ requestId: 'first-3', landed: false });
+  });
+});
+
+describe('the flags default OFF — the shipped bridge is byte-identical', () => {
+  it('LEFT OUT (Lovable): paste goes FIRST and execCommand is never reached when it lands', async () => {
+    const { pastes, apply } = makeComposer();
+    const exec = stubExecCommand((_c, value) => { apply(value); return true; });
+    document.querySelector('.tiptap.ProseMirror')!.addEventListener('paste', (ev) => {
+      const dt = (ev as ClipboardEvent).clipboardData as { getData(f: string): string } | null;
+      apply(dt ? dt.getData('text/plain') : '');
+    });
+
+    // A SINGLE-line body: the shipped raw `textContent` read can see it, so this
+    // exercises the shipped order without depending on the landing-check fix.
+    const single = 'Add a dark mode toggle';
+    const reply = nextResult();
+    request({ requestId: 'off-1', selector: '.tiptap.ProseMirror', text: single });
+
+    expect(await reply).toMatchObject({ requestId: 'off-1', landed: true });
+    expect(pastes).toEqual([single]);   // paste first, exactly as shipped
+    expect(exec.calls).toEqual([]);     // and the retry was never needed
+  });
+
+  it('LEFT OUT: still retries through execCommand after a paste that does not land', async () => {
+    const { pastes, apply } = makeComposer();
+    const exec = stubExecCommand((_c, value) => { apply(value); return true; });
+    // No paste listener that applies anything — the paste is recorded but inert.
+
+    const single = 'Add a dark mode toggle';
+    const reply = nextResult();
+    request({ requestId: 'off-2', selector: '.tiptap.ProseMirror', text: single });
+
+    expect(await reply).toMatchObject({ requestId: 'off-2', landed: true });
+    expect(pastes).toEqual([single]);         // paste attempted first...
+    expect(exec.calls).toEqual(['insertText']); // ...then the shipped retry
+  });
+});
+
+describe('useRenderedLandingText reaches the bridge too', () => {
+  it('OPTED IN: a multi-line prompt that landed is reported landed', async () => {
+    const { apply } = makeComposer();
+    stubExecCommand((_c, value) => { apply(value); return true; });
+
+    const reply = nextResult();
+    request({
+      requestId: 'read-1', selector: '.tiptap.ProseMirror', text: BODY,
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+    expect(await reply).toMatchObject({ landed: true });
+  });
+
+  it('LEFT OUT: the same landed text is reported landed:false — shipped behaviour, preserved', async () => {
+    const { apply } = makeComposer();
+    stubExecCommand((_c, value) => { apply(value); return true; });
+
+    const reply = nextResult();
+    request({
+      requestId: 'read-2', selector: '.tiptap.ProseMirror', text: BODY,
+      useDirectInsertFirst: true,   // order flipped, but the RAW read still decides
+    });
+    expect(await reply).toMatchObject({ landed: false });
+  });
+});
+
+describe('guards that must not weaken', () => {
+  it('blank text is refused before anything touches the composer', async () => {
+    const { input, pastes, apply } = makeComposer();
+    apply('the user was still typing this');
+    const exec = stubExecCommand(() => true);
+
+    const reply = nextResult();
+    request({
+      requestId: 'blank-1', selector: '.tiptap.ProseMirror', text: '   \n  ',
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+
+    expect(await reply).toMatchObject({ landed: false });
+    expect(exec.calls).toEqual([]);
+    expect(pastes).toEqual([]);
+    expect(input.textContent).toBe('the user was still typing this');
+  });
+
+  it('a missing composer is refused, with both flags on', async () => {
+    stubExecCommand(() => true);
+    const reply = nextResult();
+    request({
+      requestId: 'none-1', selector: '.no-such-composer', text: BODY,
+      useRenderedLandingText: true, useDirectInsertFirst: true,
+    });
+    expect(await reply).toMatchObject({ landed: false });
+  });
+});

--- a/src/ext-browser/inject/main-world.ts
+++ b/src/ext-browser/inject/main-world.ts
@@ -349,6 +349,12 @@ interface InjectRequestMsg {
   useDirectInsertFirst?: boolean;
   /** See `editorApiInsert` below. Absent ⇒ false ⇒ the bridge never looks for an editor view. */
   useEditorApiInsert?: boolean;
+  /**
+   * True when this body is longer than the composer's paste size limit, so a
+   * whole-body paste would be DROPPED. Absent ⇒ false ⇒ pasting is safe, which
+   * is the case for every composer that has no such limit.
+   */
+  bodyExceedsPasteLimit?: boolean;
 }
 
 /**
@@ -494,6 +500,7 @@ function performMainWorldInject(
   useRendered: boolean,
   directInsertFirst: boolean,
   editorApiInsert: boolean,
+  bodyExceedsPasteLimit: boolean,
 ): boolean {
   // Blank text is never a real injection and both paths select-all first, so
   // honouring it would wipe the user's composer (see landing-check.ts).
@@ -504,16 +511,19 @@ function performMainWorldInject(
 
   if (editorApiInsert) {
     if (insertViaEditorApi(input, text)) return true;
-    // No editor view, or the transaction did not take. Report failure and touch
-    // NOTHING ELSE — deliberately not falling through to the paste below.
+    // No editor view, or the transaction did not take.
     //
-    // The caller that asks for this route is the one whose composer has a paste
-    // SIZE LIMIT, so the whole-body paste below is precisely what that composer
-    // drops. Attempting it would select-all first, leaving the user's own prompt
-    // deleted and nothing put in its place. Returning false instead hands the
-    // delivery straight back to the caller's own chain — which splits the body
-    // into sub-limit pieces and is the path that is proven live on that site.
-    return false;
+    // Whether it is safe to carry on depends entirely on ONE thing: would the
+    // whole-body paste below survive this composer? The caller that asks for
+    // this route is the one with a paste SIZE LIMIT, and that paste select-alls
+    // first — so for an over-limit body, attempting it would leave the user's
+    // own prompt deleted and nothing put in its place. Refuse, and hand the
+    // delivery back to the caller's chunked chain, which is proven live there.
+    if (bodyExceedsPasteLimit) return false;
+    // Within the limit, the paste is exactly as safe as it was before this route
+    // existed — and before it existed, this is the path that delivered. Falling
+    // through keeps that, so a page that stops exposing an editor view degrades
+    // to the shipped behaviour rather than to the clipboard.
   }
 
   // Which read decides "landed". Resolved once so the two attempts below can
@@ -557,9 +567,13 @@ if (typeof window.addEventListener === 'function') {
     const useRendered = msg.useRenderedLandingText === true;
     const directInsertFirst = msg.useDirectInsertFirst === true;
     const editorApiInsert = msg.useEditorApiInsert === true;
+    const bodyExceedsPasteLimit = msg.bodyExceedsPasteLimit === true;
     let landed = false;
     try {
-      landed = performMainWorldInject(msg.selector, msg.text, useRendered, directInsertFirst, editorApiInsert);
+      landed = performMainWorldInject(
+        msg.selector, msg.text, useRendered, directInsertFirst, editorApiInsert,
+        bodyExceedsPasteLimit,
+      );
     } catch { /* landed stays false — the content script's fallback chain takes over */ }
     window.postMessage(
       { type: 'nexpath:inject-result', requestId: msg.requestId, landed },

--- a/src/ext-browser/inject/main-world.ts
+++ b/src/ext-browser/inject/main-world.ts
@@ -11,7 +11,7 @@
  */
 
 import { resolveAgentFromHostname } from '../content/agents/agent-hosts.js';
-import { hasTextLanded } from '../content/agents/landing-check.js';
+import { hasTextLanded, readLandingText } from '../content/agents/landing-check.js';
 import { setupSubmitFlowPage, SUBMIT_FLOW_EVENT_TYPE } from './submit-flow-page.js';
 import { createSubmitGate } from './submit-gate.js';
 import { createDecisionChannel } from './submit-decision-channel.js';
@@ -343,23 +343,31 @@ interface InjectRequestMsg {
   requestId: string;
   selector: string;
   text: string;
+  /** See `useRendered` below. Absent ⇒ false ⇒ the shipped raw read. */
+  useRenderedLandingText?: boolean;
+  /** See `directInsertFirst` below. Absent ⇒ false ⇒ the shipped paste-first order. */
+  useDirectInsertFirst?: boolean;
 }
 
-function performMainWorldInject(selector: string, text: string): boolean {
-  // Blank text is never a real injection and the paste path select-alls first,
-  // so honouring it would wipe the user's composer (see landing-check.ts).
-  if (text.trim().length === 0) return false;
-  const candidates = [...document.querySelectorAll<HTMLElement>(selector)];
-  const input = candidates.find((el) => el.getClientRects().length > 0) ?? candidates[0];
-  if (!input) return false;
-
+/** Put the caret across the whole composer, so an insertion REPLACES it. */
+function selectAllIn(input: HTMLElement): void {
   input.focus();
   const selection = window.getSelection();
   const range = document.createRange();
   range.selectNodeContents(input);
   selection?.removeAllRanges();
   selection?.addRange(range);
+}
 
+/** The trusted-editing command path: synchronous, and never touches a clipboard. */
+function insertTextIn(input: HTMLElement, text: string): void {
+  selectAllIn(input);
+  try { document.execCommand('insertText', false, text); } catch { /* the caller re-checks */ }
+}
+
+/** The first-class paste path: what a rich editor's own paste handler consumes. */
+function firePasteIn(input: HTMLElement, text: string): void {
+  selectAllIn(input);
   const dataTransfer = new DataTransfer();
   dataTransfer.setData('text/plain', text);
   input.dispatchEvent(new ClipboardEvent('paste', {
@@ -367,21 +375,82 @@ function performMainWorldInject(selector: string, text: string): boolean {
     bubbles: true,
     cancelable: true,
   }));
-  if (hasTextLanded(input.textContent ?? '', text)) return true;
+}
 
-  // The editor ignored the synthetic paste — the trusted-editing command path.
-  // Re-select before the retry: without it the insert lands at the caret and the
+/**
+ * Insert `text` into the page's own composer, from the page's own world.
+ *
+ * ── `directInsertFirst`: WHY THE ORDER MATTERS ──────────────────────────────
+ * Both mechanisms below deliver the same text. They differ in one respect that
+ * is invisible from here and very visible to the user: the paste path dispatches
+ * a `paste` event AT THE SITE, and the insertText path does not.
+ *
+ * On Chrome that difference is what raises a permission prompt. A site whose
+ * paste handler receives an event it cannot read the clipboardData of falls back
+ * to `navigator.clipboard.read()` to find out what was pasted, and Chrome then
+ * asks the user "<site> wants to — See text and images copied to the clipboard".
+ * The bubble takes focus off the page, which is why injection appeared to resume
+ * only once the user answered it. Firefox never shows it, because a
+ * script-constructed ClipboardEvent's clipboardData is dropped there entirely,
+ * so the site's paste handler never runs and our code reaches execCommand
+ * instead — the same route this flag selects, deliberately, on Chrome.
+ *
+ * MEASURED on Bolt's real ProseMirror composer in Chrome (2026-08-27): a
+ * page-world `execCommand('insertText')` of a 2,400-character multi-line prompt
+ * returned true, landed the whole text exactly (10 paragraphs, blank lines
+ * preserved), took 2 ms, made ZERO clipboard calls, and never fired the site's
+ * paste handler.
+ *
+ * ── WHY THIS STAYS SYNCHRONOUS ───────────────────────────────────────────────
+ * Both mechanisms apply synchronously — the same measurement shows the composer
+ * already carrying the text on the very next statement. An earlier reading of
+ * these failures as "the editor has not finished reconciling" was wrong: what
+ * failed was the READ (`textContent` on a multi-line prompt — see
+ * landing-check.ts), not the timing. Nothing here needs to wait.
+ *
+ * ── FAIL-OPEN IS UNCHANGED ───────────────────────────────────────────────────
+ * Whichever order is taken, both mechanisms are attempted, and a false return
+ * hands the delivery back to the content script's own fallback chain exactly as
+ * before. This bridge can still only improve delivery, never block it.
+ */
+function performMainWorldInject(
+  selector: string,
+  text: string,
+  useRendered: boolean,
+  directInsertFirst: boolean,
+): boolean {
+  // Blank text is never a real injection and both paths select-all first, so
+  // honouring it would wipe the user's composer (see landing-check.ts).
+  if (text.trim().length === 0) return false;
+  const candidates = [...document.querySelectorAll<HTMLElement>(selector)];
+  const input = candidates.find((el) => el.getClientRects().length > 0) ?? candidates[0];
+  if (!input) return false;
+
+  // Which read decides "landed". Resolved once so the two attempts below can
+  // never be judged by different rules. See landing-check.ts for why the raw
+  // `textContent` read cannot recognise a multi-line prompt, and
+  // InjectOptions.useRenderedLandingText for why the fix is opt-in per agent.
+  const landed = (): boolean =>
+    hasTextLanded(useRendered ? readLandingText(input) : (input.textContent ?? ''), text);
+
+  if (directInsertFirst) {
+    insertTextIn(input, text);
+    if (landed()) return true;
+    // The editor does not honour the command (measured: Replit's CodeMirror 6
+    // returns false and inserts nothing). Fall through to the paste it does
+    // honour — the select-all inside replaces anything partially inserted.
+    firePasteIn(input, text);
+    return landed();
+  }
+
+  // Shipped order, byte-identical: paste first, then the trusted-editing retry.
+  // Each attempt re-selects — without it the insert lands at the caret and the
   // composer ends up holding OLD TEXT + NEW TEXT, which the landing check would
-  // then pass and the caller would auto-submit (the isolated-world twin has
-  // always re-selected — `focusAndSelectAll` in inject-kit.ts).
-  input.focus();
-  const retrySelection = window.getSelection();
-  const retryRange = document.createRange();
-  retryRange.selectNodeContents(input);
-  retrySelection?.removeAllRanges();
-  retrySelection?.addRange(retryRange);
-  try { document.execCommand('insertText', false, text); } catch { /* checked below */ }
-  return hasTextLanded(input.textContent ?? '', text);
+  // then pass and the caller would auto-submit.
+  firePasteIn(input, text);
+  if (landed()) return true;
+  insertTextIn(input, text);
+  return landed();
 }
 
 // Guarded like the fetch patch above: the module must load under partial
@@ -392,9 +461,14 @@ if (typeof window.addEventListener === 'function') {
     const msg = ev.data as InjectRequestMsg | null;
     if (!msg || msg.type !== 'nexpath:inject-request') return;
     if (typeof msg.requestId !== 'string' || typeof msg.selector !== 'string' || typeof msg.text !== 'string') return;
+    // Both flags default OFF, so a request from an older content script — the
+    // real case during an extension update, when the page still holds the
+    // previous generation's script — is answered exactly as it always was.
+    const useRendered = msg.useRenderedLandingText === true;
+    const directInsertFirst = msg.useDirectInsertFirst === true;
     let landed = false;
     try {
-      landed = performMainWorldInject(msg.selector, msg.text);
+      landed = performMainWorldInject(msg.selector, msg.text, useRendered, directInsertFirst);
     } catch { /* landed stays false — the content script's fallback chain takes over */ }
     window.postMessage(
       { type: 'nexpath:inject-result', requestId: msg.requestId, landed },

--- a/src/ext-browser/inject/main-world.ts
+++ b/src/ext-browser/inject/main-world.ts
@@ -347,6 +347,81 @@ interface InjectRequestMsg {
   useRenderedLandingText?: boolean;
   /** See `directInsertFirst` below. Absent ⇒ false ⇒ the shipped paste-first order. */
   useDirectInsertFirst?: boolean;
+  /** See `editorApiInsert` below. Absent ⇒ false ⇒ the bridge never looks for an editor view. */
+  useEditorApiInsert?: boolean;
+}
+
+/**
+ * The slice of CodeMirror 6's `EditorView` this file uses. Deliberately tiny —
+ * the shape is structurally checked at runtime before anything is called, so a
+ * future CM version that no longer matches simply fails the guard and the
+ * caller's own delivery chain takes over.
+ */
+interface EditorViewLike {
+  state: { doc: { length: number; toString(): string } };
+  dispatch(spec: { changes: { from: number; to: number; insert: string } }): void;
+}
+
+/**
+ * Find the composer's own editor instance, if it exposes one.
+ *
+ * CodeMirror 6 hangs its view off the content DOM node as a `cmView` expando.
+ * That is a PAGE-WORLD property: a content script can reach the element but not
+ * this field, which is exactly why this route has to live in this file.
+ *
+ * Every step is guarded. `cmView` may be the view itself or a wrapper carrying
+ * `.view`, depending on the build, and either may be absent entirely — an
+ * unrecognised shape returns null rather than throwing.
+ */
+function resolveEditorView(input: HTMLElement): EditorViewLike | null {
+  const holder = (input as unknown as { cmView?: unknown }).cmView;
+  if (!holder || typeof holder !== 'object') return null;
+  const candidate = (holder as { view?: unknown }).view ?? holder;
+  if (!candidate || typeof candidate !== 'object') return null;
+  const view = candidate as Partial<EditorViewLike>;
+  if (typeof view.dispatch !== 'function') return null;
+  if (!view.state || typeof view.state.doc?.length !== 'number') return null;
+  return view as EditorViewLike;
+}
+
+/**
+ * Replace the composer's whole document through the editor's own API.
+ *
+ * ── WHY THIS ROUTE EXISTS ────────────────────────────────────────────────────
+ * Neither of the other two routes serves Replit. Its CodeMirror 6 composer
+ * REFUSES `execCommand('insertText')` — measured live on a real Repl
+ * (2026-08-27): returns false and inserts nothing, confirming the same result
+ * recorded months earlier. And its paste path carries a size limit that forces
+ * the delivery to be split into sub-limit pieces, which is a character-count
+ * rule the delivery is not supposed to need.
+ *
+ * A transaction has neither problem. Measured on that same live composer:
+ *
+ *     55 chars    2 ms     doc matched exactly
+ *     2,500 chars 6 ms     doc matched exactly
+ *     8,000 chars 3 ms     doc matched exactly
+ *
+ * No paste event, no clipboard, no execCommand, and no size rule — the same
+ * single call regardless of how long the user's prompt is.
+ *
+ * ── WHY IT VERIFIES AGAINST THE DOCUMENT, NOT THE DOM ────────────────────────
+ * CodeMirror 6 VIRTUALISES: it renders only the lines in view. On that live
+ * composer an 8,000-character body rendered 27 of roughly 337 lines, so any
+ * DOM-based landing check — `innerText` included — reports a body that size as
+ * missing when it is perfectly present. The editor's own document has no
+ * viewport, so asking it is both cheaper and correct at any length.
+ */
+function insertViaEditorApi(input: HTMLElement, text: string): boolean {
+  const view = resolveEditorView(input);
+  if (!view) return false;
+  try {
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+  } catch {
+    return false;
+  }
+  // `state` is re-read here on purpose: CodeMirror's state is immutable, so this
+  // is the NEW document produced by the transaction, not the one dispatched to.
+  return hasTextLanded(view.state.doc.toString(), text);
 }
 
 /** Put the caret across the whole composer, so an insertion REPLACES it. */
@@ -418,6 +493,7 @@ function performMainWorldInject(
   text: string,
   useRendered: boolean,
   directInsertFirst: boolean,
+  editorApiInsert: boolean,
 ): boolean {
   // Blank text is never a real injection and both paths select-all first, so
   // honouring it would wipe the user's composer (see landing-check.ts).
@@ -425,6 +501,20 @@ function performMainWorldInject(
   const candidates = [...document.querySelectorAll<HTMLElement>(selector)];
   const input = candidates.find((el) => el.getClientRects().length > 0) ?? candidates[0];
   if (!input) return false;
+
+  if (editorApiInsert) {
+    if (insertViaEditorApi(input, text)) return true;
+    // No editor view, or the transaction did not take. Report failure and touch
+    // NOTHING ELSE — deliberately not falling through to the paste below.
+    //
+    // The caller that asks for this route is the one whose composer has a paste
+    // SIZE LIMIT, so the whole-body paste below is precisely what that composer
+    // drops. Attempting it would select-all first, leaving the user's own prompt
+    // deleted and nothing put in its place. Returning false instead hands the
+    // delivery straight back to the caller's own chain — which splits the body
+    // into sub-limit pieces and is the path that is proven live on that site.
+    return false;
+  }
 
   // Which read decides "landed". Resolved once so the two attempts below can
   // never be judged by different rules. See landing-check.ts for why the raw
@@ -466,9 +556,10 @@ if (typeof window.addEventListener === 'function') {
     // previous generation's script — is answered exactly as it always was.
     const useRendered = msg.useRenderedLandingText === true;
     const directInsertFirst = msg.useDirectInsertFirst === true;
+    const editorApiInsert = msg.useEditorApiInsert === true;
     let landed = false;
     try {
-      landed = performMainWorldInject(msg.selector, msg.text, useRendered, directInsertFirst);
+      landed = performMainWorldInject(msg.selector, msg.text, useRendered, directInsertFirst, editorApiInsert);
     } catch { /* landed stays false — the content script's fallback chain takes over */ }
     window.postMessage(
       { type: 'nexpath:inject-result', requestId: msg.requestId, landed },

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nexpath",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "AI coding assistant for Replit, Lovable, and Bolt — reviews your prompt before you send it.",
   "permissions": [
     "storage",

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nexpath",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "AI coding assistant for Replit, Lovable, and Bolt — reviews your prompt before you send it.",
   "permissions": [
     "storage",

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -81,23 +81,30 @@ describe('ext-browser manifests — permission surface', () => {
   });
 
   // Store version ordering is per-component NUMERIC, not decimal: 0.1.51 is [0,1,51], which
-  // outranks [0,1,6]. Whatever ordering the team picks, a released version can never be
-  // re-used or gone backwards from — so the released set is pinned here and a bump must be
-  // strictly ahead of every one of them.
-  it('ships a version strictly ahead of everything already submitted to a store', () => {
-    const RELEASED = ['0.1.5'];
+  // outranks [0,1,6]. Shipping 0.1.51 therefore made 0.1.6 through 0.1.50 permanently
+  // unreleasable — they would be downgrades, which both stores reject forever.
+  //
+  // What this guards is going BACKWARDS, which is irreversible. It deliberately allows the
+  // manifest to EQUAL the latest released version: that is the resting state between releases,
+  // and a test that runs continuously cannot tell "resting" from "about to re-upload". A genuine
+  // same-version re-upload is caught by the store at submit time, immediately and harmlessly.
+  it('never ships a version below one already submitted to a store', () => {
+    // Append at release time. A version that shipped can never be re-used or gone below,
+    // so this list only grows.
+    const RELEASED = ['0.1.5', '0.1.51'];
     const parse = (v: string) => v.split('.').map(Number);
-    const isAhead = (a: number[], b: number[]) => {
+    const isBelow = (a: number[], b: number[]) => {
       for (let i = 0; i < Math.max(a.length, b.length); i++) {
         const x = a[i] ?? 0, y = b[i] ?? 0;
-        if (x !== y) return x > y;
+        if (x !== y) return x < y;
       }
-      return false;   // equal is NOT ahead — both stores refuse a re-upload
+      return false;   // equal is not below
     };
     const current = parse(load('chrome').version as string);
     for (const released of RELEASED) {
-      expect(isAhead(current, parse(released)),
-        `manifest version must be strictly ahead of the released ${released}`).toBe(true);
+      expect(isBelow(current, parse(released)),
+        `manifest version is BELOW the released ${released} — both stores reject downgrades permanently`,
+      ).toBe(false);
     }
   });
 });

--- a/src/public-safe.test.ts
+++ b/src/public-safe.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// L12/D-20: "no free plan/pro plan wording scattered through the open-source
+// code — plan/branding awareness lives on the website/server only." Mirrors
+// readme.test.ts's shape (a fixed content set, checked for forbidden terms).
+//
+// ⚠️ Scope is deliberately the files this milestone's client seam actually
+// owns, not a sweep of the whole repository. A repo-wide sweep found real hits
+// in files this guard has no authority over: `auto.ts` is on §0's frozen list
+// and already carries pre-existing, unrelated developer-name comments from
+// before this milestone, predating anything this guard is meant to catch.
+// Flagging frozen content this guard cannot fix would make it permanently red
+// for a reason unrelated to what it exists to prevent. If a future unit adds
+// another file under the client seam's own ownership, add it to this list.
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const OWNED_FILES = [
+  'src/config/NexpathTokenStore.ts',
+  'src/config/ApiKeyResolver.ts',
+  'src/cli/commands/token.ts',
+];
+
+const sourceFiles = OWNED_FILES.map((relative) => join(ROOT, relative));
+
+// Plan/pricing/branding terms that belong to the private planning artefacts
+// and must never appear in this public repo's source — the client seam's own
+// vocabulary (plan/pricing wording, internal decision/risk/unit IDs, and the
+// private repos' names). Terms are matched as substrings deliberately, but
+// each was checked against the real tree first so a term does not fire on an
+// unrelated word that merely contains it (e.g. NOT "nexpath-pro", which is a
+// substring of the legitimate "nexpath-prompt-store" MCP server name).
+const FORBIDDEN_TERMS = [
+  'free plan',
+  'pro plan',
+  'freeproplan',
+  'emptyops/nexpath-pro',
+  'nexpath-prompt-enhancement-submodule',
+  '30% margin',
+  'dep-fp-',
+  'risk-1',
+  'risk-2',
+  'risk-3',
+  'risk-4',
+  'risk-5',
+  'risk-6',
+  'risk-7',
+  'risk-8',
+  'risk-9',
+  'fp-0.',
+  'fp-1.',
+  'fp-2.',
+  'fp-3.',
+  'fp-4.',
+  'fp-5.',
+  'fp-6.',
+  'fp-7.',
+  'fp-8.',
+  'hiren',
+  'bhavnesh',
+  'vedansi',
+];
+
+describe('client seam — public-safe content guard (FP-4.4)', () => {
+  it('does not leak plan, pricing, internal-decision, or team-name terminology', () => {
+    for (const file of sourceFiles) {
+      const text = readFileSync(file, 'utf8').toLowerCase();
+      for (const term of FORBIDDEN_TERMS) {
+        expect(text, `${file} contains forbidden term "${term}"`).not.toContain(term);
+      }
+    }
+  });
+
+  it('the guard actually fires: a planted "Pro plan" string is caught', () => {
+    const planted = 'export const upsell = "Upgrade to the Pro plan for more credit";';
+    const lower = planted.toLowerCase();
+    expect(FORBIDDEN_TERMS.some((term) => lower.includes(term))).toBe(true);
+  });
+
+  it('the guard actually fires: a planted internal risk ID is caught', () => {
+    const planted = '// mitigates RISK-7, the free-credit farming concern';
+    const lower = planted.toLowerCase();
+    expect(FORBIDDEN_TERMS.some((term) => lower.includes(term))).toBe(true);
+  });
+
+  it('the guard actually fires: a planted team name is caught', () => {
+    const planted = "// per Hiren's instruction, this stays a no-op";
+    const lower = planted.toLowerCase();
+    expect(FORBIDDEN_TERMS.some((term) => lower.includes(term))).toBe(true);
+  });
+
+  it('does not fire on a lookalike substring that is not the forbidden term', () => {
+    // "nexpath-prompt-store" contains "nexpath-pro" as a raw substring; the
+    // precise term below must not match it, which is why the exact
+    // "emptyops/nexpath-pro" form is what is actually forbidden above.
+    const lookalike = "const MCP_SERVER_NAME = 'nexpath-prompt-store';".toLowerCase();
+    expect(FORBIDDEN_TERMS.some((term) => lookalike.includes(term))).toBe(false);
+  });
+
+  it('every file this guard claims to own actually exists and was scanned', () => {
+    expect(sourceFiles.length).toBe(OWNED_FILES.length);
+    for (const file of sourceFiles) {
+      expect(() => readFileSync(file, 'utf8')).not.toThrow();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, configDefaults } from 'vitest/config';
+import { existsSync } from 'node:fs';
 
 // Config for Phases P4 + P5:
 //  - setupFiles redirects the nexpath home to a temp dir so tests never mutate the real ~/.nexpath (P4).
@@ -6,10 +7,43 @@ import { defineConfig, configDefaults } from 'vitest/config';
 //  - exclude src/ext-vscode/** (P5): that sub-package has its own package.json + native better-sqlite3
 //    dependency and is not installed at the root, so the root `tsconfig.json` already excludes it; the
 //    root test run must exclude it too, or it fails with "Cannot find package 'better-sqlite3'".
+
+// ── Suites that read the PRIVATE planning submodule ──────────────────────────
+// These assert on markdown inside `lib/shared/submodules/nexpath-prompt-enhancement-submodule/`,
+// which is a separate private repo. They are deliberately written to FAIL rather than skip when it
+// is missing — a guard that quietly passes when its subject is absent is the problem it exists to
+// catch — and that is right for a developer who is supposed to have it checked out.
+//
+// A CI runner can never have it: there is no `.gitmodules` on `main`, so `actions/checkout` has
+// nothing to fetch even with credentials. The result was that the publish workflow's `npm test`
+// step failed on every run, the job never produced the `store-packages` artefact, and automated
+// publishing has therefore never worked once.
+//
+// So the presence of the submodule decides whether these are collected at all. Checked-out ⇒ they
+// run and assert exactly as their authors intended. Absent ⇒ they are not part of the run, and the
+// notice below says so out loud, in the CI log, every time. Not collected is honest; silently
+// passing would not be.
+const PLANNING_SUBMODULE = 'lib/shared/submodules/nexpath-prompt-enhancement-submodule';
+const NEEDS_PLANNING_SUBMODULE = [
+  'src/prompt-enhancement/dev-plan-table-integrity.test.ts',
+  'src/prompt-enhancement/hv1-env-supply.test.ts',
+];
+const planningSubmodulePresent = existsSync(PLANNING_SUBMODULE);
+if (!planningSubmodulePresent) {
+  console.warn(
+    `[vitest] ${PLANNING_SUBMODULE} is not checked out — skipping ${NEEDS_PLANNING_SUBMODULE.length} ` +
+    'planning-doc suite(s) that read it. Everything else runs. Check them out to run these locally.',
+  );
+}
+
 export default defineConfig({
   test: {
     setupFiles: ['./vitest.setup.ts'],
     globalSetup: ['./vitest.global-setup.ts'],
-    exclude: [...configDefaults.exclude, 'src/ext-vscode/**'],
+    exclude: [
+      ...configDefaults.exclude,
+      'src/ext-vscode/**',
+      ...(planningSubmodulePresent ? [] : NEEDS_PLANNING_SUBMODULE),
+    ],
   },
 });


### PR DESCRIPTION
**Overview**

This PR brings the browser extension 0.1.52 changes into `staging` so the updated work can move
forward with the rest of the staging branch.

**What's Included**

* Merged the browser extension 0.1.52 updates into `staging`.
* Carried across the faster delivery, the removal of Chrome's clipboard permission prompt, and the
  Replit editor-transaction delivery.
* Carried across the double-send and multi-line delivery fixes.
* Carried across the FreeProPlan client-seam work and the publish workflow test fix.
* Both manifests read 0.1.52 and the changelog is current.

**Verification**

The relevant changes and tests have been checked on this base, including both TypeScript projects
and the full repository suite. Both extension packages build.

Please review the changes and merge this PR into `staging` if everything looks good.