### PR TITLE
Add Content-Free Feedback Signal Tracking for Extension Events

### DIFF
--- a/src/cli/commands/record-signal.test.ts
+++ b/src/cli/commands/record-signal.test.ts
@@ -43,6 +43,12 @@ describe('record-signal command', () => {
     expect(await rows()).toEqual([{ project_root: '/proj', kind: 'pe_shorter', occurred_at: 1000 }]);
   });
 
+  it('records pe_shown (the shown-popup kind)', async () => {
+    const code = await recordSignalAction({ kind: 'pe_shown', project: '/p', at: '7', db: dbPath });
+    expect(code).toBe(0);
+    expect(await rows()).toEqual([{ project_root: '/p', kind: 'pe_shown', occurred_at: 7 }]);
+  });
+
   it('records the two standalone signals (advisory_fired, option_selected)', async () => {
     expect(await recordSignalAction({ kind: 'advisory_fired',  project: '/p', at: '1', db: dbPath })).toBe(0);
     expect(await recordSignalAction({ kind: 'option_selected', project: '/p', at: '2', db: dbPath })).toBe(0);

--- a/src/cli/commands/record-signal.test.ts
+++ b/src/cli/commands/record-signal.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openStore, closeStore, type Store } from '../../store/db.js';
+import { recordSignalAction } from './record-signal.js';
+
+// The command opens the CLI-owned store, records one content-free signal, and
+// closes it. Tests drive a real temp-file DB so the write is observable across
+// the open/close boundary (a fresh `:memory:` DB would not persist between calls).
+
+interface Row { project_root: string; kind: string; occurred_at: number }
+
+function readRows(store: Store): Row[] {
+  const res = store.db.exec(
+    'SELECT project_root, kind, occurred_at FROM feedback_signals ORDER BY occurred_at ASC',
+  );
+  return (res[0]?.values ?? []).map((r) => ({
+    project_root: r[0] as string,
+    kind:         r[1] as string,
+    occurred_at:  r[2] as number,
+  }));
+}
+
+describe('record-signal command', () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nexpath-recsig-'));
+    dbPath = join(dir, 'store.db');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  async function rows(): Promise<Row[]> {
+    const store = await openStore(dbPath);
+    try { return readRows(store); } finally { closeStore(store); }
+  }
+
+  it('records a valid per-action kind as exactly one content-free row', async () => {
+    const code = await recordSignalAction({ kind: 'pe_shorter', project: '/proj', at: '1000', db: dbPath });
+    expect(code).toBe(0);
+    expect(await rows()).toEqual([{ project_root: '/proj', kind: 'pe_shorter', occurred_at: 1000 }]);
+  });
+
+  it('records the two standalone signals (advisory_fired, option_selected)', async () => {
+    expect(await recordSignalAction({ kind: 'advisory_fired',  project: '/p', at: '1', db: dbPath })).toBe(0);
+    expect(await recordSignalAction({ kind: 'option_selected', project: '/p', at: '2', db: dbPath })).toBe(0);
+    expect((await rows()).map((r) => r.kind)).toEqual(['advisory_fired', 'option_selected']);
+  });
+
+  it('rejects an invalid kind with exit 1 and writes nothing', async () => {
+    const code = await recordSignalAction({ kind: 'not_a_kind', project: '/p', at: '1', db: dbPath });
+    expect(code).toBe(1);
+    expect(await rows()).toEqual([]);
+  });
+
+  it('rejects a non-numeric --at with exit 1 and writes nothing', async () => {
+    const code = await recordSignalAction({ kind: 'pe_close', project: '/p', at: 'abc', db: dbPath });
+    expect(code).toBe(1);
+    expect(await rows()).toEqual([]);
+  });
+
+  it('respects an explicit --at timestamp', async () => {
+    await recordSignalAction({ kind: 'pe_use_current', project: '/p', at: '424242', db: dbPath });
+    expect((await rows())[0]?.occurred_at).toBe(424242);
+  });
+
+  it('defaults --at to now when omitted', async () => {
+    const before = Date.now();
+    await recordSignalAction({ kind: 'pe_back', project: '/p', db: dbPath });
+    const after = Date.now();
+    const ts = (await rows())[0]?.occurred_at ?? 0;
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('handles rapid sequential calls without loss or corruption', async () => {
+    const kinds = ['pe_shorter', 'pe_more_thorough', 'pe_apply_details', 'pe_close', 'pe_use_original'];
+    let at = 100;
+    for (const kind of kinds) {
+      expect(await recordSignalAction({ kind, project: '/p', at: String(at++), db: dbPath })).toBe(0);
+    }
+    const r = await rows();
+    expect(r.length).toBe(kinds.length);
+    expect(r.map((x) => x.kind)).toEqual(kinds);
+  });
+});

--- a/src/cli/commands/record-signal.test.ts
+++ b/src/cli/commands/record-signal.test.ts
@@ -49,6 +49,15 @@ describe('record-signal command', () => {
     expect(await rows()).toEqual([{ project_root: '/p', kind: 'pe_shown', occurred_at: 7 }]);
   });
 
+  it('accepts every MPS action kind (readiness for when the extension MPS surface lands)', async () => {
+    const mpsKinds = ['mps_send', 'mps_cancel', 'mps_decline', 'mps_interruption', 'mps_apply_details'];
+    let at = 10;
+    for (const kind of mpsKinds) {
+      expect(await recordSignalAction({ kind, project: '/p', at: String(at++), db: dbPath })).toBe(0);
+    }
+    expect((await rows()).map((r) => r.kind)).toEqual(mpsKinds);
+  });
+
   it('records the two standalone signals (advisory_fired, option_selected)', async () => {
     expect(await recordSignalAction({ kind: 'advisory_fired',  project: '/p', at: '1', db: dbPath })).toBe(0);
     expect(await recordSignalAction({ kind: 'option_selected', project: '/p', at: '2', db: dbPath })).toBe(0);

--- a/src/cli/commands/record-signal.ts
+++ b/src/cli/commands/record-signal.ts
@@ -1,0 +1,90 @@
+import { openStore, closeStore, DEFAULT_DB_PATH } from '../../store/db.js';
+import {
+  ACTION_SIGNAL_KINDS,
+  SIGNAL_ADVISORY_FIRED,
+  SIGNAL_OPTION_SELECTED,
+  recordActionSignal,
+  recordAdvisoryFired,
+  recordOptionSelected,
+  type PromptActionSignalKind,
+} from '../../store/feedback-signals.js';
+
+/**
+ * `nexpath record-signal` — record ONE content-free UI-action feedback signal
+ * (kind + timestamp only) in the CLI-owned store.
+ *
+ * The store is owned exclusively by the CLI; surfaces that cannot write it —
+ * notably the VS Code extension, which opens the DB read-only — spawn this
+ * command to record the same signals the CLI records for its own popups. The
+ * payload is a fixed UI-action enum plus an optional timestamp: NO prompt,
+ * body, option, or additional-details text (or any content-derived id) is ever
+ * accepted or stored (see feedback-signals.ts).
+ */
+
+/** The kinds this command accepts: the per-action enum plus the two standalone
+ *  timestamp signals. Every value here already exists in feedback-signals.ts. */
+const VALID_KINDS: ReadonlySet<string> = new Set<string>([
+  ...ACTION_SIGNAL_KINDS,
+  SIGNAL_ADVISORY_FIRED,
+  SIGNAL_OPTION_SELECTED,
+]);
+
+export interface RecordSignalOptions {
+  kind:     string;
+  project:  string;
+  at?:      string;
+  db:       string;
+}
+
+/**
+ * Validate and record a single signal. Returns the process exit code: 0 on a
+ * successful write, 1 on any rejected input or store failure. Never throws, and
+ * writes nothing unless the kind is valid.
+ */
+export async function recordSignalAction(opts: RecordSignalOptions): Promise<number> {
+  const kind = opts.kind;
+  if (!VALID_KINDS.has(kind)) {
+    process.stderr.write(`record-signal: invalid --kind '${kind}'\n`);
+    return 1;
+  }
+
+  const occurredAt = opts.at !== undefined ? Number(opts.at) : Date.now();
+  if (!Number.isFinite(occurredAt) || occurredAt <= 0) {
+    process.stderr.write(`record-signal: invalid --at '${opts.at}'\n`);
+    return 1;
+  }
+
+  let store;
+  try {
+    store = await openStore(opts.db);
+  } catch {
+    process.stderr.write('record-signal: could not open store\n');
+    return 1;
+  }
+
+  try {
+    if (kind === SIGNAL_ADVISORY_FIRED) {
+      recordAdvisoryFired(store, opts.project, occurredAt);
+    } else if (kind === SIGNAL_OPTION_SELECTED) {
+      recordOptionSelected(store, opts.project, occurredAt);
+    } else {
+      recordActionSignal(store, opts.project, kind as PromptActionSignalKind, occurredAt);
+    }
+  } finally {
+    closeStore(store);
+  }
+  return 0;
+}
+
+export function registerRecordSignalCommand(program: import('commander').Command): void {
+  program
+    .command('record-signal')
+    .description('Record a content-free UI-action feedback signal (kind + timestamp only)')
+    .requiredOption('--kind <kind>', 'Signal kind (a fixed UI-action enum)')
+    .option('-p, --project <path>', 'Project root path', process.cwd())
+    .option('--at <epochMs>', 'Occurred-at timestamp in epoch ms (default: now)')
+    .option('--db <path>', 'Database path', DEFAULT_DB_PATH)
+    .action(async (opts: RecordSignalOptions) => {
+      process.exitCode = await recordSignalAction(opts);
+    });
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -27,6 +27,7 @@ import { initAction } from './commands/init.js';
 import { envAction } from './commands/env.js';
 import { registerAutoCommand } from './commands/auto.js';
 import { registerStopCommand } from './commands/stop.js';
+import { registerRecordSignalCommand } from './commands/record-signal.js';
 import { registerWindsurfHookCommand } from './commands/windsurf-hook.js';
 import { registerCursorHookCommand } from './commands/cursor-hook.js';
 import { registerOptimizeCommand } from './commands/optimize.js';
@@ -101,6 +102,7 @@ export function createProgram(): Command {
 
   registerAutoCommand(program);
   registerStopCommand(program);
+  registerRecordSignalCommand(program);
   registerWindsurfHookCommand(program);
   registerCursorHookCommand(program);
 

--- a/src/ext-vscode/src/advisory-fallback.test.ts
+++ b/src/ext-vscode/src/advisory-fallback.test.ts
@@ -123,6 +123,35 @@ describe('createAdvisoryFallback', () => {
     expect(publishPayload).not.toHaveBeenCalled();
   });
 
+  it('showAdvisory() records advisory_fired for the project after a successful publish', async () => {
+    read.mockResolvedValue(advisory({ createdAt: 5000 }));
+    const recordAdvisoryShown = vi.fn();
+    const fb = createAdvisoryFallback({ publishPayload, statusBar, read, recordAdvisoryShown, now: () => 6000 });
+    await fb.armIfPending('/proj');
+    await fb.showAdvisory();
+    expect(publishPayload).toHaveBeenCalled();
+    expect(recordAdvisoryShown).toHaveBeenCalledWith('/proj');
+    expect(recordAdvisoryShown).toHaveBeenCalledTimes(1);
+  });
+
+  it('showAdvisory() does NOT record when nothing is pending', async () => {
+    const recordAdvisoryShown = vi.fn();
+    const fb = createAdvisoryFallback({ publishPayload, statusBar, read, recordAdvisoryShown });
+    await fb.showAdvisory();
+    expect(recordAdvisoryShown).not.toHaveBeenCalled();
+  });
+
+  it('showAdvisory() does NOT record when the advisory vanished from the store', async () => {
+    read.mockResolvedValueOnce(advisory({ createdAt: 5000 })); // arm
+    read.mockResolvedValueOnce(null);                          // gone before opening
+    const recordAdvisoryShown = vi.fn();
+    const fb = createAdvisoryFallback({ publishPayload, statusBar, read, recordAdvisoryShown, now: () => 6000 });
+    await fb.armIfPending('/proj');
+    await fb.showAdvisory();
+    expect(publishPayload).not.toHaveBeenCalled();
+    expect(recordAdvisoryShown).not.toHaveBeenCalled();
+  });
+
   it('showAdvisory() hides the status bar if the advisory vanished from the store', async () => {
     read.mockResolvedValueOnce(advisory({ createdAt: 5000 })); // arm
     read.mockResolvedValueOnce(null);                          // gone by the time we open it

--- a/src/ext-vscode/src/advisory-fallback.ts
+++ b/src/ext-vscode/src/advisory-fallback.ts
@@ -35,6 +35,14 @@ export interface StatusBarHandle {
 export interface AdvisoryFallbackDeps {
   /** Push a payload to the webview (`view-provider.publishPayload`). */
   publishPayload: (payload: DecisionSessionPayload) => void;
+  /**
+   * Record that the advisory was shown here (content-free `advisory_fired`
+   * signal), so the extension surface reports the same signal the CLI records
+   * when its own popup fires. Given the project root the advisory belongs to.
+   * Optional + defaults to a no-op; `extension.ts` wires the real fire-and-forget
+   * spawn. No prompt/option text is passed — only the project root.
+   */
+  recordAdvisoryShown?: (projectRoot: string) => void;
   /** The status-bar surface to light when an advisory is waiting. */
   statusBar: StatusBarHandle;
   /** Read the latest stored advisory for a project (defaults to the real store reader). */
@@ -120,9 +128,10 @@ export function createAdvisoryFallback(deps: AdvisoryFallbackDeps): AdvisoryFall
 
     async showAdvisory(): Promise<void> {
       if (pendingProject === null) return;
+      const project = pendingProject;
       let advisory: StoredAdvisory | null;
       try {
-        advisory = await read(pendingProject);
+        advisory = await read(project);
       } catch {
         return;
       }
@@ -132,6 +141,9 @@ export function createAdvisoryFallback(deps: AdvisoryFallbackDeps): AdvisoryFall
         return;
       }
       deps.publishPayload(toPayload(advisory));
+      // Record the shown-advisory signal ONLY after a successful publish, so the
+      // count reflects advisories the user actually saw here.
+      deps.recordAdvisoryShown?.(project);
       deps.statusBar.hide();
       pendingProject = null;
     },

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -166,6 +166,7 @@ vi.mock('./chat-pipeline.js', () => ({
 vi.mock('./ipc.js', () => ({
   spawnAuto: vi.fn(),
   spawnStop: vi.fn(),
+  spawnRecordSignal: vi.fn(() => Promise.resolve()),
 }));
 vi.mock('./advisory-fallback.js', () => ({
   createAdvisoryFallback: vi.fn(() => ({

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -407,11 +407,24 @@ describe('activate', () => {
       expect(provider.getCurrentPayload()).toEqual(payload);
     });
 
-    it('onPublish never crashes when given a null payload (malformed row)', async () => {
+    it('onPublish records pe_shown for the PE popup (Windsurf-poller parity)', async () => {
+      vi.mocked(spawnRecordSignal).mockClear();
+      mockShowOnboarding.mockResolvedValueOnce(undefined);
+      mockDetectHost.mockReturnValueOnce('windsurf');
+      await activate(makeCtx(true) as never);
+      capturedDeps().onPublish?.({ currentBodyId: 'body-1', bodyRevision: 3 });
+      const peShownCalls = vi.mocked(spawnRecordSignal).mock.calls.filter((c) => c[0] === 'pe_shown');
+      expect(peShownCalls).toHaveLength(1);
+    });
+
+    it('onPublish never crashes when given a null payload (malformed row) and records nothing', async () => {
+      vi.mocked(spawnRecordSignal).mockClear();
       mockShowOnboarding.mockResolvedValueOnce(undefined);
       mockDetectHost.mockReturnValueOnce('windsurf');
       await activate(makeCtx(true) as never);
       expect(() => capturedDeps().onPublish?.(null)).not.toThrow();
+      const peShownCalls = vi.mocked(spawnRecordSignal).mock.calls.filter((c) => c[0] === 'pe_shown');
+      expect(peShownCalls).toHaveLength(0);
     });
 
     it('onDeliver: succeeds via the clipboard-free Cascade command when it is registered', async () => {

--- a/src/ext-vscode/src/extension.test.ts
+++ b/src/ext-vscode/src/extension.test.ts
@@ -168,6 +168,7 @@ vi.mock('./ipc.js', () => ({
   spawnStop: vi.fn(),
   spawnRecordSignal: vi.fn(() => Promise.resolve()),
 }));
+import { spawnRecordSignal } from './ipc.js';
 vi.mock('./advisory-fallback.js', () => ({
   createAdvisoryFallback: vi.fn(() => ({
     armIfPending: mockArmIfPending,
@@ -731,6 +732,33 @@ describe('activate', () => {
       const provider = getPeViewProvider() as unknown as { getCurrentPayload: () => { currentBodyId: string } | null };
       expect(provider.getCurrentPayload()?.currentBodyId).toBe('body-1');
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('PE visible-surface ACK: pe_body_visible'));
+    });
+
+    it('checkPeOrigin: records pe_shown once when the PE popup is published', async () => {
+      vi.mocked(spawnRecordSignal).mockClear();
+      mockIsPeOriginTurn.mockResolvedValueOnce(true);
+      mockReadPendingPromptEnhancement.mockResolvedValueOnce({
+        id: 1, projectRoot: '/proj', sessionId: 's1', promptCount: 1,
+        status: 'pending', createdAt: 100, requestJson: '{}', resultJson: validResultJson,
+      });
+      await activateWithWatcher();
+      await pipelineDeps().checkPeOrigin!(makeEvent());
+      const peShownCalls = vi.mocked(spawnRecordSignal).mock.calls.filter((c) => c[0] === 'pe_shown');
+      expect(peShownCalls).toHaveLength(1);
+    });
+
+    it('checkPeOrigin: does NOT record pe_shown twice for the same createdAt (re-publish guard)', async () => {
+      vi.mocked(spawnRecordSignal).mockClear();
+      mockIsPeOriginTurn.mockResolvedValue(true);
+      mockReadPendingPromptEnhancement.mockResolvedValue({
+        id: 1, projectRoot: '/proj', sessionId: 's1', promptCount: 1,
+        status: 'pending', createdAt: 500, requestJson: '{}', resultJson: validResultJson,
+      });
+      await activateWithWatcher();
+      await pipelineDeps().checkPeOrigin!(makeEvent()); // publishes → records pe_shown
+      await pipelineDeps().checkPeOrigin!(makeEvent()); // same createdAt → no second record
+      const peShownCalls = vi.mocked(spawnRecordSignal).mock.calls.filter((c) => c[0] === 'pe_shown');
+      expect(peShownCalls).toHaveLength(1);
     });
 
     it('checkPeOrigin: ACKs not_counted_as_shown (never render_failure) when the pending row vanished before it could be read', async () => {

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -1156,8 +1156,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           parsed = parsePromptEnhancementExtensionPayloadV1(pending.resultJson);
           if (parsed) {
             if (pending.createdAt >= peLastPublishedCreatedAt) {
+              const isNewPeShow = pending.createdAt > peLastPublishedCreatedAt;
               peLastPublishedCreatedAt = pending.createdAt;
               peViewProvider?.publishPayload(parsed);
+              // Record the content-free `pe_shown` signal once per DISTINCT popup
+              // (strictly-new createdAt), so a same-createdAt re-publish does not
+              // double-count. Fire-and-forget; only the kind is sent, no body text.
+              if (isNewPeShow) {
+                void spawnRecordSignal('pe_shown', { cwd: projectRoot });
+              }
             } else {
               log(`[nexpath] PE publish suppressed: a newer turn's payload is already visible (createdAt ${pending.createdAt} < ${peLastPublishedCreatedAt})`);
             }

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -585,6 +585,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const advisoryFallback: AdvisoryFallback = createAdvisoryFallback({
     publishPayload: (payload) => viewProvider?.publishPayload(payload),
+    // Record the content-free `advisory_fired` signal when the advisory is shown
+    // in the webview — the same signal the CLI records for its own popup. Fire-
+    // and-forget; `projectRoot` is already the canonicalized project the advisory
+    // belongs to (armed from `cwdForEvent`).
+    recordAdvisoryShown: (projectRoot) =>
+      void spawnRecordSignal('advisory_fired', { cwd: projectRoot }),
     statusBar: {
       show: (text, tooltip) => {
         statusBarItem.text = text;

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -770,7 +770,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         executeCommand: (id, ...args) => vscode.commands.executeCommand(id, ...args),
         getCommands: (filter) => vscode.commands.getCommands(filter),
       })),
-      onPublish: (payload) => { if (payload) peViewProvider?.publishPayload(payload); },
+      onPublish: (payload) => {
+        if (!payload) return;
+        peViewProvider?.publishPayload(payload);
+        // Windsurf-poller PE-show parity: record the same content-free `pe_shown`
+        // signal the checkPeOrigin path records, so PE popups are counted on
+        // Windsurf too. The poller dedups by createdAt (its own `handledAt`), so
+        // onPublish fires once per distinct PE — no extra guard needed here.
+        // Fire-and-forget; only the kind is sent, no body text.
+        void spawnRecordSignal('pe_shown', {
+          cwd: canonicalizeCwd(vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd()),
+        });
+      },
       onOutcome: (outcome) => log(`[nexpath] windsurf PE poller insert outcome: ${outcome}`),
     });
     pePoller.start();

--- a/src/ext-vscode/src/extension.ts
+++ b/src/ext-vscode/src/extension.ts
@@ -58,7 +58,8 @@ import {
   type ChatHistoryWatcher,
 } from './chat-history-watcher.js';
 import { createChatEventHandler } from './chat-pipeline.js';
-import { spawnAuto, spawnStop } from './ipc.js';
+import { spawnAuto, spawnStop, spawnRecordSignal } from './ipc.js';
+import { peEventTypeToSignalKind } from './pe-signal-map.js';
 import { resolveWorkspaceFromDbPath, canonicalizeCwd } from './resolve-db-workspace.js';
 import { createAdvisoryFallback, type AdvisoryFallback } from './advisory-fallback.js';
 import { createAdvisoryPoller, type AdvisoryPoller } from './advisory-poller.js';
@@ -499,6 +500,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       });
       if (!event) return;
       log(`[nexpath] PE event: ${JSON.stringify(describePeEventSafely(event))}`);
+      // Record a content-free feedback signal for this action, mirroring what the
+      // CLI records for its own popup. Fire-and-forget: never blocks the webview,
+      // never throws. Only the action's signal kind is sent — no body/details
+      // text. Attributed to the workspace project the same way the pipeline
+      // spawns resolve it (canonicalized workspace folder).
+      const signalKind = peEventTypeToSignalKind(event.eventType);
+      if (signalKind) {
+        const projectCwd = canonicalizeCwd(
+          vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd(),
+        );
+        void spawnRecordSignal(signalKind, { cwd: projectCwd });
+      }
       // P7 (VED-PE-7): gate the one event type that actually attempts
       // delivery today. No real insertion exists yet (P8/P9) — logging the
       // gate decision here proves "delivery unreachable unless intent_ready"

--- a/src/ext-vscode/src/ipc-record-signal.test.ts
+++ b/src/ext-vscode/src/ipc-record-signal.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+import { spawnRecordSignal } from './ipc.js';
+
+function makeFakeChild(opts: { exitCode?: number; errorBeforeClose?: Error } = {}) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: Writable;
+    stdout: Readable;
+    stderr: Readable;
+  };
+  child.stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  queueMicrotask(() => {
+    if (opts.errorBeforeClose) { child.emit('error', opts.errorBeforeClose); return; }
+    child.emit('close', opts.exitCode ?? 0);
+  });
+  return child;
+}
+
+describe('spawnRecordSignal', () => {
+  it('builds the record-signal argv (kind only) and resolves on exit 0', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 0 }));
+    await expect(
+      spawnRecordSignal('pe_shorter', { spawnFn: spawnFn as never }),
+    ).resolves.toBeUndefined();
+    expect(spawnFn).toHaveBeenCalledWith(
+      'nexpath',
+      ['record-signal', '--kind', 'pe_shorter'],
+      expect.any(Object),
+    );
+  });
+
+  it('includes --db when dbPath is provided', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 0 }));
+    await spawnRecordSignal('pe_close', { spawnFn: spawnFn as never, dbPath: '/tmp/x.db' });
+    expect(spawnFn).toHaveBeenCalledWith(
+      'nexpath',
+      ['record-signal', '--kind', 'pe_close', '--db', '/tmp/x.db'],
+      expect.any(Object),
+    );
+  });
+
+  it('sends NO stdin payload (content-free — only the kind travels in argv)', async () => {
+    let written = '';
+    const child = makeFakeChild({ exitCode: 0 });
+    child.stdin = new Writable({ write(chunk, _enc, cb) { written += chunk.toString(); cb(); } });
+    const spawnFn = vi.fn(() => child);
+    await spawnRecordSignal('pe_apply_details', { spawnFn: spawnFn as never });
+    expect(written).toBe('');
+  });
+
+  it('swallows a spawn error and resolves (never rejects)', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ errorBeforeClose: new Error('ENOENT') }));
+    await expect(
+      spawnRecordSignal('pe_use_current', { spawnFn: spawnFn as never }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows a non-zero exit and resolves', async () => {
+    const spawnFn = vi.fn(() => makeFakeChild({ exitCode: 1 }));
+    await expect(
+      spawnRecordSignal('pe_use_original', { spawnFn: spawnFn as never }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws even if the spawner throws synchronously', async () => {
+    const spawnFn = vi.fn(() => { throw new Error('boom'); });
+    await expect(
+      spawnRecordSignal('pe_more_thorough', { spawnFn: spawnFn as never }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/ext-vscode/src/ipc.ts
+++ b/src/ext-vscode/src/ipc.ts
@@ -324,6 +324,34 @@ export function spawnAuto(
 }
 
 /**
+ * Fire-and-forget: spawn `nexpath record-signal --kind <kind>` to record ONE
+ * content-free feedback signal (kind + timestamp) in the CLI-owned store — the
+ * same signal the CLI records for its own popups. Only the kind string is sent;
+ * NO prompt / body / option / additional-details text.
+ *
+ * Telemetry must NEVER disrupt the UX, so this never rejects: a missing binary,
+ * a spawn failure, or a non-zero exit are all swallowed and the promise resolves.
+ * `cwd` drives the CLI's `--project` default, exactly as in `spawnAuto`.
+ */
+export function spawnRecordSignal(kind: string, opts: IpcOptions = {}): Promise<void> {
+  return new Promise<void>((resolve) => {
+    try {
+      const bin = resolveBinaryPath(opts);
+      const args = ['record-signal', '--kind', kind];
+      if (opts.dbPath) args.push('--db', opts.dbPath);
+      const spawner = opts.spawnFn ?? spawn;
+      const safe = shellSafeSpawnTokens(bin, args);
+      const child = spawner(safe.bin, safe.args, buildSpawnOptions(opts));
+      child.on('error', () => resolve());   // missing binary / spawn failure — swallow
+      child.on('close', () => resolve());    // any exit code — swallow (fire-and-forget)
+      child.stdin?.end();                    // record-signal reads no stdin
+    } catch {
+      resolve();                             // never throw into the caller
+    }
+  });
+}
+
+/**
  * Spawn `nexpath stop` and parse the decision-session payload from stdout.
  *
  * Layer C's `nexpath stop` expects a full Claude Code-shaped `StopPayload`

--- a/src/ext-vscode/src/pe-signal-map.test.ts
+++ b/src/ext-vscode/src/pe-signal-map.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { peEventTypeToSignalKind } from './pe-signal-map.js';
+import type { PeEventType } from './pe-events.js';
+
+describe('peEventTypeToSignalKind', () => {
+  const MAPPED: ReadonlyArray<readonly [PeEventType, string]> = [
+    ['deliver_current_body',          'pe_use_current'],
+    ['use_original',                  'pe_use_original'],
+    ['request_shorter',               'pe_shorter'],
+    ['request_more_thorough',         'pe_more_thorough'],
+    ['request_more_project_grounded', 'pe_more_project_grounded'],
+    ['submit_additional_details',     'pe_apply_details'],
+    ['close_no_send',                 'pe_close'],
+  ];
+
+  const UNMAPPED: ReadonlyArray<PeEventType> = ['edit_body', 'skip_or_reject', 'explicit_feedback'];
+
+  it.each(MAPPED)('maps %s -> %s', (eventType, kind) => {
+    expect(peEventTypeToSignalKind(eventType)).toBe(kind);
+  });
+
+  it.each(UNMAPPED)('maps %s -> null (no corresponding signal)', (eventType) => {
+    expect(peEventTypeToSignalKind(eventType)).toBeNull();
+  });
+
+  it('accounts for every PeEventType (mapped + unmapped = all 10)', () => {
+    // If a new PeEventType is added to pe-events.ts, update this list — the count
+    // guard then forces a deliberate decision about its signal (or lack of one).
+    const all: ReadonlyArray<PeEventType> = [
+      'deliver_current_body', 'use_original', 'edit_body', 'skip_or_reject',
+      'request_shorter', 'request_more_thorough', 'request_more_project_grounded',
+      'submit_additional_details', 'explicit_feedback', 'close_no_send',
+    ];
+    expect(all.length).toBe(MAPPED.length + UNMAPPED.length);
+  });
+});

--- a/src/ext-vscode/src/pe-signal-map.ts
+++ b/src/ext-vscode/src/pe-signal-map.ts
@@ -1,0 +1,43 @@
+import type { PeEventType } from './pe-events.js';
+
+/**
+ * Content-free feedback-signal kinds this extension can produce for a PE action.
+ *
+ * These string literals MUST stay in sync with `ACTION_SIGNAL_KINDS` in the CLI's
+ * `src/store/feedback-signals.ts`. This package is import-isolated from the main
+ * `src`, so the type cannot be shared directly — but the CLI's `record-signal`
+ * command validates the kind against that list and rejects anything it does not
+ * recognise, so a drift here fails CLOSED (no row written), never a silent bad
+ * record.
+ */
+export type PeActionSignalKind =
+  | 'pe_use_current'
+  | 'pe_use_original'
+  | 'pe_shorter'
+  | 'pe_more_thorough'
+  | 'pe_more_project_grounded'
+  | 'pe_apply_details'
+  | 'pe_close';
+
+/**
+ * Webview PE event types that correspond to a content-free feedback signal.
+ * `edit_body`, `skip_or_reject`, and `explicit_feedback` have no signal kind and
+ * map to `null`. (`pe_back` is a declared CLI kind with no webview event yet.)
+ */
+const EVENT_TO_SIGNAL: Partial<Record<PeEventType, PeActionSignalKind>> = {
+  deliver_current_body:          'pe_use_current',
+  use_original:                  'pe_use_original',
+  request_shorter:               'pe_shorter',
+  request_more_thorough:         'pe_more_thorough',
+  request_more_project_grounded: 'pe_more_project_grounded',
+  submit_additional_details:     'pe_apply_details',
+  close_no_send:                 'pe_close',
+};
+
+/**
+ * Map a webview PE event type to its content-free feedback-signal kind, or
+ * `null` when the event type has no corresponding signal.
+ */
+export function peEventTypeToSignalKind(eventType: PeEventType): PeActionSignalKind | null {
+  return EVENT_TO_SIGNAL[eventType] ?? null;
+}

--- a/src/store/feedback-signals.ts
+++ b/src/store/feedback-signals.ts
@@ -21,7 +21,7 @@ export const SIGNAL_OPTION_SELECTED = 'option_selected';
  */
 export const ACTION_SIGNAL_KINDS = [
   'pe_use_current', 'pe_use_original', 'pe_shorter', 'pe_more_thorough',
-  'pe_more_project_grounded', 'pe_apply_details', 'pe_back', 'pe_close',
+  'pe_more_project_grounded', 'pe_apply_details', 'pe_back', 'pe_close', 'pe_shown',
   'mps_send', 'mps_cancel', 'mps_decline', 'mps_interruption', 'mps_apply_details',
 ] as const;
 export type PromptActionSignalKind = typeof ACTION_SIGNAL_KINDS[number];

--- a/src/telemetry/telemetry-enabled.ts
+++ b/src/telemetry/telemetry-enabled.ts
@@ -2,8 +2,9 @@ import type { Store } from '../store/db.js';
 import { getConfig } from '../store/config.js';
 
 /**
- * True unless telemetry has been explicitly disabled. Defaults to on, matching
- * the `telemetry.enabled` config default.
+ * Telemetry is opt-in and OFF by default: `telemetry.enabled` defaults to
+ * `'false'` in DEFAULT_CONFIG, so this returns `true` only when a stored value
+ * has explicitly set it to something other than `'false'`.
  */
 export function isTelemetryEnabled(store: Store): boolean {
   return getConfig(store.db, 'telemetry.enabled') !== 'false';


### PR DESCRIPTION
# Add Content-Free Feedback Signal Tracking for Extension Events

## Summary

This PR adds support for recording content-free feedback signals from the extension through the NexPath CLI.

The goal is to make sure key Prompt Enhancement and advisory actions are tracked consistently across the CLI and extension surfaces without storing any prompt or user content.

## Changes Included

* Added the `record-signal` CLI command for recording existing feedback signal kinds.
* Added extension-side mapping for Prompt Enhancement actions to their corresponding signal kinds.
* Recorded PE action signals through a fire-and-forget CLI call.
* Added `advisory_fired` tracking when an advisory is actually shown in the webview.
* Added `pe_shown` tracking for Prompt Enhancement popups.
* Covered both the VS Code/Cursor hook-chain path and the Windsurf poller publish path.
* Corrected the telemetry configuration comment to match the actual opt-in default.
* Added test coverage for the supported MPS action signal kinds.

## Privacy

Only the signal kind and required project context are used for recording. No prompt text, response content, option details, or other user content is stored.

## Verification

The relevant CLI and extension behavior has been covered with tests, including invalid signal handling, action mapping, publish-path tracking, and duplicate prevention.

I’d appreciate a review of the changes. If everything looks good, please consider merging this into `main`.
