### PR TITLE
Add Ext Browser Rating and Telemetry Support

### DIFF
--- a/src/cli/commands/install.test.ts
+++ b/src/cli/commands/install.test.ts
@@ -11,6 +11,8 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { openStore, closeStore } from '../../store/db.js';
 import { CLAUDE_HOOK_TIMEOUT_SECONDS } from '../../agents/adapters/claude-code.js';
+import { cursorConfigDir } from '../../agents/adapters/cursor.js';
+import { windsurfConfigDir } from '../../agents/adapters/windsurf.js';
 import { setConfig, isConfigSet, getConfig } from '../../store/config.js';
 
 import {
@@ -52,6 +54,29 @@ function tmpDir(): { dir: string; cleanup: () => void } {
   mkdirSync(dir, { recursive: true });
   return { dir, cleanup: () => { try { rmSync(dir, { recursive: true }); } catch { /* ignore */ } } };
 }
+
+/**
+ * Make the named agents detectable, on the RUNNING platform, inside `dir` only.
+ *
+ * These tests used to write `<dir>/.config/<Agent>` — the LINUX layout — and stub
+ * only HOME. On Windows the adapters look in `%APPDATA%\<Agent>` instead, so the
+ * fixture was invisible and detection fell through to the developer's REAL
+ * installs. That made the Cursor cases pass for the wrong reason (Cursor is
+ * installed on the machine, so they passed without creating anything) and the
+ * Windsurf ones fail for the right one (it is not).
+ *
+ * Stubbing APPDATA as well seals the sandbox, and building the path with the
+ * adapters' OWN helpers means the fixture lands wherever detection actually
+ * looks — on every platform, without the test knowing which one it is on.
+ */
+function detectableAgents(dir: string, ...agents: ReadonlyArray<'cursor' | 'windsurf'>): void {
+  vi.stubEnv('HOME', dir);
+  vi.stubEnv('APPDATA', join(dir, 'AppData', 'Roaming'));
+  for (const agent of agents) {
+    mkdirSync(agent === 'cursor' ? cursorConfigDir(dir) : windsurfConfigDir(dir), { recursive: true });
+  }
+}
+
 
 /**
  * Mark Claude Code as "installed" inside a tmpDir sandbox by creating the
@@ -950,8 +975,7 @@ describe('installAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor');
       const paths = resolveAgentPaths(dir, dir, dir);
       await installAction({ yes: true }, {  // platform defaults to cli
         paths,
@@ -972,8 +996,7 @@ describe('installAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'windsurf');
       const paths = resolveAgentPaths(dir, dir, dir);
       await installAction({ yes: true }, {
         paths,
@@ -994,9 +1017,7 @@ describe('installAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor', 'windsurf');
       const paths = resolveAgentPaths(dir, dir, dir);
       await installAction({ yes: true }, {
         paths,
@@ -1020,8 +1041,7 @@ describe('installAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor');
       const paths = resolveAgentPaths(dir, dir, dir);
       await installAction({ yes: true, platform: 'browser' }, {
         paths,
@@ -1074,9 +1094,7 @@ describe('installAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor', 'windsurf');
       const paths = resolveAgentPaths(dir, dir, dir);
       await installAction({ yes: true }, {  // platform defaults to cli
         paths,
@@ -1412,8 +1430,7 @@ describe('uninstallAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor');
       const paths = resolveAgentPaths(dir, dir, dir);
       await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, storeDeleteConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
@@ -1429,8 +1446,7 @@ describe('uninstallAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'windsurf');
       const paths = resolveAgentPaths(dir, dir, dir);
       await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, storeDeleteConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');
@@ -1450,9 +1466,7 @@ describe('uninstallAction', () => {
     const { dir, cleanup } = tmpDir();
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      mkdirSync(join(dir, '.config', 'Cursor'), { recursive: true });
-      mkdirSync(join(dir, '.config', 'Windsurf'), { recursive: true });
-      vi.stubEnv('HOME', dir);
+      detectableAgents(dir, 'cursor', 'windsurf');
       const paths = resolveAgentPaths(dir, dir, dir);
       await uninstallAction({ paths, execFn: () => {}, apiKeyConfirmFn: async () => false, storeDeleteConfirmFn: async () => false, dbPath: ':memory:' });
       const output = spy.mock.calls.map((c) => c[0] as string).join('\n');

--- a/src/cli/commands/stop-feedback.test.ts
+++ b/src/cli/commands/stop-feedback.test.ts
@@ -73,8 +73,9 @@ const dismissRender: FeedbackRenderFn = async () => null;
 let store: Store;
 /** Never the real sender: a stray real call would POST to PostHog for real. */
 let sendDismissed: ReturnType<typeof vi.fn>;
+let sendRatingOption: ReturnType<typeof vi.fn>;
 
-beforeEach(async () => { store = await openStore(':memory:'); sendDismissed = vi.fn().mockResolvedValue(true); });
+beforeEach(async () => { store = await openStore(':memory:'); sendDismissed = vi.fn().mockResolvedValue(true); sendRatingOption = vi.fn().mockResolvedValue(true); });
 afterEach(() => { closeStore(store); vi.restoreAllMocks(); });
 
 describe('feedback popup integration', () => {
@@ -82,7 +83,7 @@ describe('feedback popup integration', () => {
     vi.mocked(flushLifecycle).mockClear();
     makeEligible(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed };
+    const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed, sendRatingOption };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -104,7 +105,7 @@ describe('feedback popup integration', () => {
     vi.mocked(flushLifecycle).mockClear();
     makeEligible(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: dismissRender, send, sendDismissed };
+    const deps: FeedbackDeps = { render: dismissRender, send, sendDismissed, sendRatingOption };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -119,7 +120,7 @@ describe('feedback popup integration', () => {
     vi.mocked(flushLifecycle).mockClear();
     makeEligible(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: pickRating(2), send, sendDismissed };
+    const deps: FeedbackDeps = { render: pickRating(2), send, sendDismissed, sendRatingOption };
 
     await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -128,12 +129,49 @@ describe('feedback popup integration', () => {
     expect(sendDismissed).not.toHaveBeenCalled();    // the two are exclusive
   });
 
+  it('⭐ a selection also reports the option under its own event name', async () => {
+    makeEligible(store);
+    const send = vi.fn().mockResolvedValue(true);
+    const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed, sendRatingOption };
+
+    await runStop(makePayload(), store, undefined, undefined, deps);
+
+    expect(sendRatingOption).toHaveBeenCalledOnce();
+    expect(sendRatingOption).toHaveBeenCalledWith(store, 3);   // the rating the user picked
+  });
+
+  it('⭐ a dismissal reports no option — there is none to report', async () => {
+    makeEligible(store);
+    const send = vi.fn().mockResolvedValue(true);
+    const deps: FeedbackDeps = { render: dismissRender, send, sendDismissed, sendRatingOption };
+
+    await runStop(makePayload(), store, undefined, undefined, deps);
+
+    expect(sendDismissed).toHaveBeenCalledOnce();
+    expect(sendRatingOption).not.toHaveBeenCalled();
+  });
+
+  it('a failed per-option send does not disturb the rating or the cadence', async () => {
+    // It is the second envelope on one consent; the record the dashboards were
+    // built on must not depend on it.
+    makeEligible(store);
+    const send = vi.fn().mockResolvedValue(true);
+    sendRatingOption.mockResolvedValue(false);
+    const deps: FeedbackDeps = { render: pickRating(1), send, sendDismissed, sendRatingOption };
+
+    const result = await runStop(makePayload(), store, undefined, undefined, deps);
+
+    expect(result.outcome).toBe('feedback_shown');
+    expect(send).toHaveBeenCalledOnce();
+    expect(readCadence(store).lastFeedbackAt).not.toBeNull();
+  });
+
   it('preempts the advisory when both are due', async () => {
     makeEligible(store);
     insertAdvisory(store);
     const advisorySelect: SelectFn = vi.fn().mockResolvedValue('some option');
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: pickRating(4), send, sendDismissed };
+    const deps: FeedbackDeps = { render: pickRating(4), send, sendDismissed, sendRatingOption };
 
     const result = await runStop(makePayload(), store, advisorySelect, undefined, deps);
 
@@ -145,7 +183,7 @@ describe('feedback popup integration', () => {
     insertAdvisory(store);
     const send = vi.fn().mockResolvedValue(true);
     const render = vi.fn<FeedbackRenderFn>(async () => null);
-    const deps: FeedbackDeps = { render, send, sendDismissed };
+    const deps: FeedbackDeps = { render, send, sendDismissed, sendRatingOption };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -157,7 +195,7 @@ describe('feedback popup integration', () => {
     makeEligible(store);
     insertAdvisory(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: null, send, sendDismissed };
+    const deps: FeedbackDeps = { render: null, send, sendDismissed, sendRatingOption };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -173,7 +211,7 @@ describe('feedback popup integration', () => {
       let s = await openStore(dbPath);
       makeEligible(s);
       const send = vi.fn().mockResolvedValue(true);
-      const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed };
+      const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed, sendRatingOption };
 
       const result = await runStop(makePayload(), s, undefined, undefined, deps);
       expect(result.outcome).toBe('feedback_shown');

--- a/src/cli/commands/stop-feedback.test.ts
+++ b/src/cli/commands/stop-feedback.test.ts
@@ -88,7 +88,7 @@ describe('feedback popup integration', () => {
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
     expect(result.outcome).toBe('feedback_shown');
-    expect(send).toHaveBeenCalledWith(store, 3);
+    expect(send).toHaveBeenCalledWith(store, 3, expect.any(Number));
     // consent gate: buffered lifecycle events flushed on a rating
     expect(flushLifecycle).toHaveBeenCalledWith(store);
     // cadence reset
@@ -137,7 +137,7 @@ describe('feedback popup integration', () => {
     await runStop(makePayload(), store, undefined, undefined, deps);
 
     expect(sendRatingOption).toHaveBeenCalledOnce();
-    expect(sendRatingOption).toHaveBeenCalledWith(store, 3);   // the rating the user picked
+    expect(sendRatingOption).toHaveBeenCalledWith(store, 3, expect.any(Number));   // rating + the shared timestamp
   });
 
   it('⭐ a dismissal reports no option — there is none to report', async () => {
@@ -215,7 +215,7 @@ describe('feedback popup integration', () => {
 
       const result = await runStop(makePayload(), s, undefined, undefined, deps);
       expect(result.outcome).toBe('feedback_shown');
-      expect(send).toHaveBeenCalledWith(s, 3);
+      expect(send).toHaveBeenCalledWith(s, 3, expect.any(Number));
       closeStore(s);
 
       // Reopen: markFeedbackShown ran after release→popup→reacquire+reload, so the

--- a/src/cli/commands/stop-feedback.test.ts
+++ b/src/cli/commands/stop-feedback.test.ts
@@ -71,7 +71,10 @@ const pickRating = (rating: number): FeedbackRenderFn => {
 const dismissRender: FeedbackRenderFn = async () => null;
 
 let store: Store;
-beforeEach(async () => { store = await openStore(':memory:'); });
+/** Never the real sender: a stray real call would POST to PostHog for real. */
+let sendDismissed: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => { store = await openStore(':memory:'); sendDismissed = vi.fn().mockResolvedValue(true); });
 afterEach(() => { closeStore(store); vi.restoreAllMocks(); });
 
 describe('feedback popup integration', () => {
@@ -79,7 +82,7 @@ describe('feedback popup integration', () => {
     vi.mocked(flushLifecycle).mockClear();
     makeEligible(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: pickRating(3), send };
+    const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -93,18 +96,36 @@ describe('feedback popup integration', () => {
     expect(c.lastFeedbackAt).not.toBeNull();
   });
 
-  it('resets cadence but does not send or flush on dismiss', async () => {
+  it('⭐ on dismiss: reports the dismissal, sends no rating, and does NOT flush', async () => {
+    // The dismissal event exists so that "asked and declined" is not the same
+    // absence in the data as "never asked". It must still not release the
+    // buffer: the rating CLICK is the consent for that, and this is its
+    // opposite.
     vi.mocked(flushLifecycle).mockClear();
     makeEligible(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: dismissRender, send };
+    const deps: FeedbackDeps = { render: dismissRender, send, sendDismissed };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
     expect(result.outcome).toBe('feedback_shown');
-    expect(send).not.toHaveBeenCalled();
+    expect(sendDismissed).toHaveBeenCalledOnce();
+    expect(send).not.toHaveBeenCalled();             // no rating to send
     expect(flushLifecycle).not.toHaveBeenCalled();   // no consent → no flush
     expect(readCadence(store).lastFeedbackAt).not.toBeNull();
+  });
+
+  it('⭐ on a selection: sends the rating and flushes, and does NOT report a dismissal', async () => {
+    vi.mocked(flushLifecycle).mockClear();
+    makeEligible(store);
+    const send = vi.fn().mockResolvedValue(true);
+    const deps: FeedbackDeps = { render: pickRating(2), send, sendDismissed };
+
+    await runStop(makePayload(), store, undefined, undefined, deps);
+
+    expect(send).toHaveBeenCalledOnce();
+    expect(flushLifecycle).toHaveBeenCalledOnce();
+    expect(sendDismissed).not.toHaveBeenCalled();    // the two are exclusive
   });
 
   it('preempts the advisory when both are due', async () => {
@@ -112,7 +133,7 @@ describe('feedback popup integration', () => {
     insertAdvisory(store);
     const advisorySelect: SelectFn = vi.fn().mockResolvedValue('some option');
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: pickRating(4), send };
+    const deps: FeedbackDeps = { render: pickRating(4), send, sendDismissed };
 
     const result = await runStop(makePayload(), store, advisorySelect, undefined, deps);
 
@@ -124,7 +145,7 @@ describe('feedback popup integration', () => {
     insertAdvisory(store);
     const send = vi.fn().mockResolvedValue(true);
     const render = vi.fn<FeedbackRenderFn>(async () => null);
-    const deps: FeedbackDeps = { render, send };
+    const deps: FeedbackDeps = { render, send, sendDismissed };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -136,7 +157,7 @@ describe('feedback popup integration', () => {
     makeEligible(store);
     insertAdvisory(store);
     const send = vi.fn().mockResolvedValue(true);
-    const deps: FeedbackDeps = { render: null, send };
+    const deps: FeedbackDeps = { render: null, send, sendDismissed };
 
     const result = await runStop(makePayload(), store, undefined, undefined, deps);
 
@@ -152,7 +173,7 @@ describe('feedback popup integration', () => {
       let s = await openStore(dbPath);
       makeEligible(s);
       const send = vi.fn().mockResolvedValue(true);
-      const deps: FeedbackDeps = { render: pickRating(3), send };
+      const deps: FeedbackDeps = { render: pickRating(3), send, sendDismissed };
 
       const result = await runStop(makePayload(), s, undefined, undefined, deps);
       expect(result.outcome).toBe('feedback_shown');

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -10,7 +10,7 @@ import {
 } from '../../store/pending-prompt-enhancements.js';
 import { isFeedbackEligible, markFeedbackShown } from '../../store/feedback-cadence.js';
 import { recordActionSignal, type PromptActionSignalKind } from '../../store/feedback-signals.js';
-import { sendFeedback } from '../../telemetry/feedback-send.js';
+import { sendFeedback, sendFeedbackDismissed } from '../../telemetry/feedback-send.js';
 import { runFeedbackPopup, type FeedbackRenderFn, type FeedbackResult } from '../../decision-session/feedback-popup.js';
 import { createFeedbackRenderFn } from '../../decision-session/feedback-tty.js';
 import type { SelectFn } from '../../decision-session/DecisionSession.js';
@@ -202,6 +202,18 @@ export function persistPromptEnhancementSequenceContinuationCancelV1(
 export interface FeedbackDeps {
   render: FeedbackRenderFn | null;
   send:   (store: Store, rating: number) => Promise<boolean>;
+  /**
+   * Required, not optional, and deliberately so: an optional field would let a
+   * test that forgets it fall through to the REAL sender, which posts to
+   * PostHog for real — the built-in api key is a shipped default, so nothing
+   * would stop it.
+   *
+   * ⚠️ `tsconfig.json` excludes `**​/*.test.ts`, so this is NOT caught at
+   * typecheck; a test that omits it fails at RUNTIME with "fbDismissed is not a
+   * function". Loud, immediate, and in the test rather than on the wire — which
+   * is the outcome that matters.
+   */
+  sendDismissed: (store: Store) => Promise<boolean>;
 }
 
 // ── Core logic ─────────────────────────────────────────────────────────────────
@@ -513,6 +525,7 @@ export async function runStop(
   if (isFeedbackEligible(store)) {
     const fbRender = feedbackDeps ? feedbackDeps.render : createFeedbackRenderFn();
     const fbSend   = feedbackDeps ? feedbackDeps.send   : sendFeedback;
+    const fbDismissed = feedbackDeps ? feedbackDeps.sendDismissed : sendFeedbackDismissed;
     if (fbRender) {
       // The popup blocks for user input; don't hold the global DB lock across it (MPS-8) — release
       // before, re-acquire + reload after, so other sessions are not blocked and their concurrent
@@ -526,6 +539,16 @@ export async function runStop(
         // Flush regardless of telemetry.enabled — this explicit action is the consent.
         await flushLifecycle(store);
         await fbSend(store, result.rating);
+      } else {
+        // Shown and closed without an answer. Reported so that "asked and
+        // declined" is distinguishable from "never asked" — without it the
+        // rating has no denominator of its own.
+        //
+        // NO FLUSH HERE, and that is the whole point: releasing the buffer is
+        // what the rating CLICK consents to, and this is the opposite of that
+        // click. The dismissal goes out on its own, carrying an installation id
+        // and a timestamp.
+        await fbDismissed(store);
       }
       markFeedbackShown(store);
       logger.info('stop_feedback_shown', { cwd: payload.cwd, selected: result.outcome === 'selected' });

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -10,7 +10,7 @@ import {
 } from '../../store/pending-prompt-enhancements.js';
 import { isFeedbackEligible, markFeedbackShown } from '../../store/feedback-cadence.js';
 import { recordActionSignal, type PromptActionSignalKind } from '../../store/feedback-signals.js';
-import { sendFeedback, sendFeedbackDismissed } from '../../telemetry/feedback-send.js';
+import { sendFeedback, sendFeedbackDismissed, sendFeedbackRatingOption } from '../../telemetry/feedback-send.js';
 import { runFeedbackPopup, type FeedbackRenderFn, type FeedbackResult } from '../../decision-session/feedback-popup.js';
 import { createFeedbackRenderFn } from '../../decision-session/feedback-tty.js';
 import type { SelectFn } from '../../decision-session/DecisionSession.js';
@@ -214,6 +214,8 @@ export interface FeedbackDeps {
    * is the outcome that matters.
    */
   sendDismissed: (store: Store) => Promise<boolean>;
+  /** Required for the same reason `sendDismissed` is — see above. */
+  sendRatingOption: (store: Store, rating: number) => Promise<boolean>;
 }
 
 // ── Core logic ─────────────────────────────────────────────────────────────────
@@ -526,6 +528,7 @@ export async function runStop(
     const fbRender = feedbackDeps ? feedbackDeps.render : createFeedbackRenderFn();
     const fbSend   = feedbackDeps ? feedbackDeps.send   : sendFeedback;
     const fbDismissed = feedbackDeps ? feedbackDeps.sendDismissed : sendFeedbackDismissed;
+    const fbRatingOption = feedbackDeps ? feedbackDeps.sendRatingOption : sendFeedbackRatingOption;
     if (fbRender) {
       // The popup blocks for user input; don't hold the global DB lock across it (MPS-8) — release
       // before, re-acquire + reload after, so other sessions are not blocked and their concurrent
@@ -539,6 +542,14 @@ export async function runStop(
         // Flush regardless of telemetry.enabled — this explicit action is the consent.
         await flushLifecycle(store);
         await fbSend(store, result.rating);
+        // The same answer under its own event NAME (`feedback_rating_good` and
+        // its siblings), alongside `feedback_submitted` rather than instead of
+        // it — replacing would rename history and break existing charts.
+        //
+        // AFTER the rating, not before: this is a second envelope on the SAME
+        // consent, and if one of the two has to fail it should be the
+        // convenience one, not the record the dashboards were built on.
+        await fbRatingOption(store, result.rating);
       } else {
         // Shown and closed without an answer. Reported so that "asked and
         // declined" is distinguishable from "never asked" — without it the

--- a/src/cli/commands/stop.ts
+++ b/src/cli/commands/stop.ts
@@ -201,7 +201,7 @@ export function persistPromptEnhancementSequenceContinuationCancelV1(
  */
 export interface FeedbackDeps {
   render: FeedbackRenderFn | null;
-  send:   (store: Store, rating: number) => Promise<boolean>;
+  send:   (store: Store, rating: number, now?: number) => Promise<boolean>;
   /**
    * Required, not optional, and deliberately so: an optional field would let a
    * test that forgets it fall through to the REAL sender, which posts to
@@ -215,7 +215,7 @@ export interface FeedbackDeps {
    */
   sendDismissed: (store: Store) => Promise<boolean>;
   /** Required for the same reason `sendDismissed` is — see above. */
-  sendRatingOption: (store: Store, rating: number) => Promise<boolean>;
+  sendRatingOption: (store: Store, rating: number, now?: number) => Promise<boolean>;
 }
 
 // ── Core logic ─────────────────────────────────────────────────────────────────
@@ -526,9 +526,17 @@ export async function runStop(
   //      consuming the cadence) when no renderer is available.
   if (isFeedbackEligible(store)) {
     const fbRender = feedbackDeps ? feedbackDeps.render : createFeedbackRenderFn();
-    const fbSend   = feedbackDeps ? feedbackDeps.send   : sendFeedback;
+    // The two rating envelopes describe ONE click, so they take one timestamp
+    // rather than each calling `Date.now()` — a millisecond apart is enough to
+    // break anything that joins them on time, and the browser's end-to-end suite
+    // caught exactly that happening under load.
+    const fbSend = feedbackDeps
+      ? feedbackDeps.send
+      : (s: Store, r: number, n?: number) => sendFeedback(s, r, n === undefined ? {} : { now: n });
     const fbDismissed = feedbackDeps ? feedbackDeps.sendDismissed : sendFeedbackDismissed;
-    const fbRatingOption = feedbackDeps ? feedbackDeps.sendRatingOption : sendFeedbackRatingOption;
+    const fbRatingOption = feedbackDeps
+      ? feedbackDeps.sendRatingOption
+      : (s: Store, r: number, n?: number) => sendFeedbackRatingOption(s, r, n === undefined ? {} : { now: n });
     if (fbRender) {
       // The popup blocks for user input; don't hold the global DB lock across it (MPS-8) — release
       // before, re-acquire + reload after, so other sessions are not blocked and their concurrent
@@ -541,7 +549,8 @@ export async function runStop(
         // events (install + advisory + option-selected), then send the rating.
         // Flush regardless of telemetry.enabled — this explicit action is the consent.
         await flushLifecycle(store);
-        await fbSend(store, result.rating);
+        const answeredAt = Date.now();
+        await fbSend(store, result.rating, answeredAt);
         // The same answer under its own event NAME (`feedback_rating_good` and
         // its siblings), alongside `feedback_submitted` rather than instead of
         // it — replacing would rename history and break existing charts.
@@ -549,7 +558,7 @@ export async function runStop(
         // AFTER the rating, not before: this is a second envelope on the SAME
         // consent, and if one of the two has to fail it should be the
         // convenience one, not the record the dashboards were built on.
-        await fbRatingOption(store, result.rating);
+        await fbRatingOption(store, result.rating, answeredAt);
       } else {
         // Shown and closed without an answer. Reported so that "asked and
         // declined" is distinguishable from "never asked" — without it the

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -153,6 +153,24 @@ once testing is done.
   (verified by OPTIONS preflight), so an ordinary request from the worker succeeds. The install
   dialog therefore still reads **4 domains**. If a reviewer asks why an analytics host appears in the
   source but not in the permissions, that is the answer.
+- **The complete event list** (reviewers do ask for it by name). Sixteen, and no others. Every one
+  carries the same four fields — a random installation ID, `$lib`, `$lib_version`, `surface:"browser"` —
+  plus the one timestamp named beside it. **No event has a field that can hold text.**
+
+  | Event | When | Extra field |
+  |---|---|---|
+  | `nexpath_installed` | once, on the first send after install | `installed_at` |
+  | `feedback_submitted` | the user answers the rating prompt | `rating`, `feedback_at` |
+  | `feedback_rating_bad` / `_fine` / `_good` / `_excellent` | the same answer under its own name | `rating`, `feedback_at` |
+  | `feedback_dismissed` | the prompt was shown and closed unanswered | `dismissed_at` |
+  | `pe_use_current`, `pe_use_original`, `pe_apply_details`, `pe_close` | a prompt-enhancement popup button | `action_ts` |
+  | `mps_send`, `mps_cancel`, `mps_decline`, `mps_interruption`, `mps_apply_details` | a sequence-offer button | `action_ts` |
+
+  The nine `pe_*` / `mps_*` events are BUFFERED locally as they happen and leave only when the user
+  answers a rating; `feedback_dismissed` is the one event that goes out without that answer, and it
+  releases nothing that was buffered. Keep this table in step with `adapters/telemetry-send.ts` — a
+  test in `options.test.ts` fails if an event name here is not in the code, or the reverse.
+
 - **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
   a random installation ID, a 1–4 rating, and content-free action names + timestamps. Dismissing the
   prompt sends ONE line — the installation ID and a timestamp — and releases none of the buffered

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -73,8 +73,14 @@ not `npm install`, and match the Node version above.
 
 The Firefox manifest sets `strict_min_version` **112** and declares
 `browser_specific_settings.gecko.data_collection_permissions.required = ["authenticationInfo",
-"websiteContent"]` (Mozilla's built-in data-consent) — keep these in sync with the store data
-disclosures (the API key + prompt text).
+"websiteContent", "technicalAndInteraction"]` (Mozilla's built-in data-consent) — keep these in sync
+with the store data disclosures (the API key + prompt text, and the rating telemetry).
+
+`technicalAndInteraction` covers the rating send (installation ID, rating, timestamps). It is
+declared **required**, not optional: Mozilla allows that one category under `optional`, but only for
+an extension that offers a per-category opt-out, and this one has none. Revisit if a telemetry kill
+switch ships. ⚠️ Verify the spelling against AMO at submission — an unrecognised category value is
+rejected there, not at build time.
 
 ---
 
@@ -125,9 +131,18 @@ once testing is done.
 - **Name:** Nexpath · **Category:** Developer Tools.
 - **Summary:** "Behaviour guidance for vibe coders using AI coding agents."
 - **Permission justifications** (both stores ask): `storage` (save key/settings), `tabs` (show the
-  popup on the right tab), host access limited to
-  `*.replit.com`, `bolt.new`, `*.stackblitz.com`, `lovable.dev`. (Injection is declarative —
-  `content_scripts` + `web_accessible_resources` — so no `scripting` permission is requested.)
+  popup on the right tab), and host access to **five** hosts —
+  `*.replit.com`, `bolt.new`, `*.stackblitz.com`, `lovable.dev` (the agent sites the extension runs
+  on) plus `us.i.posthog.com` (the analytics host it POSTs a rating to; it is talked **to**, never
+  run **on** — no content script matches it). (Injection is declarative — `content_scripts` +
+  `web_accessible_resources` — so no `scripting` permission is requested.)
+- ⚠️ **The install dialog now reads "Access your data for sites in 5 domains", not 4.** That dialog
+  is the browser's own consent UI and cannot be suppressed — only its contents change. Expect the
+  extra host to draw a reviewer question; the answer is the bullet above.
+- **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
+  a random installation ID, a 1–4 rating, and content-free action names + timestamps. **Never**
+  prompt text, option text, URLs or project paths. Keep this identical to the *Privacy* section of
+  `src/ext-browser/README.md`, which is what the privacy-policy URL points at.
 - **Privacy policy URL**, **screenshots** (1280×800), **128×128 icon** (`icons/icon128.png`).
 
 ---

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -131,14 +131,14 @@ once testing is done.
 - **Name:** Nexpath · **Category:** Developer Tools.
 - **Summary:** "Behaviour guidance for vibe coders using AI coding agents."
 - **Permission justifications** (both stores ask): `storage` (save key/settings), `tabs` (show the
-  popup on the right tab), and host access to **five** hosts —
-  `*.replit.com`, `bolt.new`, `*.stackblitz.com`, `lovable.dev` (the agent sites the extension runs
-  on) plus `us.i.posthog.com` (the analytics host it POSTs a rating to; it is talked **to**, never
-  run **on** — no content script matches it). (Injection is declarative — `content_scripts` +
-  `web_accessible_resources` — so no `scripting` permission is requested.)
-- ⚠️ **The install dialog now reads "Access your data for sites in 5 domains", not 4.** That dialog
-  is the browser's own consent UI and cannot be suppressed — only its contents change. Expect the
-  extra host to draw a reviewer question; the answer is the bullet above.
+  popup on the right tab), host access limited to
+  `*.replit.com`, `bolt.new`, `*.stackblitz.com`, `lovable.dev`. (Injection is declarative —
+  `content_scripts` + `web_accessible_resources` — so no `scripting` permission is requested.)
+- **The rating POST needs no host permission**, and none is requested. `host_permissions` exists to
+  bypass CORS, and `us.i.posthog.com/capture/` sends CORS headers for a `chrome-extension://` origin
+  (verified by OPTIONS preflight), so an ordinary request from the worker succeeds. The install
+  dialog therefore still reads **4 domains**. If a reviewer asks why an analytics host appears in the
+  source but not in the permissions, that is the answer.
 - **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
   a random installation ID, a 1–4 rating, and content-free action names + timestamps. **Never**
   prompt text, option text, URLs or project paths. Keep this identical to the *Privacy* section of

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -77,10 +77,24 @@ The Firefox manifest sets `strict_min_version` **112** and declares
 with the store data disclosures (the API key + prompt text, and the rating telemetry).
 
 `technicalAndInteraction` covers the rating send (installation ID, rating, timestamps). It is
-declared **required**, not optional: Mozilla allows that one category under `optional`, but only for
-an extension that offers a per-category opt-out, and this one has none. Revisit if a telemetry kill
-switch ships. ⚠️ Verify the spelling against AMO at submission — an unrecognised category value is
-rejected there, not at build time.
+declared **required**, not `optional`, and the reason is a mechanism mismatch — not an absence of
+user control. The extension DOES have a kill switch (Settings → Feedback), but that is an extension
+setting; Mozilla's `optional` is a permission the BROWSER toggles in about:addons and the extension
+is expected to honour through `browser.permissions`. Declaring `optional` while ignoring that API
+would advertise a control the extension does not read.
+
+Honouring it properly is blocked by our own support range: `strict_min_version` is **112**, and
+data-collection permissions are a much later Firefox feature (140+). Across most of the range we
+ship to, the key is ignored entirely and the `browser.permissions` data-collection API is not there
+to check — so an `optional` declaration would have to fail open on those versions, which is the
+opposite of what declaring it optional promises.
+
+`required` is therefore the honest declaration: when this extension collects, it does so under its
+own setting, with no browser-level toggle involved. Revisit if `strict_min_version` ever rises past
+the versions that support the API.
+
+⚠️ Verify the spelling against AMO at submission — an unrecognised category value is rejected there,
+not at build time.
 
 ---
 
@@ -141,8 +155,9 @@ once testing is done.
   source but not in the permissions, that is the answer.
 - **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
   a random installation ID, a 1–4 rating, and content-free action names + timestamps. **Never**
-  prompt text, option text, URLs or project paths. Keep this identical to the *Privacy* section of
-  `src/ext-browser/README.md`, which is what the privacy-policy URL points at.
+  prompt text, option text, URLs or project paths. **There is a user control:** Settings → Feedback →
+  "Never ask" stops the prompt, and with it every send. Keep all of this identical to the *Privacy*
+  section of `src/ext-browser/README.md`, which is what the privacy-policy URL points at.
 - **Privacy policy URL**, **screenshots** (1280×800), **128×128 icon** (`icons/icon128.png`).
 
 ---

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -174,10 +174,14 @@ once testing is done.
 - **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
   a random installation ID, a 1–4 rating, and content-free action names + timestamps. Dismissing the
   prompt sends ONE line — the installation ID and a timestamp — and releases none of the buffered
-  action names. **Never** prompt text, option text, URLs or project paths. **There is a user
-  control:** Settings → Feedback → "Never ask" stops the prompt, and with it every send. Keep all of
-  this identical to the *Privacy* section of `src/ext-browser/README.md`, which is what the
-  privacy-policy URL points at.
+  action names. **Never** prompt text, option text, URLs or project paths.
+- ⚠️ **There is NO per-user opt-out, and a reviewer may ask.** The rating prompt is shown to every
+  installation (owner decision 2026-09-01); the options page carries no toggle for it and the
+  extension reads no setting that would disable it. This matches the CLI, whose feedback send is
+  deliberately independent of `telemetry.enabled` because the click is the consent. What limits the
+  data is its shape, not a switch: nothing is sent unless the user answers or dismisses the prompt,
+  and no field in any envelope can hold text. Keep this and the event table identical to the
+  *Privacy* section of `src/ext-browser/README.md`, which is what the privacy-policy URL points at.
 - **Privacy policy URL**, **screenshots** (1280×800), **128×128 icon** (`icons/icon128.png`).
 
 ---

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -154,10 +154,12 @@ once testing is done.
   dialog therefore still reads **4 domains**. If a reviewer asks why an analytics host appears in the
   source but not in the permissions, that is the answer.
 - **Data disclosure** — what leaves the machine, and only when the user answers the rating prompt:
-  a random installation ID, a 1–4 rating, and content-free action names + timestamps. **Never**
-  prompt text, option text, URLs or project paths. **There is a user control:** Settings → Feedback →
-  "Never ask" stops the prompt, and with it every send. Keep all of this identical to the *Privacy*
-  section of `src/ext-browser/README.md`, which is what the privacy-policy URL points at.
+  a random installation ID, a 1–4 rating, and content-free action names + timestamps. Dismissing the
+  prompt sends ONE line — the installation ID and a timestamp — and releases none of the buffered
+  action names. **Never** prompt text, option text, URLs or project paths. **There is a user
+  control:** Settings → Feedback → "Never ask" stops the prompt, and with it every send. Keep all of
+  this identical to the *Privacy* section of `src/ext-browser/README.md`, which is what the
+  privacy-policy URL points at.
 - **Privacy policy URL**, **screenshots** (1280×800), **128×128 icon** (`icons/icon128.png`).
 
 ---

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -88,9 +88,6 @@ workflow without slowing it down.
 - **If you dismiss the prompt, one line goes out saying just that** — your installation ID and the
   time, so we can tell "asked and declined" apart from "never asked". No rating, because you did not
   give one, and the local usage signals above stay on your machine: only answering releases those.
-- **You can turn the prompt off, and that turns the sending off with it.** Settings → Feedback →
-  "Never ask". Nothing is ever sent without the prompt, so switching it off leaves the extension
-  sending nothing at all.
 - **Your prompt text is never part of that.** The only place prompt text goes is OpenAI, with your
   own key, as described above.
 

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -84,8 +84,7 @@ workflow without slowing it down.
 - **The only thing that sends is the rating prompt, and only when you answer it.** Occasionally
   Nexpath asks how it is working out for you. Choosing a rating is what sends — and it sends only
   a random installation ID (not tied to you or your machine), your 1–4 rating, and the timestamps
-  above. Dismissing the prompt sends nothing and clears nothing. This is why the extension asks for
-  access to `us.i.posthog.com`, the analytics host that receives it.
+  above. Dismissing the prompt sends nothing and clears nothing.
 - **Your prompt text is never part of that.** The only place prompt text goes is OpenAI, with your
   own key, as described above.
 

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -84,7 +84,10 @@ workflow without slowing it down.
 - **The only thing that sends is the rating prompt, and only when you answer it.** Occasionally
   Nexpath asks how it is working out for you. Choosing a rating is what sends — and it sends only
   a random installation ID (not tied to you or your machine), your 1–4 rating, and the timestamps
-  above. Dismissing the prompt sends nothing and clears nothing.
+  above.
+- **If you dismiss the prompt, one line goes out saying just that** — your installation ID and the
+  time, so we can tell "asked and declined" apart from "never asked". No rating, because you did not
+  give one, and the local usage signals above stay on your machine: only answering releases those.
 - **You can turn the prompt off, and that turns the sending off with it.** Settings → Feedback →
   "Never ask". Nothing is ever sent without the prompt, so switching it off leaves the extension
   sending nothing at all.

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -75,7 +75,19 @@ workflow without slowing it down.
 - Your **API key** and settings are stored **locally in your browser** — never bundled or logged.
 - To generate a decision session, Nexpath sends **recent prompt context to OpenAI** using **your**
   key — that is the only place your prompt text is sent, and only when a session fires.
-- **No telemetry, no tracking, no remote code.** Nothing is sent to any Nexpath or third-party server.
+- **No tracking and no remote code.** There is no analytics script, no ad or tracking network, and
+  no code is ever downloaded and run.
+- **Usage signals stay on your machine until you choose to send them.** Nexpath keeps a local,
+  content-free record of *which* popup buttons you press and *when* — a fixed list of action names
+  (for example `pe_shorter`, `mps_send`) and timestamps. It never records prompt text, the text of
+  an option, which site you are on, or your project path.
+- **The only thing that sends is the rating prompt, and only when you answer it.** Occasionally
+  Nexpath asks how it is working out for you. Choosing a rating is what sends — and it sends only
+  a random installation ID (not tied to you or your machine), your 1–4 rating, and the timestamps
+  above. Dismissing the prompt sends nothing and clears nothing. This is why the extension asks for
+  access to `us.i.posthog.com`, the analytics host that receives it.
+- **Your prompt text is never part of that.** The only place prompt text goes is OpenAI, with your
+  own key, as described above.
 
 ---
 

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -85,6 +85,9 @@ workflow without slowing it down.
   Nexpath asks how it is working out for you. Choosing a rating is what sends — and it sends only
   a random installation ID (not tied to you or your machine), your 1–4 rating, and the timestamps
   above. Dismissing the prompt sends nothing and clears nothing.
+- **You can turn the prompt off, and that turns the sending off with it.** Settings → Feedback →
+  "Never ask". Nothing is ever sent without the prompt, so switching it off leaves the extension
+  sending nothing at all.
 - **Your prompt text is never part of that.** The only place prompt text goes is OpenAI, with your
   own key, as described above.
 

--- a/src/ext-browser/adapters/lifecycle-signals.test.ts
+++ b/src/ext-browser/adapters/lifecycle-signals.test.ts
@@ -189,3 +189,73 @@ describe('the install-event sent flag', () => {
     expect(await isInstalledEventSent(store)).toBe(false);
   });
 });
+
+/**
+ * The regression for a bug that was measured, not imagined: before the writes
+ * were serialised, two overlapping `recordSignal` calls left ONE signal. The
+ * whole buffer lives under one storage key, so both read the old list and the
+ * second write erased the first — and `pe-popup-host.ts` fires these off with
+ * `void` on every popup action, so overlap is the normal case, not the edge one.
+ */
+describe('⭐ concurrent writes do not lose each other', () => {
+  /** A store with a real await on both sides, so overlap actually happens. */
+  function slowStore() {
+    const data: Record<string, string> = {};
+    const tick = () => new Promise((r) => setTimeout(r, 0));
+    const store: LifecycleSignalsKeyStore = {
+      getKey: async (k) => { await tick(); return k in data ? data[k] : null; },
+      setKey: async (k, v) => { await tick(); data[k] = v; },
+    };
+    return { store, data };
+  }
+
+  it('two overlapping records both survive', async () => {
+    const { store } = slowStore();
+
+    await Promise.all([
+      recordSignal(store, 'pe_close', T0),
+      recordSignal(store, 'pe_back',  T0 + 1),
+    ]);
+
+    expect((await readSignals(store)).map((s) => s.kind)).toEqual(['pe_close', 'pe_back']);
+  });
+
+  it('ten overlapping records all survive', async () => {
+    const { store } = slowStore();
+
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) => recordSignal(store, SIGNAL_ADVISORY_FIRED, T0 + i)),
+    );
+
+    expect(await readSignals(store)).toHaveLength(10);
+  });
+
+  it('a prune racing a record does not drop the record', async () => {
+    const { store } = slowStore();
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    await Promise.all([
+      pruneSignalAt(store, SIGNAL_ADVISORY_FIRED, T0),
+      recordSignal(store, 'mps_send', T0 + 5),
+    ]);
+
+    expect((await readSignals(store)).map((s) => s.kind)).toEqual(['mps_send']);
+  });
+
+  it('a failing write does not wedge the queue for the next caller', async () => {
+    const data: Record<string, string> = {};
+    let failNext = true;
+    const store: LifecycleSignalsKeyStore = {
+      getKey: async (k) => (k in data ? data[k] : null),
+      setKey: async (k, v) => {
+        if (failNext) { failNext = false; throw new Error('quota'); }
+        data[k] = v;
+      },
+    };
+
+    await recordSignal(store, 'pe_close', T0);        // this one is lost to the failure
+    await recordSignal(store, 'pe_back',  T0 + 1);    // this one must still land
+
+    expect((await readSignals(store)).map((s) => s.kind)).toEqual(['pe_back']);
+  });
+});

--- a/src/ext-browser/adapters/lifecycle-signals.test.ts
+++ b/src/ext-browser/adapters/lifecycle-signals.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readSignals, recordSignal, pruneSignalAt,
+  getInstalledAt, setInstalledAtIfMissing,
+  isInstalledEventSent, markInstalledEventSent,
+  SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED,
+  KEY_SIGNALS, KEY_INSTALLED_AT, KEY_INSTALLED_EVENT_SENT, MAX_SIGNALS,
+  type LifecycleSignalsKeyStore,
+} from './lifecycle-signals.js';
+
+function memStore(seed: Record<string, string> = {}) {
+  const data = { ...seed };
+  const store: LifecycleSignalsKeyStore = {
+    getKey: async (k) => (k in data ? data[k] : null),
+    setKey: async (k, v) => { data[k] = v; },
+  };
+  return { store, data };
+}
+
+const T0 = 1_700_000_000_000;
+
+describe('the signal buffer', () => {
+  it('starts empty', async () => {
+    expect(await readSignals(memStore().store)).toEqual([]);
+  });
+
+  it('records and reads back oldest first, whatever order they arrive in', async () => {
+    const { store } = memStore();
+
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0 + 200);
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0);
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0 + 100);
+
+    expect(await readSignals(store)).toEqual([
+      { kind: SIGNAL_ADVISORY_FIRED,  occurredAt: T0 },
+      { kind: SIGNAL_ADVISORY_FIRED,  occurredAt: T0 + 100 },
+      { kind: SIGNAL_OPTION_SELECTED, occurredAt: T0 + 200 },
+    ]);
+  });
+
+  it('⭐ stores nothing but a kind and a timestamp', async () => {
+    // The privacy claim, checked against what is actually on disk rather than
+    // against the type: no prompt text, option text, index, URL or root.
+    const { store, data } = memStore();
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    const stored = JSON.parse(data[KEY_SIGNALS]);
+    expect(Object.keys(stored[0]).sort()).toEqual(['kind', 'occurredAt']);
+  });
+
+  it('caps at MAX_SIGNALS, dropping the OLDEST', async () => {
+    const { store } = memStore({
+      [KEY_SIGNALS]: JSON.stringify(
+        Array.from({ length: MAX_SIGNALS }, (_, i) => ({ kind: SIGNAL_ADVISORY_FIRED, occurredAt: T0 + i })),
+      ),
+    });
+
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0 + MAX_SIGNALS);
+
+    const list = await readSignals(store);
+    expect(list).toHaveLength(MAX_SIGNALS);
+    expect(list[0].occurredAt).toBe(T0 + 1);                       // the oldest went
+    expect(list[list.length - 1]).toEqual({ kind: SIGNAL_OPTION_SELECTED, occurredAt: T0 + MAX_SIGNALS });
+  });
+
+  it('prunes exactly one (kind, occurredAt) and leaves everything else', async () => {
+    const { store } = memStore();
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0);
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0);          // same ts, other kind
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0 + 1);
+
+    await pruneSignalAt(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    expect(await readSignals(store)).toEqual([
+      { kind: SIGNAL_OPTION_SELECTED, occurredAt: T0 },
+      { kind: SIGNAL_ADVISORY_FIRED,  occurredAt: T0 + 1 },
+    ]);
+  });
+
+  it('pruning a pair removes its duplicates too, as the CLI DELETE does', async () => {
+    const { store } = memStore();
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED, T0);
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    await pruneSignalAt(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    expect(await readSignals(store)).toEqual([]);
+  });
+
+  it('pruning something that is not there changes nothing', async () => {
+    const { store } = memStore();
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED, T0);
+
+    await pruneSignalAt(store, SIGNAL_OPTION_SELECTED, T0);
+
+    expect(await readSignals(store)).toHaveLength(1);
+  });
+});
+
+describe('a damaged buffer reads as empty, never as junk', () => {
+  it.each([
+    ['malformed JSON',   '{not json'],
+    ['a JSON non-array', '{"kind":"advisory_fired"}'],
+    ['a JSON scalar',    '42'],
+  ])('%s', async (_label, raw) => {
+    expect(await readSignals(memStore({ [KEY_SIGNALS]: raw }).store)).toEqual([]);
+  });
+
+  it('⭐ drops entries that are not well-formed signals', async () => {
+    // Otherwise a junk `kind` reaches the flush and is posted as an event NAME.
+    const { store } = memStore({
+      [KEY_SIGNALS]: JSON.stringify([
+        { kind: SIGNAL_ADVISORY_FIRED, occurredAt: T0 },
+        { kind: 'drop_table_users',    occurredAt: T0 + 1 },   // unknown kind
+        { kind: SIGNAL_ADVISORY_FIRED, occurredAt: 'soon' },   // bad timestamp
+        { kind: SIGNAL_ADVISORY_FIRED },                       // no timestamp
+        null,
+        'a string',
+      ]),
+    });
+
+    expect(await readSignals(store)).toEqual([{ kind: SIGNAL_ADVISORY_FIRED, occurredAt: T0 }]);
+  });
+
+  it('an unreadable store reads as empty', async () => {
+    const store: LifecycleSignalsKeyStore = {
+      getKey: async () => { throw new Error('gone'); },
+      setKey: async () => {},
+    };
+    expect(await readSignals(store)).toEqual([]);
+  });
+
+  it('an unwritable store does not throw out of recordSignal', async () => {
+    const store: LifecycleSignalsKeyStore = {
+      getKey: async () => null,
+      setKey: async () => { throw new Error('quota'); },
+    };
+    await expect(recordSignal(store, SIGNAL_ADVISORY_FIRED, T0)).resolves.toBeUndefined();
+  });
+});
+
+describe('the install stamp', () => {
+  it('setInstalledAtIfMissing writes once and never overwrites', async () => {
+    const { store, data } = memStore();
+
+    await setInstalledAtIfMissing(store, T0);
+    await setInstalledAtIfMissing(store, T0 + 99_999);
+
+    expect(data[KEY_INSTALLED_AT]).toBe(String(T0));
+  });
+
+  it('getInstalledAt backfills a missing stamp once, then reads it back', async () => {
+    const { store, data } = memStore();
+
+    expect(await getInstalledAt(store, T0)).toBe(T0);
+    expect(data[KEY_INSTALLED_AT]).toBe(String(T0));
+    expect(await getInstalledAt(store, T0 + 5_000)).toBe(T0);       // not re-stamped
+  });
+
+  it('a corrupt stamp is treated as absent and re-stamped', async () => {
+    const { store } = memStore({ [KEY_INSTALLED_AT]: 'yesterday' });
+
+    expect(await getInstalledAt(store, T0)).toBe(T0);
+  });
+});
+
+describe('the install-event sent flag', () => {
+  it('is false until marked, true after', async () => {
+    const { store, data } = memStore();
+
+    expect(await isInstalledEventSent(store)).toBe(false);
+    await markInstalledEventSent(store);
+    expect(await isInstalledEventSent(store)).toBe(true);
+    expect(data[KEY_INSTALLED_EVENT_SENT]).toBe('true');
+  });
+
+  it('⭐ an unreadable flag reads as NOT sent', async () => {
+    // Fails toward a duplicate install event rather than toward losing the
+    // denominator entirely.
+    const store: LifecycleSignalsKeyStore = {
+      getKey: async () => { throw new Error('gone'); },
+      setKey: async () => {},
+    };
+    expect(await isInstalledEventSent(store)).toBe(false);
+  });
+
+  it('anything other than the exact string "true" is not sent', async () => {
+    const { store } = memStore({ [KEY_INSTALLED_EVENT_SENT]: 'TRUE' });
+    expect(await isInstalledEventSent(store)).toBe(false);
+  });
+});

--- a/src/ext-browser/adapters/lifecycle-signals.ts
+++ b/src/ext-browser/adapters/lifecycle-signals.ts
@@ -1,0 +1,209 @@
+/**
+ * The browser's lifecycle signal buffer — a port of the CLI's
+ * `store/feedback-signals.ts`, narrowed to what §4.2 of the dev plan asks for:
+ * an install stamp, a one-time sent-flag, and a capped list of
+ * `{kind, occurredAt}`.
+ *
+ * Content-free by construction. A signal is a KIND from a fixed two-value enum
+ * plus a timestamp. No prompt text, option text, option index, project root or
+ * URL is stored — there is no field here that could carry one.
+ *
+ * Writes are unconditional. Buffering locally is not sending: nothing leaves
+ * the machine until the user clicks a rating, which is the browser's consent
+ * moment (§4.2).
+ *
+ * ── WHAT CHANGED IN THE PORT, AND WHY ────────────────────────────────────────
+ *
+ * 1. **One `storage.local` key holding a JSON array, not a SQL table.** The CLI
+ *    can `DELETE ... WHERE`; this has to read, filter and write back.
+ *
+ * 2. **CAPPED.** The CLI's table is unbounded because a flush is never far away
+ *    — the CLI has an install-time consent, so telemetry-on users flush at each
+ *    occurrence. The browser has no consent moment until the first rating, and
+ *    a user who never rates buffers forever. The cap makes that bounded, and
+ *    drops the OLDEST first so the buffer keeps the most recent picture.
+ *
+ * 3. **`project_root` is dropped.** The CLI stores it and then never sends it
+ *    (`lifecycle-send.ts` posts a timestamp only), and its per-project readers
+ *    serve CLI paths with no browser equivalent. Storing a field nothing reads
+ *    and nothing sends would be collecting for its own sake.
+ *
+ * 4. **Never throws.** Same rule as the cadence: measurement must not be able to
+ *    break the pipeline it measures. A damaged buffer reads as EMPTY.
+ *
+ * 5. **Only the two lifecycle kinds.** The CLI also buffers the Plan-B per-action
+ *    kinds (`pe_*`, `mps_*`); §4.2 scopes the browser to `advisory_fired` and
+ *    `option_selected` plus the install stamp.
+ */
+
+/** The slice of the key store this module needs; injected so tests need no polyfill. */
+export interface LifecycleSignalsKeyStore {
+  getKey(name: string): Promise<string | null>;
+  setKey(name: string, value: string): Promise<void>;
+}
+
+/** `feedback-signals.ts:15-16` — the CLI's kind strings, which are also the event names. */
+export const SIGNAL_ADVISORY_FIRED  = 'advisory_fired';
+export const SIGNAL_OPTION_SELECTED = 'option_selected';
+
+export type SignalKind = typeof SIGNAL_ADVISORY_FIRED | typeof SIGNAL_OPTION_SELECTED;
+
+/** CLI-mirrored config keys keep the CLI's bare names, as the cadence keys do. */
+export const KEY_INSTALLED_AT         = 'installed_at';
+export const KEY_INSTALLED_EVENT_SENT = 'installed_event_sent';
+
+/**
+ * The buffer itself is browser-only state with no CLI key to mirror — the CLI
+ * keeps it in a table — so it takes the extension's own `nexpath_*` prefix.
+ */
+export const KEY_SIGNALS = 'nexpath_lifecycle_signals';
+
+/**
+ * Most signals kept. Chosen to sit far above any plausible pre-first-rating
+ * count while staying trivially small on disk (~40 bytes each, so ~20 KB full).
+ */
+export const MAX_SIGNALS = 500;
+
+export interface LifecycleSignal {
+  kind:       SignalKind;
+  occurredAt: number;
+}
+
+const KINDS: readonly string[] = [SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED];
+
+function isSignal(v: unknown): v is LifecycleSignal {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.kind === 'string' && KINDS.includes(o.kind)
+    && typeof o.occurredAt === 'number' && Number.isFinite(o.occurredAt);
+}
+
+/**
+ * Every buffered signal, oldest first — the CLI's `ORDER BY occurred_at ASC`.
+ *
+ * A missing key, an unreadable store, malformed JSON and a non-array all answer
+ * the same way: empty. Entries that are not well-formed signals are dropped
+ * rather than passed on, so a damaged buffer cannot put a junk `kind` on the
+ * wire as an event name.
+ */
+export async function readSignals(store: LifecycleSignalsKeyStore): Promise<LifecycleSignal[]> {
+  let raw: string | null;
+  try {
+    raw = await store.getKey(KEY_SIGNALS);
+  } catch {
+    return [];
+  }
+  if (raw === null) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isSignal).sort((a, b) => a.occurredAt - b.occurredAt);
+}
+
+async function writeSignals(store: LifecycleSignalsKeyStore, list: LifecycleSignal[]): Promise<void> {
+  try {
+    await store.setKey(KEY_SIGNALS, JSON.stringify(list));
+  } catch {
+    /* buffering is best-effort; a lost signal must not break the caller */
+  }
+}
+
+/**
+ * Buffer one signal. Over the cap the OLDEST are dropped, so the buffer holds
+ * the most recent `MAX_SIGNALS`.
+ */
+export async function recordSignal(
+  store:      LifecycleSignalsKeyStore,
+  kind:       SignalKind,
+  occurredAt: number = Date.now(),
+): Promise<void> {
+  const list = await readSignals(store);
+  list.push({ kind, occurredAt });
+  list.sort((a, b) => a.occurredAt - b.occurredAt);
+  await writeSignals(store, list.slice(Math.max(0, list.length - MAX_SIGNALS)));
+}
+
+/**
+ * Drop every signal matching this exact (kind, occurredAt).
+ *
+ * Matches the CLI's `pruneSignalAt` — a `DELETE ... WHERE kind = ? AND
+ * occurred_at = ?`, which also removes duplicates of the pair. Called only
+ * after that signal's own send succeeded, so a failed send stays buffered.
+ */
+export async function pruneSignalAt(
+  store:      LifecycleSignalsKeyStore,
+  kind:       SignalKind,
+  occurredAt: number,
+): Promise<void> {
+  const list = await readSignals(store);
+  const kept = list.filter((s) => !(s.kind === kind && s.occurredAt === occurredAt));
+  if (kept.length !== list.length) await writeSignals(store, kept);
+}
+
+async function readNum(store: LifecycleSignalsKeyStore, key: string): Promise<number | null> {
+  let raw: string | null;
+  try {
+    raw = await store.getKey(key);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Record the install time, but only if one is not already set — the CLI's
+ * `setInstalledAtIfMissing`. Safe to call on every install AND update, which is
+ * what backfills the stamp for an installation that predates this field.
+ */
+export async function setInstalledAtIfMissing(
+  store: LifecycleSignalsKeyStore,
+  now:   number = Date.now(),
+): Promise<void> {
+  if (await readNum(store, KEY_INSTALLED_AT) !== null) return;
+  try {
+    await store.setKey(KEY_INSTALLED_AT, String(now));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * The install timestamp, setting it to `now` once if it is missing — the CLI's
+ * `getInstalledAt`, so the field is never absent going forward.
+ */
+export async function getInstalledAt(
+  store: LifecycleSignalsKeyStore,
+  now:   number = Date.now(),
+): Promise<number> {
+  const stored = await readNum(store, KEY_INSTALLED_AT);
+  if (stored !== null) return stored;
+  await setInstalledAtIfMissing(store, now);
+  return now;
+}
+
+/** True once the install event has been successfully sent, so it fires only once. */
+export async function isInstalledEventSent(store: LifecycleSignalsKeyStore): Promise<boolean> {
+  try {
+    return (await store.getKey(KEY_INSTALLED_EVENT_SENT)) === 'true';
+  } catch {
+    // Unreadable → treat as NOT sent. Re-sending an install event is a
+    // duplicate row; never sending one loses the denominator entirely.
+    return false;
+  }
+}
+
+/** Mark the install event as sent so it is not emitted again. */
+export async function markInstalledEventSent(store: LifecycleSignalsKeyStore): Promise<void> {
+  try {
+    await store.setKey(KEY_INSTALLED_EVENT_SENT, 'true');
+  } catch {
+    /* best-effort; an unmarked send is retried next flush */
+  }
+}

--- a/src/ext-browser/adapters/lifecycle-signals.ts
+++ b/src/ext-browser/adapters/lifecycle-signals.ts
@@ -4,9 +4,9 @@
  * an install stamp, a one-time sent-flag, and a capped list of
  * `{kind, occurredAt}`.
  *
- * Content-free by construction. A signal is a KIND from a fixed two-value enum
- * plus a timestamp. No prompt text, option text, option index, project root or
- * URL is stored — there is no field here that could carry one.
+ * Content-free by construction. A signal is a KIND from a fixed enum of UI
+ * actions plus a timestamp. No prompt text, option text, option index, project
+ * root or URL is stored — there is no field here that could carry one.
  *
  * Writes are unconditional. Buffering locally is not sending: nothing leaves
  * the machine until the user clicks a rating, which is the browser's consent
@@ -31,9 +31,13 @@
  * 4. **Never throws.** Same rule as the cadence: measurement must not be able to
  *    break the pipeline it measures. A damaged buffer reads as EMPTY.
  *
- * 5. **Only the two lifecycle kinds.** The CLI also buffers the Plan-B per-action
- *    kinds (`pe_*`, `mps_*`); §4.2 scopes the browser to `advisory_fired` and
- *    `option_selected` plus the install stamp.
+ * 5. **The kinds are the CLI's LIVE ones, which is not what §4.2 named.** The
+ *    plan scoped this to `advisory_fired` + `option_selected`. Measured, the CLI
+ *    has ZERO production call sites for either — the pair is dead there too, and
+ *    porting only those would have given the browser a buffer that can never
+ *    fill. What the CLI actually records is the Plan-B per-action enum via
+ *    `recordActionSignal`, so that enum is carried here as well. Both sets are
+ *    kept, because the CLI keeps both. (Owner instruction: follow the CLI.)
  */
 
 /** The slice of the key store this module needs; injected so tests need no polyfill. */
@@ -42,11 +46,44 @@ export interface LifecycleSignalsKeyStore {
   setKey(name: string, value: string): Promise<void>;
 }
 
-/** `feedback-signals.ts:15-16` — the CLI's kind strings, which are also the event names. */
+/**
+ * `feedback-signals.ts:15-16` — the CLI's two original kinds.
+ *
+ * ⚠️ MEASURED 2026-08-31: the CLI has ZERO production call sites for
+ * `recordAdvisoryFired` / `recordOptionSelected`. Both are dead there, and the
+ * loops that flush them in `lifecycle-flush.ts` never have anything to send.
+ * They are kept here only because the CLI keeps them — dropping them would be
+ * the browser diverging first.
+ */
 export const SIGNAL_ADVISORY_FIRED  = 'advisory_fired';
 export const SIGNAL_OPTION_SELECTED = 'option_selected';
 
-export type SignalKind = typeof SIGNAL_ADVISORY_FIRED | typeof SIGNAL_OPTION_SELECTED;
+/**
+ * `feedback-signals.ts:24-28` — the CLI's Plan-B per-action kinds, and the ones
+ * it ACTUALLY records (`auto.ts:841`, `prompt-enhancement-popup-host.ts:216`,
+ * `:222`, `:259`, `stop.ts:377`).
+ *
+ * The kind IS the event name, and it is a fixed enum of UI actions. No prompt
+ * text, option text or option index is ever recorded — the same guarantee the
+ * CLI's own header makes.
+ */
+export const ACTION_SIGNAL_KINDS = [
+  'pe_use_current', 'pe_use_original', 'pe_shorter', 'pe_more_thorough',
+  'pe_more_project_grounded', 'pe_apply_details', 'pe_back', 'pe_close',
+  'mps_send', 'mps_cancel', 'mps_decline', 'mps_interruption', 'mps_apply_details',
+] as const;
+
+export type PromptActionSignalKind = typeof ACTION_SIGNAL_KINDS[number];
+
+export type SignalKind =
+  | typeof SIGNAL_ADVISORY_FIRED
+  | typeof SIGNAL_OPTION_SELECTED
+  | PromptActionSignalKind;
+
+/** True for the Plan-B action kinds, which flush through the action sender. */
+export function isActionKind(kind: string): kind is PromptActionSignalKind {
+  return (ACTION_SIGNAL_KINDS as readonly string[]).includes(kind);
+}
 
 /** CLI-mirrored config keys keep the CLI's bare names, as the cadence keys do. */
 export const KEY_INSTALLED_AT         = 'installed_at';
@@ -69,7 +106,9 @@ export interface LifecycleSignal {
   occurredAt: number;
 }
 
-const KINDS: readonly string[] = [SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED];
+const KINDS: readonly string[] = [
+  SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED, ...ACTION_SIGNAL_KINDS,
+];
 
 function isSignal(v: unknown): v is LifecycleSignal {
   if (typeof v !== 'object' || v === null) return false;

--- a/src/ext-browser/adapters/lifecycle-signals.ts
+++ b/src/ext-browser/adapters/lifecycle-signals.ts
@@ -144,6 +144,31 @@ export async function readSignals(store: LifecycleSignalsKeyStore): Promise<Life
   return parsed.filter(isSignal).sort((a, b) => a.occurredAt - b.occurredAt);
 }
 
+/**
+ * Every read-modify-write on the buffer runs through here, one at a time.
+ *
+ * The CLI needs nothing like this: its `recordSignal` is a synchronous SQL
+ * INSERT. Here the whole list lives under ONE `storage.local` key, so a record
+ * or a prune is read → modify → write with two awaits in the middle, and two
+ * overlapping calls both read the OLD list and the second write erases the
+ * first. Measured: two concurrent `recordSignal` calls left ONE signal.
+ *
+ * That is reachable in production — `pe-popup-host.ts` fires these off with
+ * `void` on every popup action, and a flush's prunes interleave with them the
+ * same way. A lost action signal is silent: the event simply never arrives.
+ *
+ * A plain promise chain is enough because there is exactly one worker thread;
+ * this orders the await points, it is not a cross-process lock. Failures are
+ * swallowed into the chain so one broken write cannot wedge every later one.
+ */
+let writeChain: Promise<unknown> = Promise.resolve();
+
+function serialize<T>(task: () => Promise<T>): Promise<T> {
+  const next = writeChain.then(task, task);
+  writeChain = next.then(() => undefined, () => undefined);
+  return next;
+}
+
 async function writeSignals(store: LifecycleSignalsKeyStore, list: LifecycleSignal[]): Promise<void> {
   try {
     await store.setKey(KEY_SIGNALS, JSON.stringify(list));
@@ -156,15 +181,17 @@ async function writeSignals(store: LifecycleSignalsKeyStore, list: LifecycleSign
  * Buffer one signal. Over the cap the OLDEST are dropped, so the buffer holds
  * the most recent `MAX_SIGNALS`.
  */
-export async function recordSignal(
+export function recordSignal(
   store:      LifecycleSignalsKeyStore,
   kind:       SignalKind,
   occurredAt: number = Date.now(),
 ): Promise<void> {
-  const list = await readSignals(store);
-  list.push({ kind, occurredAt });
-  list.sort((a, b) => a.occurredAt - b.occurredAt);
-  await writeSignals(store, list.slice(Math.max(0, list.length - MAX_SIGNALS)));
+  return serialize(async () => {
+    const list = await readSignals(store);
+    list.push({ kind, occurredAt });
+    list.sort((a, b) => a.occurredAt - b.occurredAt);
+    await writeSignals(store, list.slice(Math.max(0, list.length - MAX_SIGNALS)));
+  });
 }
 
 /**
@@ -174,14 +201,16 @@ export async function recordSignal(
  * occurred_at = ?`, which also removes duplicates of the pair. Called only
  * after that signal's own send succeeded, so a failed send stays buffered.
  */
-export async function pruneSignalAt(
+export function pruneSignalAt(
   store:      LifecycleSignalsKeyStore,
   kind:       SignalKind,
   occurredAt: number,
 ): Promise<void> {
-  const list = await readSignals(store);
-  const kept = list.filter((s) => !(s.kind === kind && s.occurredAt === occurredAt));
-  if (kept.length !== list.length) await writeSignals(store, kept);
+  return serialize(async () => {
+    const list = await readSignals(store);
+    const kept = list.filter((s) => !(s.kind === kind && s.occurredAt === occurredAt));
+    if (kept.length !== list.length) await writeSignals(store, kept);
+  });
 }
 
 async function readNum(store: LifecycleSignalsKeyStore, key: string): Promise<number | null> {

--- a/src/ext-browser/adapters/rating-cadence.test.ts
+++ b/src/ext-browser/adapters/rating-cadence.test.ts
@@ -10,6 +10,8 @@
  * because the store is different: a `storage.local` value can be corrupt or
  * unreadable in a way a table the CLI exclusively owns cannot.
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 import {
   readCadence,
@@ -248,5 +250,52 @@ describe('what the port does differently, and only because the store is differen
     } finally {
       vi.restoreAllMocks();
     }
+  });
+});
+
+/**
+ * Same discipline `submit-hold-budget.test.ts:143-157` applies to its own port:
+ * read the shipped CLI module as text and pin the lines this copy mirrors. The
+ * tests above assert what THIS file does; without these, the CLI could change a
+ * threshold and both copies would keep passing while quietly disagreeing.
+ */
+describe('contract with the shipped CLI copy (the two must not drift)', () => {
+  const shipped = readFileSync(
+    join(process.cwd(), 'src', 'store', 'feedback-cadence.ts'), 'utf8',
+  );
+
+  it('the three thresholds match the shipped module exactly', () => {
+    expect(shipped).toContain('export const USAGE_THRESHOLD_MS = 2 * 60 * 60 * 1000;');
+    expect(shipped).toContain('export const MIN_GAP_MS = 2 * 24 * 60 * 60 * 1000;');
+    expect(shipped).toContain('export const IDLE_CAP_MS = 15 * 60 * 1000;');
+  });
+
+  it('the three storage keys match the shipped module exactly', () => {
+    expect(shipped).toContain("'feedback_active_ms'");
+    expect(shipped).toContain("'feedback_last_activity_at'");
+    expect(shipped).toContain("'feedback_last_shown_at'");
+  });
+
+  it('the shipped module still discards idle breaks the same way', () => {
+    expect(shipped).toContain('delta !== null && delta > 0 && delta <= IDLE_CAP_MS ? delta : 0');
+  });
+
+  it('the shipped module still gates eligibility the same way', () => {
+    expect(shipped).toContain('if (state.activeMs + tail < USAGE_THRESHOLD_MS) return false;');
+    expect(shipped).toContain('if (state.lastFeedbackAt === null) return true;');
+    expect(shipped).toContain('return now - state.lastFeedbackAt >= MIN_GAP_MS;');
+  });
+
+  it('the shipped live clamp is the same, minus the negative guard this port adds', () => {
+    // The CLI cannot see a backwards clock: its `now` comes from one process
+    // writing its own marker. storage.local can, so this port wraps the same
+    // expression in Math.max(..., 0). Everything else is identical.
+    expect(shipped).toContain('Math.min(now - state.lastActivityAt, IDLE_CAP_MS)');
+  });
+
+  it('the shipped markFeedbackShown still resets all three values', () => {
+    expect(shipped).toContain('writeNum(store, KEY_ACTIVE_MS, 0);');
+    expect(shipped).toContain('writeNum(store, KEY_LAST_ACTIVITY_AT, now);');
+    expect(shipped).toContain('writeNum(store, KEY_LAST_SHOWN_AT, now);');
   });
 });

--- a/src/ext-browser/adapters/rating-cadence.test.ts
+++ b/src/ext-browser/adapters/rating-cadence.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Rating-popup cadence — the browser port of `src/store/feedback-cadence.ts`.
+ *
+ * The first group pins the RULES, which belong to the CLI and must not drift:
+ * the usage threshold, the idle cap, the minimum gap, first-time eligibility and
+ * what `markFeedbackShown` resets. If one of these fails, the port has changed
+ * behaviour rather than re-homed it.
+ *
+ * The second group pins what the port deliberately does DIFFERENTLY, and only
+ * because the store is different: a `storage.local` value can be corrupt or
+ * unreadable in a way a table the CLI exclusively owns cannot.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  readCadence,
+  recordActivity,
+  isFeedbackEligible,
+  markFeedbackShown,
+  USAGE_THRESHOLD_MS,
+  MIN_GAP_MS,
+  IDLE_CAP_MS,
+  KEY_ACTIVE_MS,
+  KEY_LAST_ACTIVITY_AT,
+  KEY_LAST_SHOWN_AT,
+  type RatingCadenceKeyStore,
+} from './rating-cadence.js';
+
+/** An in-memory key store with the same contract as ChromeStorageKeyAdapter. */
+function makeStore(initial: Record<string, string> = {}): RatingCadenceKeyStore & {
+  data: Record<string, string>;
+} {
+  const data: Record<string, string> = { ...initial };
+  return {
+    data,
+    getKey: async (name) => (typeof data[name] === 'string' && data[name].length > 0 ? data[name] : null),
+    setKey: async (name, value) => { data[name] = value; },
+  };
+}
+
+const T0 = 1_700_000_000_000;
+
+describe('the CLI rules, unchanged by the port', () => {
+  it('the three thresholds are the CLI values', () => {
+    expect(USAGE_THRESHOLD_MS).toBe(2 * 60 * 60 * 1000);   // 2 hours
+    expect(MIN_GAP_MS).toBe(2 * 24 * 60 * 60 * 1000);      // 2 days
+    expect(IDLE_CAP_MS).toBe(15 * 60 * 1000);              // 15 minutes
+  });
+
+  it('the three storage keys are the CLI names — unprefixed, like advisory_frequency and role', () => {
+    expect(KEY_ACTIVE_MS).toBe('feedback_active_ms');
+    expect(KEY_LAST_ACTIVITY_AT).toBe('feedback_last_activity_at');
+    expect(KEY_LAST_SHOWN_AT).toBe('feedback_last_shown_at');
+  });
+
+  it('an empty store reads as zero usage and nothing recorded', async () => {
+    expect(await readCadence(makeStore())).toEqual({
+      activeMs: 0, lastActivityAt: null, lastFeedbackAt: null,
+    });
+  });
+
+  it('the FIRST invocation banks no time — there is no earlier marker to measure from', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    expect(await readCadence(store)).toEqual({
+      activeMs: 0, lastActivityAt: T0, lastFeedbackAt: null,
+    });
+  });
+
+  it('a gap WITHIN the idle cap is accumulated', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await recordActivity(store, T0 + 5 * 60_000);
+    expect((await readCadence(store)).activeMs).toBe(5 * 60_000);
+  });
+
+  it('⭐ a gap OVER the idle cap is an idle break — it counts as nothing', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await recordActivity(store, T0 + IDLE_CAP_MS + 1);
+    const state = await readCadence(store);
+    expect(state.activeMs).toBe(0);                       // the break was not banked...
+    expect(state.lastActivityAt).toBe(T0 + IDLE_CAP_MS + 1); // ...but the marker still advanced
+  });
+
+  it('a gap EXACTLY at the idle cap still counts (the boundary is inclusive)', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await recordActivity(store, T0 + IDLE_CAP_MS);
+    expect((await readCadence(store)).activeMs).toBe(IDLE_CAP_MS);
+  });
+
+  it('accumulates across many invocations', async () => {
+    const store = makeStore();
+    for (let i = 0; i <= 10; i++) await recordActivity(store, T0 + i * 60_000);
+    expect((await readCadence(store)).activeMs).toBe(10 * 60_000);
+  });
+
+  it('⭐ not eligible below the usage threshold', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS - 60_000),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+    });
+    expect(await isFeedbackEligible(store, T0)).toBe(false);
+  });
+
+  it('⭐ eligible at the threshold when it has NEVER been shown', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+    });
+    expect(await isFeedbackEligible(store, T0)).toBe(true);
+  });
+
+  it('the live clamp counts the in-progress turn, so the threshold can be crossed in-session', async () => {
+    // Banked usage is one minute short; the current turn has been running five.
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS - 60_000),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+    });
+    expect(await isFeedbackEligible(store, T0)).toBe(false);
+    expect(await isFeedbackEligible(store, T0 + 5 * 60_000)).toBe(true);
+  });
+
+  it('the live clamp is itself capped at the idle cap — walking away cannot make it eligible', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS - IDLE_CAP_MS - 1),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+    });
+    expect(await isFeedbackEligible(store, T0 + 10 * 60 * 60 * 1000)).toBe(false);
+  });
+
+  it('⭐ once shown, the minimum gap blocks it even with usage banked', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+      [KEY_LAST_SHOWN_AT]: String(T0),
+    });
+    expect(await isFeedbackEligible(store, T0 + MIN_GAP_MS - 1)).toBe(false);
+    expect(await isFeedbackEligible(store, T0 + MIN_GAP_MS)).toBe(true);
+  });
+
+  it('⭐ markFeedbackShown resets the accumulator AND the activity marker, and stamps the show', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await recordActivity(store, T0 + 10 * 60_000);
+    expect((await readCadence(store)).activeMs).toBe(10 * 60_000);
+
+    await markFeedbackShown(store, T0 + 10 * 60_000);
+
+    expect(await readCadence(store)).toEqual({
+      activeMs: 0,
+      lastActivityAt: T0 + 10 * 60_000,
+      lastFeedbackAt: T0 + 10 * 60_000,
+    });
+  });
+
+  it('resetting the activity marker stops the pre-popup gap leaking into the fresh count', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await markFeedbackShown(store, T0);
+    // The next heartbeat measures from the RESET marker, not from before the popup.
+    await recordActivity(store, T0 + 60_000);
+    expect((await readCadence(store)).activeMs).toBe(60_000);
+  });
+});
+
+describe('what the port does differently, and only because the store is different', () => {
+  it('⭐ a corrupt value reads as ABSENT, not as NaN', async () => {
+    // NaN would poison the arithmetic: `NaN + tail < THRESHOLD` is false, so a
+    // damaged store would report "eligible" — the opposite of fail-closed.
+    const store = makeStore({ [KEY_ACTIVE_MS]: 'not-a-number' });
+    expect((await readCadence(store)).activeMs).toBe(0);
+    expect(await isFeedbackEligible(store, T0)).toBe(false);
+  });
+
+  it('a corrupt last-shown stamp does not unlock the popup', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS),
+      [KEY_LAST_ACTIVITY_AT]: String(T0),
+      [KEY_LAST_SHOWN_AT]: 'garbage',
+    });
+    // Absent last-shown means "never shown", which is the CLI's own rule.
+    expect(await isFeedbackEligible(store, T0)).toBe(true);
+  });
+
+  it('a clock that moves BACKWARDS banks nothing and cannot go negative', async () => {
+    const store = makeStore();
+    await recordActivity(store, T0);
+    await recordActivity(store, T0 - 60_000);
+    expect((await readCadence(store)).activeMs).toBe(0);
+  });
+
+  it('a backwards clock cannot make the live clamp negative either', async () => {
+    const store = makeStore({
+      [KEY_ACTIVE_MS]: String(USAGE_THRESHOLD_MS),
+      [KEY_LAST_ACTIVITY_AT]: String(T0 + 60_000),   // marker in the future
+    });
+    expect(await isFeedbackEligible(store, T0)).toBe(true);   // clamped to 0, not subtracted
+  });
+
+  it('⭐ an unreadable store never throws — the pipeline it measures must not break', async () => {
+    const broken: RatingCadenceKeyStore = {
+      getKey: async () => { throw new Error('storage gone'); },
+      setKey: async () => { throw new Error('storage gone'); },
+    };
+    await expect(recordActivity(broken, T0)).resolves.toBeUndefined();
+    await expect(markFeedbackShown(broken, T0)).resolves.toBeUndefined();
+    await expect(readCadence(broken)).resolves.toEqual({
+      activeMs: 0, lastActivityAt: null, lastFeedbackAt: null,
+    });
+  });
+
+  it('⭐ an unreadable store fails CLOSED — no popup, rather than a popup on no evidence', async () => {
+    const broken: RatingCadenceKeyStore = {
+      getKey: async () => { throw new Error('storage gone'); },
+      setKey: async () => {},
+    };
+    expect(await isFeedbackEligible(broken, T0)).toBe(false);
+  });
+
+  it('a failed marker write leaves the older marker, which over-counts rather than losing the gap', async () => {
+    const data: Record<string, string> = {};
+    let failNext = false;
+    const store: RatingCadenceKeyStore = {
+      getKey: async (n) => (typeof data[n] === 'string' ? data[n] : null),
+      setKey: async (n, v) => {
+        if (failNext && n === KEY_LAST_ACTIVITY_AT) throw new Error('write failed');
+        data[n] = v;
+      },
+    };
+    await recordActivity(store, T0);
+    failNext = true;
+    await recordActivity(store, T0 + 60_000);     // banks 60s, marker write fails
+    failNext = false;
+    await recordActivity(store, T0 + 120_000);    // re-measures from T0: banks 120s
+
+    // 60 + 120 — the gap is counted twice. Deliberate: losing the marker would
+    // leave every later gap measured from nothing at all.
+    expect((await readCadence(store)).activeMs).toBe(180_000);
+  });
+
+  it('defaults `now` to the real clock when the caller does not pass one', async () => {
+    const store = makeStore();
+    vi.spyOn(Date, 'now').mockReturnValue(T0);
+    try {
+      await recordActivity(store);
+      expect((await readCadence(store)).lastActivityAt).toBe(T0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/src/ext-browser/adapters/rating-cadence.test.ts
+++ b/src/ext-browser/adapters/rating-cadence.test.ts
@@ -293,6 +293,20 @@ describe('contract with the shipped CLI copy (the two must not drift)', () => {
     expect(shipped).toContain('Math.min(now - state.lastActivityAt, IDLE_CAP_MS)');
   });
 
+  it('the CLI still FEEDS on submit only and READS on stop — the split this port mirrors', () => {
+    // Why this is pinned and not merely commented: the browser worker deliberately
+    // has no stop-side heartbeat (service-worker.ts, handleResponseStop), and the
+    // only justification for that absence is the CLI's own split. If the CLI ever
+    // starts feeding on stop, this fails and the browser should follow.
+    const auto = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'auto.ts'), 'utf8');
+    const stop = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
+
+    expect(auto).toContain('recordActivity(store);');     // the one producer
+    expect(stop).not.toMatch(/\brecordActivity\s*\(/);    // stop never feeds
+    expect(stop).toContain('isFeedbackEligible(store)');  // stop reads
+    expect(stop).toContain('markFeedbackShown(store);');  // ...and resets
+  });
+
   it('the shipped markFeedbackShown still resets all three values', () => {
     expect(shipped).toContain('writeNum(store, KEY_ACTIVE_MS, 0);');
     expect(shipped).toContain('writeNum(store, KEY_LAST_ACTIVITY_AT, now);');

--- a/src/ext-browser/adapters/rating-cadence.ts
+++ b/src/ext-browser/adapters/rating-cadence.ts
@@ -1,0 +1,175 @@
+/**
+ * Rating-popup cadence, browser shape — a port of the CLI's
+ * `src/store/feedback-cadence.ts`, which is where the behaviour is defined and
+ * where any change to the RULES belongs. This file only re-homes them onto
+ * `storage.local`.
+ *
+ * The rule, unchanged: "active usage" is accumulated from the gaps between
+ * successive hook invocations, and a gap longer than `IDLE_CAP_MS` is an idle
+ * break that does not count — so the total reflects time the agent was actually
+ * being worked with, not wall-clock elapsed time. Once the popup is shown the
+ * accumulator resets and the gap timer restarts.
+ *
+ * ── WHAT CHANGED IN THE PORT, AND WHY ────────────────────────────────────────
+ *
+ * 1. **Asynchronous.** The CLI reads a synchronous in-memory sql.js table;
+ *    `storage.local` is promise-based, so every entry point here returns one.
+ *    Callers must await — a floating `recordActivity()` would silently lose the
+ *    heartbeat it was called to record.
+ *
+ * 2. **No `saveStore`.** That call flushes sql.js to disk. A `storage.local`
+ *    write is already durable, so there is nothing to flush.
+ *
+ * 3. **The key names are IDENTICAL and deliberately unprefixed.** The browser
+ *    uses two conventions: `nexpath_*` for its own runtime state
+ *    (`nexpath_pending_pe`, `nexpath_pe_feedback_events`) and bare CLI names for
+ *    CLI-mirrored settings (`advisory_frequency`, `role`, `openai_api_key`).
+ *    Cadence is the second kind, so it keeps the CLI's names.
+ *
+ *    ⚠️ Same NAMES, different STORE. `storage.local` and the CLI's SQLite
+ *    config table never see each other, so cadence is global within the browser
+ *    only — a user of both Cursor and Bolt can be asked on each. There is no
+ *    cross-surface store to fix that with; it is recorded, not solved.
+ *
+ * 4. **Corrupt values are treated as absent** (see `readNum`). The CLI owns its
+ *    config table exclusively; `storage.local` is shared with everything else
+ *    the extension keeps and survives extension updates, so a non-numeric value
+ *    is reachable here in a way it is not there. With valid data the behaviour
+ *    is identical — this only decides what a damaged store means.
+ *
+ * 5. **Never throws.** A cadence failure must not break the pipeline it is
+ *    measured from: writes swallow their errors, and the eligibility read fails
+ *    CLOSED (no popup) rather than open.
+ */
+
+/** The slice of the key store this module needs; injected so tests need no polyfill. */
+export interface RatingCadenceKeyStore {
+  getKey(name: string): Promise<string | null>;
+  setKey(name: string, value: string): Promise<void>;
+}
+
+/** Active usage that must accumulate before the popup is eligible again. */
+export const USAGE_THRESHOLD_MS = 2 * 60 * 60 * 1000;   // 2 hours
+
+/** Minimum time that must pass after the popup was last shown before it can reappear. */
+export const MIN_GAP_MS = 2 * 24 * 60 * 60 * 1000;      // 2 days
+
+/** A gap between hook invocations longer than this is an idle break (not counted). */
+export const IDLE_CAP_MS = 15 * 60 * 1000;              // 15 minutes
+
+export const KEY_ACTIVE_MS        = 'feedback_active_ms';
+export const KEY_LAST_ACTIVITY_AT = 'feedback_last_activity_at';
+export const KEY_LAST_SHOWN_AT    = 'feedback_last_shown_at';
+
+export interface CadenceState {
+  activeMs:       number;
+  lastActivityAt: number | null;
+  lastFeedbackAt: number | null;
+}
+
+/**
+ * Read one stored number, or null.
+ *
+ * A missing key, an unreadable store and a value that is not a finite number all
+ * answer the same way: absent. The last of those is the one the CLI does not
+ * need — `Number('')` is 0 and `Number('x')` is NaN, and a NaN reaching
+ * `isFeedbackEligible` would make `activeMs + tail < USAGE_THRESHOLD_MS` false
+ * and hand back "eligible" on a store that says nothing of the kind.
+ */
+async function readNum(store: RatingCadenceKeyStore, key: string): Promise<number | null> {
+  let raw: string | null;
+  try {
+    raw = await store.getKey(key);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Write one number. Best-effort: a storage failure must not break the caller. */
+async function writeNum(store: RatingCadenceKeyStore, key: string, value: number): Promise<void> {
+  try {
+    await store.setKey(key, String(value));
+  } catch {
+    /* cadence is measurement, never a gate on the pipeline it measures */
+  }
+}
+
+/** Read the current cadence state. */
+export async function readCadence(store: RatingCadenceKeyStore): Promise<CadenceState> {
+  const [activeMs, lastActivityAt, lastFeedbackAt] = await Promise.all([
+    readNum(store, KEY_ACTIVE_MS),
+    readNum(store, KEY_LAST_ACTIVITY_AT),
+    readNum(store, KEY_LAST_SHOWN_AT),
+  ]);
+  return {
+    activeMs: activeMs ?? 0,
+    lastActivityAt,
+    lastFeedbackAt,
+  };
+}
+
+/**
+ * Record a hook invocation at `now`. Adds the gap since the previous activity to
+ * the accumulator when that gap is within `IDLE_CAP_MS`, then advances the
+ * last-activity marker.
+ *
+ * The two writes are sequential rather than parallel on purpose: if the second
+ * fails, the marker still points at the older time, so the next invocation
+ * re-measures a gap that was already counted. Over-counting a single gap is a
+ * far smaller error than losing the marker and having every later gap measured
+ * from nothing.
+ */
+export async function recordActivity(
+  store: RatingCadenceKeyStore,
+  now: number = Date.now(),
+): Promise<void> {
+  const state = await readCadence(store);
+  const delta = state.lastActivityAt !== null ? now - state.lastActivityAt : null;
+  const add   = delta !== null && delta > 0 && delta <= IDLE_CAP_MS ? delta : 0;
+
+  await writeNum(store, KEY_ACTIVE_MS, state.activeMs + add);
+  await writeNum(store, KEY_LAST_ACTIVITY_AT, now);
+}
+
+/**
+ * True when enough active usage has accumulated AND enough time has passed since
+ * the popup was last shown. If it has never been shown, only the usage threshold
+ * applies.
+ *
+ * The `tail` term is the CLI's live clamp: it counts the in-progress turn (the
+ * gap since the last activity, capped) so the popup can become eligible in the
+ * same session that crosses the threshold, rather than waiting for the next
+ * heartbeat to bank it.
+ */
+export async function isFeedbackEligible(
+  store: RatingCadenceKeyStore,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const state = await readCadence(store);
+  const tail = state.lastActivityAt === null
+    ? 0
+    : Math.min(Math.max(now - state.lastActivityAt, 0), IDLE_CAP_MS);
+  if (state.activeMs + tail < USAGE_THRESHOLD_MS) return false;
+  if (state.lastFeedbackAt === null) return true;
+  return now - state.lastFeedbackAt >= MIN_GAP_MS;
+}
+
+/**
+ * Mark the popup as shown: reset the accumulator and the last-activity marker,
+ * and stamp the last-shown time so the next cycle needs a fresh usage + gap
+ * window.
+ *
+ * Resetting last-activity is what stops the gap that preceded the popup from
+ * leaking into the fresh accumulator on the next heartbeat.
+ */
+export async function markFeedbackShown(
+  store: RatingCadenceKeyStore,
+  now: number = Date.now(),
+): Promise<void> {
+  await writeNum(store, KEY_ACTIVE_MS, 0);
+  await writeNum(store, KEY_LAST_ACTIVITY_AT, now);
+  await writeNum(store, KEY_LAST_SHOWN_AT, now);
+}

--- a/src/ext-browser/adapters/rating-identity.test.ts
+++ b/src/ext-browser/adapters/rating-identity.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getInstallationId,
+  _resetIdentityInFlight,
+  KEY_INSTALLATION_ID,
+  type RatingIdentityKeyStore,
+} from './rating-identity.js';
+
+/** A storage.local stand-in that records what was written. */
+function memStore(seed: Record<string, string> = {}) {
+  const data = { ...seed };
+  const writes: [string, string][] = [];
+  const store: RatingIdentityKeyStore = {
+    getKey: async (k) => (k in data ? data[k] : null),
+    setKey: async (k, v) => { data[k] = v; writes.push([k, v]); },
+  };
+  return { store, data, writes };
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+beforeEach(() => {
+  _resetIdentityInFlight();
+  vi.restoreAllMocks();
+});
+
+describe('getInstallationId', () => {
+  it('mints a UUID on first use and persists it under the CLI key', async () => {
+    const { store, data, writes } = memStore();
+
+    const id = await getInstallationId(store);
+
+    expect(id).toMatch(UUID_RE);
+    expect(data[KEY_INSTALLATION_ID]).toBe(id);
+    expect(writes).toEqual([[KEY_INSTALLATION_ID, id]]);
+  });
+
+  it('returns the stored id and writes nothing when one already exists', async () => {
+    const { store, writes } = memStore({ [KEY_INSTALLATION_ID]: 'already-here' });
+
+    expect(await getInstallationId(store)).toBe('already-here');
+    expect(writes).toEqual([]);
+  });
+
+  it('is stable across calls — the same id every time, generated once', async () => {
+    const { store, writes } = memStore();
+
+    const first = await getInstallationId(store);
+    _resetIdentityInFlight();                       // as if the worker restarted
+    const second = await getInstallationId(store);
+    const third  = await getInstallationId(store);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(writes).toHaveLength(1);                 // minted exactly once
+  });
+
+  it('⭐ two overlapping first-time callers get the SAME id, minted once', async () => {
+    // Without the in-flight guard both read null, both mint, and the loser
+    // reports an id that is not the one in storage.
+    const { store, writes } = memStore();
+    const spy = vi.spyOn(globalThis.crypto, 'randomUUID');
+
+    const [a, b] = await Promise.all([getInstallationId(store), getInstallationId(store)]);
+
+    expect(a).toBe(b);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(writes).toHaveLength(1);
+  });
+
+  it('an unreadable store still yields a usable id rather than throwing', async () => {
+    const store: RatingIdentityKeyStore = {
+      getKey: async () => { throw new Error('storage gone'); },
+      setKey: async () => {},
+    };
+
+    await expect(getInstallationId(store)).resolves.toMatch(UUID_RE);
+  });
+
+  it('an unwritable store still yields a usable id rather than throwing', async () => {
+    const store: RatingIdentityKeyStore = {
+      getKey: async () => null,
+      setKey: async () => { throw new Error('quota'); },
+    };
+
+    await expect(getInstallationId(store)).resolves.toMatch(UUID_RE);
+  });
+
+  it('the in-flight guard is released after a failure, so the next call retries', async () => {
+    let fail = true;
+    const store: RatingIdentityKeyStore = {
+      getKey: async () => { if (fail) { fail = false; throw new Error('transient'); } return 'settled'; },
+      setKey: async () => {},
+    };
+
+    await getInstallationId(store);                 // mints, guard released
+    expect(await getInstallationId(store)).toBe('settled');
+  });
+});

--- a/src/ext-browser/adapters/rating-identity.ts
+++ b/src/ext-browser/adapters/rating-identity.ts
@@ -1,0 +1,81 @@
+/**
+ * The browser's installation id — a port of the CLI's `telemetry/identity.ts`,
+ * narrowed to the one id the rating popup needs.
+ *
+ * A random UUID, generated once and persisted, that identifies this
+ * INSTALLATION and nothing else. It is not derived from anything about the
+ * user, the machine or the pages visited, and it is the only identifier any
+ * envelope carries.
+ *
+ * ── WHAT CHANGED IN THE PORT, AND WHY ────────────────────────────────────────
+ *
+ * 1. **`globalThis.crypto.randomUUID()`, not `node:crypto`.** Precedent, not an
+ *    assumption: the shipped worker already calls it (`service-worker.ts:1382`).
+ *    ⚠️ The repo's `shims/node-crypto.ts` exposes `createHash` ONLY — it has no
+ *    `randomUUID`, so importing the CLI's module here would fail at runtime, not
+ *    at build.
+ *
+ * 2. **Asynchronous**, because `storage.local` is.
+ *
+ * 3. **Only `installation_id`.** The CLI also mints `user_id` and `team_id`;
+ *    nothing browser-side sends either, and an id that is never sent is an
+ *    identifier stored for no reason.
+ *
+ * 4. **Single-flight instead of a value cache.** The CLI caches per process to
+ *    save repeated reads. The concern here is different: `getInstallationId` is
+ *    async, so two overlapping first-time callers would BOTH read null, BOTH
+ *    mint a UUID, and the loser would report an id that is not the one stored.
+ *    An in-flight promise makes "generated once" true rather than likely.
+ *    A service worker restart clears it, which is correct — the persisted value
+ *    is then simply read back.
+ */
+
+/** The slice of the key store this module needs; injected so tests need no polyfill. */
+export interface RatingIdentityKeyStore {
+  getKey(name: string): Promise<string | null>;
+  setKey(name: string, value: string): Promise<void>;
+}
+
+/** `identity.ts:5` — the CLI's key name, kept so the two stores read alike. */
+export const KEY_INSTALLATION_ID = 'installation_id';
+
+/** Resolves to the id being minted right now, if one is in flight. */
+let inFlight: Promise<string> | null = null;
+
+async function readOrMint(store: RatingIdentityKeyStore): Promise<string> {
+  let existing: string | null = null;
+  try {
+    existing = await store.getKey(KEY_INSTALLATION_ID);
+  } catch {
+    // An unreadable store is treated as empty; the mint below still returns a
+    // usable id for this send even if it cannot be persisted.
+  }
+  if (existing) return existing;
+
+  const fresh = globalThis.crypto.randomUUID();
+  try {
+    await store.setKey(KEY_INSTALLATION_ID, fresh);
+  } catch {
+    // Persisting failed — return the id anyway rather than failing the send.
+    // The next call mints a different one, which loses continuity but never
+    // blocks; a store that cannot be written has larger problems.
+  }
+  return fresh;
+}
+
+/**
+ * The installation id, generating and persisting one on first use.
+ *
+ * Never throws: identity backs telemetry, and telemetry must not be able to
+ * break the thing it measures.
+ */
+export async function getInstallationId(store: RatingIdentityKeyStore): Promise<string> {
+  if (inFlight) return inFlight;
+  inFlight = readOrMint(store).finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+/** Test-only — drops the in-flight guard so per-test isolation works. */
+export function _resetIdentityInFlight(): void {
+  inFlight = null;
+}

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -1,0 +1,314 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  buildEnvelope, sendRating, sendInstalled, sendAdvisoryFired, sendOptionSelected,
+  flushLifecycle,
+  POSTHOG_ENDPOINT, POSTHOG_API_KEY, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE,
+  FEEDBACK_EVENT, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
+  type FetchLike, type TelemetryKeyStore,
+} from './telemetry-send.js';
+import {
+  recordSignal, readSignals, KEY_INSTALLED_AT, KEY_INSTALLED_EVENT_SENT,
+  SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED,
+} from './lifecycle-signals.js';
+import { _resetIdentityInFlight, KEY_INSTALLATION_ID } from './rating-identity.js';
+
+const T0 = 1_700_000_000_000;
+const ID = 'fixed-installation-id';
+
+function memStore(seed: Record<string, string> = {}) {
+  const data: Record<string, string> = { [KEY_INSTALLATION_ID]: ID, ...seed };
+  const store: TelemetryKeyStore = {
+    getKey: async (k) => (k in data ? data[k] : null),
+    setKey: async (k, v) => { data[k] = v; },
+  };
+  return { store, data };
+}
+
+/** A fetch stand-in that records every call and answers per `decide`. */
+function fakeFetch(decide: (body: Record<string, unknown>, n: number) => boolean = () => true) {
+  const calls: { url: string; init: Parameters<FetchLike>[1]; body: Record<string, unknown> }[] = [];
+  const fetch: FetchLike = async (url, init) => {
+    const body = JSON.parse(init.body) as Record<string, unknown>;
+    calls.push({ url, init, body });
+    const ok = decide(body, calls.length);
+    return { ok, status: ok ? 200 : 500 };
+  };
+  return { fetch, calls, events: () => calls.map((c) => c.body.event as string) };
+}
+
+beforeEach(() => { _resetIdentityInFlight(); });
+
+// ── the envelope ─────────────────────────────────────────────────────────────
+
+describe('the envelope', () => {
+  it('is the CLI\'s shape, field for field, plus `surface`', async () => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+
+    await sendRating(store, 3, { fetch, now: T0 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(POSTHOG_ENDPOINT);
+    expect(calls[0].body).toEqual({
+      api_key:     POSTHOG_API_KEY,
+      event:       'feedback_submitted',
+      distinct_id: ID,
+      timestamp:   new Date(T0).toISOString(),
+      properties: {
+        $lib:            'nexpath',
+        $lib_version:    POSTHOG_LIB_VERSION,
+        surface:         'browser',
+        installation_id: ID,
+        rating:          3,
+        feedback_at:     T0,
+      },
+    });
+  });
+
+  it('posts JSON, and does NOT set a User-Agent (a forbidden fetch header)', async () => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+
+    await sendRating(store, 1, { fetch, now: T0 });
+
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[0].init.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(Object.keys(calls[0].init.headers)).not.toContain('User-Agent');
+  });
+
+  it('backdates lifecycle events to when they happened, not to now', () => {
+    const envelope = buildEnvelope(EVENT_ADVISORY_FIRED, ID, T0, { advisory_fire_ts: T0 });
+    expect(envelope.timestamp).toBe(new Date(T0).toISOString());
+  });
+
+  it.each([
+    [EVENT_INSTALLED,       'installed_at'],
+    [EVENT_ADVISORY_FIRED,  'advisory_fire_ts'],
+    [EVENT_OPTION_SELECTED, 'option_select_ts'],
+  ])('%s carries only the id, the lib fields, surface and %s', async (event, tsProp) => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+    const senders = {
+      [EVENT_INSTALLED]:       sendInstalled,
+      [EVENT_ADVISORY_FIRED]:  sendAdvisoryFired,
+      [EVENT_OPTION_SELECTED]: sendOptionSelected,
+    };
+
+    await senders[event](store, T0, { fetch });
+
+    const props = (calls[0].body.properties as Record<string, unknown>);
+    expect(calls[0].body.event).toBe(event);
+    expect(Object.keys(props).sort())
+      .toEqual(['$lib', '$lib_version', 'installation_id', 'surface', tsProp].sort());
+    expect(props[tsProp]).toBe(T0);
+  });
+});
+
+// ── the privacy claim ────────────────────────────────────────────────────────
+
+describe('⭐ no prompt or option text can reach the wire', () => {
+  it('every payload from every sender is ids, timestamps and one number', async () => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+
+    await sendRating(store, 4, { fetch, now: T0 });
+    await sendInstalled(store, T0, { fetch });
+    await sendAdvisoryFired(store, T0, { fetch });
+    await sendOptionSelected(store, T0, { fetch });
+
+    const ALLOWED = new Set([
+      '$lib', '$lib_version', 'surface', 'installation_id',
+      'rating', 'feedback_at', 'installed_at', 'advisory_fire_ts', 'option_select_ts',
+    ]);
+    for (const call of calls) {
+      expect(Object.keys(call.body).sort())
+        .toEqual(['api_key', 'distinct_id', 'event', 'properties', 'timestamp']);
+      for (const [k, v] of Object.entries(call.body.properties as Record<string, unknown>)) {
+        expect(ALLOWED.has(k)).toBe(true);
+        // Every value is a number, or one of three fixed strings. Nothing that
+        // could be a prompt, an option label, a URL or a project root.
+        if (typeof v === 'string') {
+          expect([POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE, ID]).toContain(v);
+        } else {
+          expect(typeof v).toBe('number');
+        }
+      }
+    }
+  });
+});
+
+// ── failure is swallowed ─────────────────────────────────────────────────────
+
+describe('a failed post is swallowed', () => {
+  it('a non-2xx returns false and does not throw', async () => {
+    const { store } = memStore();
+    const { fetch } = fakeFetch(() => false);
+
+    await expect(sendRating(store, 2, { fetch, now: T0 })).resolves.toBe(false);
+  });
+
+  it('a fetch that throws returns false and does not throw', async () => {
+    const { store } = memStore();
+    const fetch: FetchLike = async () => { throw new Error('offline'); };
+
+    await expect(sendRating(store, 2, { fetch, now: T0 })).resolves.toBe(false);
+  });
+
+  it('a store that can be neither read nor written still sends, with a fresh id', async () => {
+    // Deliberate, and documented in rating-identity.ts: a broken store must not
+    // silence the one thing the user explicitly asked to send. The id cannot be
+    // persisted, so continuity across sends is lost — that is the lesser harm.
+    const store: TelemetryKeyStore = {
+      getKey: async () => { throw new Error('gone'); },
+      setKey: async () => { throw new Error('gone'); },
+    };
+    const { fetch, calls } = fakeFetch();
+
+    await expect(sendRating(store, 2, { fetch, now: T0 })).resolves.toBe(true);
+    expect(calls[0].body.distinct_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('with no fetch available at all, it returns false rather than throwing', async () => {
+    const { store } = memStore();
+
+    await expect(sendRating(store, 2, { fetch: undefined, timeoutMs: 1 })).resolves.toBeTypeOf('boolean');
+  });
+});
+
+// ── the flush ────────────────────────────────────────────────────────────────
+
+describe('flushLifecycle', () => {
+  it('sends the install event, then the buffer oldest first', async () => {
+    const { store } = memStore({ [KEY_INSTALLED_AT]: String(T0) });
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0 + 20);
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0 + 10);
+    const { fetch, events } = fakeFetch();
+
+    await flushLifecycle(store, { fetch });
+
+    expect(events()).toEqual([EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED]);
+    expect(await readSignals(store)).toEqual([]);          // all pruned on success
+  });
+
+  it('⭐ the install event fires ONCE, and only after a successful post', async () => {
+    const { store, data } = memStore({ [KEY_INSTALLED_AT]: String(T0) });
+
+    // First flush: the post fails, so the flag must NOT be set.
+    const failing = fakeFetch(() => false);
+    await flushLifecycle(store, { fetch: failing.fetch });
+    expect(failing.events()).toEqual([EVENT_INSTALLED]);
+    expect(data[KEY_INSTALLED_EVENT_SENT]).toBeUndefined();
+
+    // Second flush: it succeeds, so the flag is set...
+    const ok = fakeFetch();
+    await flushLifecycle(store, { fetch: ok.fetch });
+    expect(ok.events()).toEqual([EVENT_INSTALLED]);
+    expect(data[KEY_INSTALLED_EVENT_SENT]).toBe('true');
+
+    // ...and it never fires again.
+    const third = fakeFetch();
+    await flushLifecycle(store, { fetch: third.fetch });
+    expect(third.events()).toEqual([]);
+  });
+
+  it('⭐ a buffered signal survives a failed send and is not double-counted', async () => {
+    const { store } = memStore({
+      [KEY_INSTALLED_AT]: String(T0),
+      [KEY_INSTALLED_EVENT_SENT]: 'true',
+    });
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0 + 1);
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0 + 2);
+
+    // Only the advisory one succeeds this round.
+    const round1 = fakeFetch((body) => body.event === EVENT_ADVISORY_FIRED);
+    await flushLifecycle(store, { fetch: round1.fetch });
+
+    expect(round1.events()).toEqual([EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED]);
+    expect(await readSignals(store))
+      .toEqual([{ kind: SIGNAL_OPTION_SELECTED, occurredAt: T0 + 2 }]);   // the failure stayed
+
+    // Next round sends ONLY the survivor — the delivered one is gone for good.
+    const round2 = fakeFetch();
+    await flushLifecycle(store, { fetch: round2.fetch });
+
+    expect(round2.events()).toEqual([EVENT_OPTION_SELECTED]);
+    expect(await readSignals(store)).toEqual([]);
+  });
+
+  it('an empty buffer with the install already sent posts nothing at all', async () => {
+    const { store } = memStore({
+      [KEY_INSTALLED_AT]: String(T0),
+      [KEY_INSTALLED_EVENT_SENT]: 'true',
+    });
+    const { fetch, calls } = fakeFetch();
+
+    await flushLifecycle(store, { fetch });
+
+    expect(calls).toEqual([]);
+  });
+
+  it('never throws, even when everything fails', async () => {
+    const store: TelemetryKeyStore = {
+      getKey: async () => { throw new Error('gone'); },
+      setKey: async () => { throw new Error('gone'); },
+    };
+    const fetch: FetchLike = async () => { throw new Error('offline'); };
+
+    await expect(flushLifecycle(store, { fetch })).resolves.toBeUndefined();
+  });
+});
+
+// ── contract with the CLI ────────────────────────────────────────────────────
+
+/**
+ * Same discipline as `rating-cadence.test.ts` and `fixtures/rating.test.ts`:
+ * read the shipped CLI modules as text and pin what this copy mirrors.
+ */
+describe('contract with the shipped CLI telemetry (the two must not drift)', () => {
+  const cwd = process.cwd();
+  const config    = readFileSync(join(cwd, 'src', 'store', 'config.ts'), 'utf8');
+  const batcher   = readFileSync(join(cwd, 'src', 'telemetry', 'TelemetryBatcher.ts'), 'utf8');
+  const feedback  = readFileSync(join(cwd, 'src', 'telemetry', 'feedback-send.ts'), 'utf8');
+  const lifecycle = readFileSync(join(cwd, 'src', 'telemetry', 'lifecycle-send.ts'), 'utf8');
+  const flush     = readFileSync(join(cwd, 'src', 'telemetry', 'lifecycle-flush.ts'), 'utf8');
+
+  it('the endpoint and api key are the CLI\'s built-in defaults', () => {
+    expect(config).toContain(`telemetry_sync_endpoint: '${POSTHOG_ENDPOINT}'`);
+    expect(config).toContain(`telemetry_sync_api_key:  '${POSTHOG_API_KEY}'`);
+  });
+
+  it('the $lib name and version are the CLI\'s', () => {
+    expect(batcher).toContain(`export const POSTHOG_LIB_NAME    = '${POSTHOG_LIB_NAME}';`);
+    expect(batcher).toContain(`export const POSTHOG_LIB_VERSION = '${POSTHOG_LIB_VERSION}';`);
+  });
+
+  it('the four event names are the CLI\'s', () => {
+    expect(feedback).toContain(`export const FEEDBACK_EVENT = '${FEEDBACK_EVENT}';`);
+    expect(lifecycle).toContain(`export const EVENT_INSTALLED       = '${EVENT_INSTALLED}';`);
+    expect(lifecycle).toContain(`export const EVENT_ADVISORY_FIRED  = '${EVENT_ADVISORY_FIRED}';`);
+    expect(lifecycle).toContain(`export const EVENT_OPTION_SELECTED = '${EVENT_OPTION_SELECTED}';`);
+  });
+
+  it('the CLI still names the same envelope properties', () => {
+    const flat = feedback.replace(/\s+/g, ' ');
+    expect(flat).toContain('$lib: POSTHOG_LIB_NAME');
+    expect(flat).toContain('$lib_version: POSTHOG_LIB_VERSION');
+    expect(flat).toContain('installation_id: installationId');
+    expect(flat).toContain('feedback_at: now');
+  });
+
+  it('the CLI still marks the install event sent only after a successful post', () => {
+    const flat = flush.replace(/\s+/g, ' ');
+    expect(flat).toContain('if (await sendInstalled(store, installedAt, opts)) { markInstalledEventSent(store); }');
+  });
+
+  it('the CLI still prunes a signal only after its own send succeeds', () => {
+    const flat = flush.replace(/\s+/g, ' ');
+    expect(flat).toContain('if (await sendAdvisoryFired(store, ts, opts)) { pruneSignalAt(store, SIGNAL_ADVISORY_FIRED, ts); }');
+    expect(flat).toContain('if (await sendOptionSelected(store, ts, opts)) { pruneSignalAt(store, SIGNAL_OPTION_SELECTED, ts); }');
+  });
+});

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -5,7 +5,7 @@ import {
   buildEnvelope, sendRating, sendInstalled, sendAdvisoryFired, sendOptionSelected,
   flushLifecycle,
   POSTHOG_ENDPOINT, POSTHOG_API_KEY, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE,
-  FEEDBACK_EVENT, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
+  FEEDBACK_EVENT, FEEDBACK_DISMISSED_EVENT, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
   sendActionEvent,
   type FetchLike, type TelemetryKeyStore,
 } from './telemetry-send.js';
@@ -314,6 +314,19 @@ describe('contract with the shipped CLI telemetry (the two must not drift)', () 
   it('the $lib name and version are the CLI\'s', () => {
     expect(batcher).toContain(`export const POSTHOG_LIB_NAME    = '${POSTHOG_LIB_NAME}';`);
     expect(batcher).toContain(`export const POSTHOG_LIB_VERSION = '${POSTHOG_LIB_VERSION}';`);
+  });
+
+  it('⭐ the dismissal event is the CLI\'s, by name and by shape', () => {
+    // Agreed across three surfaces before any of them was written (plan r15).
+    // If the CLI renames it, the browser must follow in the same commit — the
+    // drift would not surface until someone built the dashboard.
+    expect(feedback).toContain(`export const FEEDBACK_DISMISSED_EVENT = '${FEEDBACK_DISMISSED_EVENT}';`);
+    expect(feedback.replace(/\s+/g, ' ')).toContain('dismissed_at: now');
+    // And the CLI must NOT flush on it — a dismissal is not consent.
+    const stop = readFileSync(join(cwd, 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
+    const flat = stop.replace(/\s+/g, ' ');
+    expect(flat).toContain('await fbDismissed(store);');
+    expect(flat).not.toMatch(/await fbDismissed\(store\); *await flushLifecycle/);
   });
 
   it('the four event names are the CLI\'s', () => {

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  buildEnvelope, sendRating, sendInstalled, sendAdvisoryFired, sendOptionSelected,
+  buildEnvelope, sendRating, sendRatingOption, sendInstalled, sendAdvisoryFired, sendOptionSelected,
   flushLifecycle,
   POSTHOG_ENDPOINT, POSTHOG_API_KEY, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE,
   FEEDBACK_EVENT, FEEDBACK_DISMISSED_EVENT, FEEDBACK_RATING_EVENTS, feedbackRatingEvent, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
@@ -479,13 +479,66 @@ describe('per-option event names — pinned to the scale AND to the CLI', () => 
     }
   });
 
-  it('⭐ Phase 1 is naming only — the browser sends none of them yet', () => {
-    // Phase 3 brings the sender, with its own tests and its own docs. If this
-    // fails, a sender landed without them.
-    const src = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'adapters', 'telemetry-send.ts'), 'utf8');
-    expect(src).not.toMatch(/export function sendRatingOption/);
+  it('⭐ the host sends the per-option event AFTER the rating, on the same consent', () => {
+    // Asserted on the source, because a reordering fails nothing behaviourally:
+    // both sends succeed either way. The rating is the record the dashboards
+    // were built on; this is the convenience, so it goes second.
     const host = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'background', 'pe-popup-host.ts'), 'utf8');
-    expect(host).not.toContain('feedbackRatingEvent');
-    expect(host).not.toContain('FEEDBACK_RATING_EVENTS');
+    expect(host.indexOf('sendRatingOption(store, command.rating'))
+      .toBeGreaterThan(host.indexOf('sendRating(store, command.rating'));
+  });
+
+  it('⭐ and NOT on a dismissal — there is no option to report', () => {
+    const host = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'background', 'pe-popup-host.ts'), 'utf8');
+    const dismissal = host.slice(host.indexOf('Anything else is a dismissal'));
+    expect(dismissal.slice(0, 900)).not.toContain('sendRatingOption');
+  });
+});
+
+describe('sendRatingOption', () => {
+  it.each(RATING_SCALE.map((c) => [c.label, c.rating] as const))(
+    '⭐ %s posts its own event name',
+    async (label, rating) => {
+      const { store } = memStore();
+      const { fetch, calls } = fakeFetch();
+
+      expect(await sendRatingOption(store, rating, { fetch, now: T0 })).toBe(true);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].body.event).toBe(`feedback_rating_${label.toLowerCase()}`);
+      const props = calls[0].body.properties as Record<string, unknown>;
+      expect(props.rating).toBe(rating);
+      expect(props.feedback_at).toBe(T0);
+      expect(props.surface).toBe('browser');
+      expect(calls[0].body.timestamp).toBe(new Date(T0).toISOString());
+    },
+  );
+
+  it('⭐ carries the SAME payload as feedback_submitted — either answers the same question', async () => {
+    const { store } = memStore();
+    const a = fakeFetch();
+    const b = fakeFetch();
+
+    await sendRatingOption(store, 2, { fetch: a.fetch, now: T0 });
+    await sendRating(store, 2, { fetch: b.fetch, now: T0 });
+
+    expect(a.calls[0].body.properties).toEqual(b.calls[0].body.properties);
+    expect(a.calls[0].body.event).not.toBe(b.calls[0].body.event);   // only the name differs
+  });
+
+  it('⭐ a rating outside the scale sends NOTHING — no fifth option can be invented', async () => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+
+    for (const r of [0, 5, -1, 1.5, Number.NaN]) {
+      expect(await sendRatingOption(store, r, { fetch }), String(r)).toBe(false);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it('a failed post is swallowed, like every other sender here', async () => {
+    const { store } = memStore();
+    const { fetch } = fakeFetch(() => false);
+    await expect(sendRatingOption(store, 3, { fetch, now: T0 })).resolves.toBe(false);
   });
 });

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -6,11 +6,12 @@ import {
   flushLifecycle,
   POSTHOG_ENDPOINT, POSTHOG_API_KEY, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE,
   FEEDBACK_EVENT, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
+  sendActionEvent,
   type FetchLike, type TelemetryKeyStore,
 } from './telemetry-send.js';
 import {
   recordSignal, readSignals, KEY_INSTALLED_AT, KEY_INSTALLED_EVENT_SENT,
-  SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED,
+  SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED, ACTION_SIGNAL_KINDS,
 } from './lifecycle-signals.js';
 import { _resetIdentityInFlight, KEY_INSTALLATION_ID } from './rating-identity.js';
 
@@ -339,5 +340,82 @@ describe('contract with the shipped CLI telemetry (the two must not drift)', () 
     const flat = flush.replace(/\s+/g, ' ');
     expect(flat).toContain('if (await sendAdvisoryFired(store, ts, opts)) { pruneSignalAt(store, SIGNAL_ADVISORY_FIRED, ts); }');
     expect(flat).toContain('if (await sendOptionSelected(store, ts, opts)) { pruneSignalAt(store, SIGNAL_OPTION_SELECTED, ts); }');
+  });
+});
+
+// ── the CLI's live kinds ─────────────────────────────────────────────────────
+
+describe('the Plan-B action kinds — the ones the CLI actually records', () => {
+  it('an action signal flushes under its OWN name, with action_ts', async () => {
+    const { store } = memStore({
+      [KEY_INSTALLED_AT]: String(T0),
+      [KEY_INSTALLED_EVENT_SENT]: 'true',
+    });
+    await recordSignal(store, 'pe_shorter', T0 + 1);
+    await recordSignal(store, 'mps_send',   T0 + 2);
+    const { fetch, calls, events } = fakeFetch();
+
+    await flushLifecycle(store, { fetch });
+
+    expect(events()).toEqual(['pe_shorter', 'mps_send']);
+    expect((calls[0].body.properties as Record<string, unknown>).action_ts).toBe(T0 + 1);
+    expect(await readSignals(store)).toEqual([]);
+  });
+
+  it('carries no more than the id, the lib fields, surface and action_ts', async () => {
+    const { store } = memStore();
+    const { fetch, calls } = fakeFetch();
+
+    await sendActionEvent(store, 'pe_close', T0, { fetch });
+
+    expect(Object.keys(calls[0].body.properties as Record<string, unknown>).sort())
+      .toEqual(['$lib', '$lib_version', 'action_ts', 'installation_id', 'surface']);
+  });
+
+  it('the three kind families share one buffer and each takes its own sender', async () => {
+    const { store } = memStore({
+      [KEY_INSTALLED_AT]: String(T0),
+      [KEY_INSTALLED_EVENT_SENT]: 'true',
+    });
+    await recordSignal(store, SIGNAL_ADVISORY_FIRED,  T0 + 1);
+    await recordSignal(store, 'pe_back',              T0 + 2);
+    await recordSignal(store, SIGNAL_OPTION_SELECTED, T0 + 3);
+    const { fetch, events } = fakeFetch();
+
+    await flushLifecycle(store, { fetch });
+
+    expect(events()).toEqual([EVENT_ADVISORY_FIRED, 'pe_back', EVENT_OPTION_SELECTED]);
+  });
+});
+
+/**
+ * The measurement that put the action kinds here at all. If the CLI ever starts
+ * calling `recordAdvisoryFired` / `recordOptionSelected` for real, or stops
+ * calling `recordActionSignal`, this fails and the browser should follow.
+ */
+describe('contract: which kinds the CLI actually records', () => {
+  const cwd = process.cwd();
+  const read = (...p: string[]) => readFileSync(join(cwd, ...p), 'utf8');
+  const signals = read('src', 'store', 'feedback-signals.ts');
+  const callers = ['auto.ts', 'prompt-enhancement-popup-host.ts', 'stop.ts']
+    .map((f) => read('src', 'cli', 'commands', f)).join('\n');
+
+  it('the CLI still records the per-action kinds', () => {
+    expect(callers).toMatch(/recordActionSignal\(/);
+  });
+
+  it('⭐ the CLI still records NEITHER advisory_fired NOR option_selected', () => {
+    expect(callers).not.toMatch(/recordAdvisoryFired\(/);
+    expect(callers).not.toMatch(/recordOptionSelected\(/);
+  });
+
+  it('the action-kind enum is the CLI\'s, in the CLI\'s order', () => {
+    const flat = signals.replace(/\s+/g, ' ');
+    expect(flat).toContain(ACTION_SIGNAL_KINDS.map((k) => `'${k}'`).join(', '));
+  });
+
+  it('the CLI still posts an action event under the kind as the event name', () => {
+    const flat = read('src', 'telemetry', 'lifecycle-send.ts').replace(/\s+/g, ' ');
+    expect(flat).toContain('return sendLifecycle(store, kind, occurredAt, { action_ts: occurredAt }, opts);');
   });
 });

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -173,9 +173,38 @@ describe('a failed post is swallowed', () => {
   });
 
   it('with no fetch available at all, it returns false rather than throwing', async () => {
+    // globalThis.fetch is REMOVED for this one case, not left in place with a
+    // short timeout: `opts.fetch ?? globalThis.fetch` would otherwise reach the
+    // real one and fire a live request at PostHog from the test suite.
     const { store } = memStore();
+    const saved = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = undefined;
+    try {
+      await expect(sendRating(store, 2, { now: T0 })).resolves.toBe(false);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).fetch = saved;
+    }
+  });
 
-    await expect(sendRating(store, 2, { fetch: undefined, timeoutMs: 1 })).resolves.toBeTypeOf('boolean');
+  it('⭐ no test in this file can reach the network', async () => {
+    // The guard for the mistake above: every send here must go through an
+    // injected fetch. If one ever forgets, this fails instead of quietly
+    // posting a test event into production analytics.
+    const { store } = memStore();
+    const saved = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = () => { throw new Error('live network reached from a test'); };
+    try {
+      const { fetch, calls } = fakeFetch();
+      await sendRating(store, 1, { fetch, now: T0 });
+      await flushLifecycle(store, { fetch });
+      expect(calls.length).toBeGreaterThan(0);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).fetch = saved;
+    }
   });
 });
 

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -5,7 +5,7 @@ import {
   buildEnvelope, sendRating, sendInstalled, sendAdvisoryFired, sendOptionSelected,
   flushLifecycle,
   POSTHOG_ENDPOINT, POSTHOG_API_KEY, POSTHOG_LIB_NAME, POSTHOG_LIB_VERSION, SURFACE,
-  FEEDBACK_EVENT, FEEDBACK_DISMISSED_EVENT, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
+  FEEDBACK_EVENT, FEEDBACK_DISMISSED_EVENT, FEEDBACK_RATING_EVENTS, feedbackRatingEvent, EVENT_INSTALLED, EVENT_ADVISORY_FIRED, EVENT_OPTION_SELECTED,
   sendActionEvent,
   type FetchLike, type TelemetryKeyStore,
 } from './telemetry-send.js';
@@ -14,6 +14,7 @@ import {
   SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED, ACTION_SIGNAL_KINDS,
 } from './lifecycle-signals.js';
 import { _resetIdentityInFlight, KEY_INSTALLATION_ID } from './rating-identity.js';
+import { RATING_SCALE } from '../ui/surfaces/fixtures/rating.js';
 
 const T0 = 1_700_000_000_000;
 const ID = 'fixed-installation-id';
@@ -430,5 +431,61 @@ describe('contract: which kinds the CLI actually records', () => {
   it('the CLI still posts an action event under the kind as the event name', () => {
     const flat = read('src', 'telemetry', 'lifecycle-send.ts').replace(/\s+/g, ' ');
     expect(flat).toContain('return sendLifecycle(store, kind, occurredAt, { action_ts: occurredAt }, opts);');
+  });
+});
+
+/**
+ * The per-option names, pinned in BOTH directions.
+ *
+ * They are a copy — see the constant's comment for why neither derivation is
+ * available — so drift can appear on either side: the browser's own scale
+ * (which the surface renders from) or the CLI's list (which the CLI sends from).
+ * Both are checked.
+ */
+describe('per-option event names — pinned to the scale AND to the CLI', () => {
+  const cliSrc = readFileSync(join(process.cwd(), 'src', 'telemetry', 'feedback-send.ts'), 'utf8');
+
+  it('one name per row of the browser\'s own scale, and no extras', () => {
+    expect(Object.keys(FEEDBACK_RATING_EVENTS).map(Number).sort())
+      .toEqual(RATING_SCALE.map((c) => c.rating).sort());
+  });
+
+  it('⭐ each name is the scale\'s label, lowercased', () => {
+    for (const c of RATING_SCALE) {
+      expect(feedbackRatingEvent(c.rating), c.label)
+        .toBe(`feedback_rating_${c.label.toLowerCase()}`);
+    }
+  });
+
+  it('⭐ the CLI ships the identical four names', () => {
+    // Two surfaces reporting one user action must not name it two ways; that
+    // drift would not surface until someone built the dashboard.
+    for (const name of Object.values(FEEDBACK_RATING_EVENTS)) {
+      expect(cliSrc, name).toContain(`'${name}'`);
+    }
+    expect(cliSrc).toContain('export const FEEDBACK_RATING_EVENTS');
+  });
+
+  it('the four are distinct and collide with neither existing event', () => {
+    const names = Object.values(FEEDBACK_RATING_EVENTS);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).not.toContain(FEEDBACK_EVENT);
+    expect(names).not.toContain(FEEDBACK_DISMISSED_EVENT);
+  });
+
+  it('a rating outside the scale has no event', () => {
+    for (const r of [0, 5, -1, 1.5, Number.NaN]) {
+      expect(feedbackRatingEvent(r), String(r)).toBeUndefined();
+    }
+  });
+
+  it('⭐ Phase 1 is naming only — the browser sends none of them yet', () => {
+    // Phase 3 brings the sender, with its own tests and its own docs. If this
+    // fails, a sender landed without them.
+    const src = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'adapters', 'telemetry-send.ts'), 'utf8');
+    expect(src).not.toMatch(/export function sendRatingOption/);
+    const host = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'background', 'pe-popup-host.ts'), 'utf8');
+    expect(host).not.toContain('feedbackRatingEvent');
+    expect(host).not.toContain('FEEDBACK_RATING_EVENTS');
   });
 });

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -1,0 +1,260 @@
+/**
+ * The browser's one-shot telemetry sender — the rating, and the three lifecycle
+ * events, on the CLI's exact envelope.
+ *
+ * One file for both because the rating and the lifecycle events share an
+ * envelope builder and a transport; change-map item #16 says so explicitly
+ * ("One file, one name").
+ *
+ * ── CONSENT ──────────────────────────────────────────────────────────────────
+ *
+ * The CLI's rule, unchanged (`stop.ts:526`): *"Flush regardless of
+ * telemetry.enabled — this explicit action is the consent."* The user clicking
+ * a rating IS the consent, and it is the only thing that ever puts a request on
+ * the wire from here. Nothing in this module fires on its own.
+ *
+ * ── WHAT IS ON THE WIRE ──────────────────────────────────────────────────────
+ *
+ * An installation id (a random UUID), a timestamp, and — for the rating — a
+ * number from 1 to 4. There is no parameter on any exported function that could
+ * carry prompt text, option text, a URL or a project root, which is the point:
+ * the payload is content-free because the API cannot express content.
+ *
+ * ── WHAT CHANGED IN THE PORT, AND WHY ────────────────────────────────────────
+ *
+ * 1. **The key and endpoint are constants, not config reads.** The CLI reads
+ *    `telemetry_sync_api_key` / `telemetry_sync_endpoint` from its config table
+ *    and falls back to the SAME built-in defaults (`store/config.ts:15-16`).
+ *    The browser has no equivalent table for these, so it ships the defaults
+ *    directly. The key is a PUBLIC PostHog ingest key — it authorises writing
+ *    events and nothing else.
+ *
+ * 2. **No `User-Agent` header.** The CLI's `postEvent` sets one
+ *    (`TelemetryClient.ts:58`). `User-Agent` is a forbidden header name for
+ *    `fetch` in a browser: setting it is silently dropped, so it is not sent
+ *    rather than left to look as though it were.
+ *
+ * 3. **Every envelope carries `surface: 'browser'`** (§9.7). `$lib` stays
+ *    `'nexpath'` so the browser's events sit in the same stream as the CLI's,
+ *    and `surface` is what tells them apart. It must ship with the FIRST send —
+ *    events sent before it exists cannot be attributed retroactively.
+ *
+ * 4. **`SendResult` is collapsed to a boolean.** The CLI distinguishes network
+ *    from HTTP failure to drive its batched retry/backoff. Nothing here retries:
+ *    a signal that fails to send simply stays buffered for the next flush.
+ */
+
+import { getInstallationId, type RatingIdentityKeyStore } from './rating-identity.js';
+import {
+  readSignals,
+  pruneSignalAt,
+  getInstalledAt,
+  isInstalledEventSent,
+  markInstalledEventSent,
+  SIGNAL_ADVISORY_FIRED,
+  SIGNAL_OPTION_SELECTED,
+  type LifecycleSignalsKeyStore,
+} from './lifecycle-signals.js';
+
+/** `store/config.ts:15`. */
+export const POSTHOG_ENDPOINT = 'https://us.i.posthog.com/capture/';
+
+/** `store/config.ts:16` — a PUBLIC PostHog ingest key; write-only by design. */
+export const POSTHOG_API_KEY = 'phc_mBETUUXjX2MLDCBpHmRoVMqHmRF2dUpnuByqVGw5qej9';
+
+/** `TelemetryBatcher.ts:4-5`. Shared with the CLI on purpose — see `SURFACE`. */
+export const POSTHOG_LIB_NAME    = 'nexpath';
+export const POSTHOG_LIB_VERSION = '0.1.1';
+
+/** §9.7 — what separates a browser event from a CLI one inside the same `$lib`. */
+export const SURFACE = 'browser';
+
+/** `TelemetryClient.ts:5`. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** `feedback-send.ts:22`. */
+export const FEEDBACK_EVENT = 'feedback_submitted';
+
+/** `lifecycle-send.ts:22-24`. */
+export const EVENT_INSTALLED       = 'nexpath_installed';
+export const EVENT_ADVISORY_FIRED  = 'advisory_fired';
+export const EVENT_OPTION_SELECTED = 'option_selected';
+
+/** `TelemetryClient.ts:7-17`, minus the response fields nothing here reads. */
+export type FetchLike = (input: string, init: {
+  method:  string;
+  headers: Record<string, string>;
+  body:    string;
+  signal:  AbortSignal;
+}) => Promise<{ ok: boolean; status: number }>;
+
+/** `telemetry/types.ts` — `PostHogSingleEnvelope`, field for field. */
+export interface PostHogSingleEnvelope {
+  api_key:     string;
+  event:       string;
+  distinct_id: string;
+  timestamp:   string;
+  properties:  Record<string, unknown>;
+}
+
+export interface SendOptions {
+  fetch?:     FetchLike;
+  timeoutMs?: number;
+}
+
+/** The store slice both halves of this module need. */
+export type TelemetryKeyStore = RatingIdentityKeyStore & LifecycleSignalsKeyStore;
+
+/**
+ * Build the envelope. Split out so the tests can assert the exact shape without
+ * a network, and so the rating and lifecycle paths cannot drift apart.
+ */
+export function buildEnvelope(
+  event:          string,
+  installationId: string,
+  occurredAt:     number,
+  extraProps:     Record<string, unknown> = {},
+): PostHogSingleEnvelope {
+  return {
+    api_key:     POSTHOG_API_KEY,
+    event,
+    distinct_id: installationId,
+    // Backdated to when the thing HAPPENED, so a deferred flush still lands at
+    // the right point on the timeline (`lifecycle-send.ts:6-8`).
+    timestamp:   new Date(occurredAt).toISOString(),
+    properties: {
+      $lib:            POSTHOG_LIB_NAME,
+      $lib_version:    POSTHOG_LIB_VERSION,
+      surface:         SURFACE,
+      installation_id: installationId,
+      ...extraProps,
+    },
+  };
+}
+
+/**
+ * POST one envelope. True only on a 2xx. Never throws — a send failure must
+ * never reach the caller, which is a UI click handler.
+ */
+async function postEnvelope(envelope: PostHogSingleEnvelope, opts: SendOptions): Promise<boolean> {
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (!fetchImpl) return false;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetchImpl(POSTHOG_ENDPOINT, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(envelope),
+      signal:  controller.signal,
+    });
+    return res.ok === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function send(
+  store:      TelemetryKeyStore,
+  event:      string,
+  occurredAt: number,
+  extraProps: Record<string, unknown>,
+  opts:       SendOptions,
+): Promise<boolean> {
+  try {
+    const installationId = await getInstallationId(store);
+    return await postEnvelope(buildEnvelope(event, installationId, occurredAt, extraProps), opts);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Post the rating. `feedback-send.ts:33-67`, with `surface` added.
+ *
+ * The payload is the rating, a feedback timestamp and the installation id —
+ * install and advisory context are their own lifecycle events, not properties
+ * here.
+ */
+export function sendRating(
+  store:  TelemetryKeyStore,
+  rating: number,
+  opts:   SendOptions & { now?: number } = {},
+): Promise<boolean> {
+  const now = opts.now ?? Date.now();
+  return send(store, FEEDBACK_EVENT, now, { rating, feedback_at: now }, opts);
+}
+
+/** `lifecycle-send.ts:69` — the one-time install event. */
+export function sendInstalled(
+  store:       TelemetryKeyStore,
+  installedAt: number,
+  opts:        SendOptions = {},
+): Promise<boolean> {
+  return send(store, EVENT_INSTALLED, installedAt, { installed_at: installedAt }, opts);
+}
+
+/** `lifecycle-send.ts:78`. */
+export function sendAdvisoryFired(
+  store:      TelemetryKeyStore,
+  occurredAt: number,
+  opts:       SendOptions = {},
+): Promise<boolean> {
+  return send(store, EVENT_ADVISORY_FIRED, occurredAt, { advisory_fire_ts: occurredAt }, opts);
+}
+
+/** `lifecycle-send.ts:87`. */
+export function sendOptionSelected(
+  store:      TelemetryKeyStore,
+  occurredAt: number,
+  opts:       SendOptions = {},
+): Promise<boolean> {
+  return send(store, EVENT_OPTION_SELECTED, occurredAt, { option_select_ts: occurredAt }, opts);
+}
+
+/**
+ * Release the buffer — `telemetry/lifecycle-flush.ts`.
+ *
+ * Called on the rating click and BEFORE the rating itself (§4.2), so the
+ * denominator lands with the number it is a denominator for.
+ *
+ * Two rules carried over exactly:
+ *   - the install event is guarded to fire ONCE, and is marked sent only after a
+ *     successful post, so a failed one is retried on the next flush;
+ *   - a buffered signal is pruned only after ITS OWN send succeeds, so nothing
+ *     is lost and nothing is counted twice.
+ *
+ * Sequential rather than parallel, like the CLI's loops: prune-after-success is
+ * a read-modify-write on one storage key, and overlapping flushes would drop
+ * each other's edits.
+ */
+export async function flushLifecycle(
+  store: TelemetryKeyStore,
+  opts:  SendOptions & { now?: number } = {},
+): Promise<void> {
+  try {
+    if (!await isInstalledEventSent(store)) {
+      const installedAt = await getInstalledAt(store, opts.now ?? Date.now());
+      if (await sendInstalled(store, installedAt, opts)) {
+        await markInstalledEventSent(store);
+      }
+    }
+
+    // Read once, oldest first. The CLI reads its two kinds separately; one pass
+    // over a single ordered list is the same set in the same order.
+    for (const signal of await readSignals(store)) {
+      const ok = signal.kind === SIGNAL_ADVISORY_FIRED
+        ? await sendAdvisoryFired(store, signal.occurredAt, opts)
+        : await sendOptionSelected(store, signal.occurredAt, opts);
+      if (ok) await pruneSignalAt(store, signal.kind, signal.occurredAt);
+    }
+  } catch {
+    // Best-effort in full: a flush that fails half way leaves the rest buffered.
+  }
+}
+
+/** Re-exported so callers wire one import; the kinds are the buffer's, not ours. */
+export { SIGNAL_ADVISORY_FIRED, SIGNAL_OPTION_SELECTED };

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -242,6 +242,29 @@ export function sendRating(
 }
 
 /**
+ * The same answer under its own event NAME — `feedback_rating_good` and its
+ * siblings — ALONGSIDE `feedback_submitted`, never instead of it (§9.8:
+ * replacing would rename history and break every existing chart).
+ *
+ * Identical payload to `sendRating`, so either event answers the same question;
+ * what differs is that this one is a name, which in PostHog is a first-class
+ * object with its own trend, funnel step and alert.
+ *
+ * A rating outside the scale sends NOTHING — a caller cannot invent a fifth
+ * option by passing 5.
+ */
+export function sendRatingOption(
+  store:  TelemetryKeyStore,
+  rating: number,
+  opts:   SendOptions & { now?: number } = {},
+): Promise<boolean> {
+  const event = feedbackRatingEvent(rating);
+  if (!event) return Promise.resolve(false);
+  const now = opts.now ?? Date.now();
+  return send(store, event, now, { rating, feedback_at: now }, opts);
+}
+
+/**
  * Report a dismissal. The rating envelope without the rating — there isn't one.
  *
  * Deliberately does NOT flush, and the caller must not either: releasing the

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -1,5 +1,5 @@
 /**
- * The browser's one-shot telemetry sender — the rating, and the three lifecycle
+ * The browser's one-shot telemetry sender — the rating, and the lifecycle
  * events, on the CLI's exact envelope.
  *
  * One file for both because the rating and the lifecycle events share an
@@ -51,6 +51,7 @@ import {
   getInstalledAt,
   isInstalledEventSent,
   markInstalledEventSent,
+  isActionKind,
   SIGNAL_ADVISORY_FIRED,
   SIGNAL_OPTION_SELECTED,
   type LifecycleSignalsKeyStore,
@@ -216,6 +217,22 @@ export function sendOptionSelected(
 }
 
 /**
+ * `lifecycle-send.ts:100` — ONE per-action event, where the event NAME is the
+ * action kind (`pe_shorter`, `mps_send`, …), backdated to when it occurred.
+ *
+ * These are the events the CLI actually produces; `advisory_fired` and
+ * `option_selected` are dead on both sides. See `lifecycle-signals.ts`.
+ */
+export function sendActionEvent(
+  store:      TelemetryKeyStore,
+  kind:       string,
+  occurredAt: number,
+  opts:       SendOptions = {},
+): Promise<boolean> {
+  return send(store, kind, occurredAt, { action_ts: occurredAt }, opts);
+}
+
+/**
  * Release the buffer — `telemetry/lifecycle-flush.ts`.
  *
  * Called on the rating click and BEFORE the rating itself (§4.2), so the
@@ -246,9 +263,12 @@ export async function flushLifecycle(
     // Read once, oldest first. The CLI reads its two kinds separately; one pass
     // over a single ordered list is the same set in the same order.
     for (const signal of await readSignals(store)) {
-      const ok = signal.kind === SIGNAL_ADVISORY_FIRED
-        ? await sendAdvisoryFired(store, signal.occurredAt, opts)
-        : await sendOptionSelected(store, signal.occurredAt, opts);
+      // Three senders, one per kind family, exactly as the CLI's three loops do:
+      // an action kind posts under its OWN name, the other two under theirs.
+      let ok: boolean;
+      if (isActionKind(signal.kind))                      ok = await sendActionEvent(store, signal.kind, signal.occurredAt, opts);
+      else if (signal.kind === SIGNAL_ADVISORY_FIRED)     ok = await sendAdvisoryFired(store, signal.occurredAt, opts);
+      else                                                ok = await sendOptionSelected(store, signal.occurredAt, opts);
       if (ok) await pruneSignalAt(store, signal.kind, signal.occurredAt);
     }
   } catch {

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -57,7 +57,21 @@ import {
   type LifecycleSignalsKeyStore,
 } from './lifecycle-signals.js';
 
-/** `store/config.ts:15`. */
+/**
+ * `store/config.ts:15`.
+ *
+ * Reached WITHOUT a `host_permissions` entry, and that is deliberate.
+ * `host_permissions` exists to bypass CORS; measured against the live endpoint
+ * (OPTIONS preflight, 2026-08-31) `us.i.posthog.com/capture/` reflects a
+ * `chrome-extension://` origin, allows `POST` and allows `content-type`, so an
+ * ordinary CORS request from the worker succeeds on its own. Declaring the host
+ * would request a permission this does not need and add a fifth line to the
+ * install dialog for nothing. `manifest.test.ts` pins the absence.
+ *
+ * If this endpoint ever stops sending CORS headers the send starts failing
+ * silently — `postEnvelope` swallows it, and the signals stay buffered. That is
+ * when the host permission has to be added, and its user-visible cost paid.
+ */
 export const POSTHOG_ENDPOINT = 'https://us.i.posthog.com/capture/';
 
 /** `store/config.ts:16` — a PUBLIC PostHog ingest key; write-only by design. */

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -90,6 +90,20 @@ export const DEFAULT_TIMEOUT_MS = 10_000;
 /** `feedback-send.ts:22`. */
 export const FEEDBACK_EVENT = 'feedback_submitted';
 
+/**
+ * `feedback-send.ts` — the popup was shown and closed without an answer.
+ *
+ * Without it, "asked and declined" and "never asked" are the same absence in the
+ * data, so the rating has no denominator of its own: `nexpath_installed` cannot
+ * say how often the prompt actually appeared.
+ *
+ * ⚠️ This is the ONE event that goes out without the rating click, so it is also
+ * the one that changes what the Privacy section can say. It carries an
+ * installation id and a timestamp, it never releases the buffer, and
+ * `src/ext-browser/README.md` says so in those terms.
+ */
+export const FEEDBACK_DISMISSED_EVENT = 'feedback_dismissed';
+
 /** `lifecycle-send.ts:22-24`. */
 export const EVENT_INSTALLED       = 'nexpath_installed';
 export const EVENT_ADVISORY_FIRED  = 'advisory_fired';
@@ -201,6 +215,21 @@ export function sendRating(
 ): Promise<boolean> {
   const now = opts.now ?? Date.now();
   return send(store, FEEDBACK_EVENT, now, { rating, feedback_at: now }, opts);
+}
+
+/**
+ * Report a dismissal. The rating envelope without the rating — there isn't one.
+ *
+ * Deliberately does NOT flush, and the caller must not either: releasing the
+ * buffer is what the rating CLICK consents to (§4.2), and closing the popup is
+ * the opposite of that click.
+ */
+export function sendRatingDismissed(
+  store: TelemetryKeyStore,
+  opts:  SendOptions & { now?: number } = {},
+): Promise<boolean> {
+  const now = opts.now ?? Date.now();
+  return send(store, FEEDBACK_DISMISSED_EVENT, now, { dismissed_at: now }, opts);
 }
 
 /** `lifecycle-send.ts:69` — the one-time install event. */

--- a/src/ext-browser/adapters/telemetry-send.ts
+++ b/src/ext-browser/adapters/telemetry-send.ts
@@ -104,6 +104,30 @@ export const FEEDBACK_EVENT = 'feedback_submitted';
  */
 export const FEEDBACK_DISMISSED_EVENT = 'feedback_dismissed';
 
+/**
+ * One event NAME per rating option, alongside `feedback_submitted`'s `rating`
+ * property — the property stays (plan §9.8), because replacing it would rename
+ * history and break every chart already built on it.
+ *
+ * ⚠️ A COPY, deliberately, and pinned twice. The names cannot be derived from
+ * the browser's own `RATING_SCALE` without this adapter importing `ui/`, a
+ * direction nothing else in `adapters/` takes; and they cannot be derived from
+ * the CLI's `FEEDBACK_OPTIONS` because that module reaches `telemetry/` and
+ * would close a cycle. So the contract tests pin this list against BOTH — the
+ * browser's scale and the CLI's file — and a rename on either side fails here.
+ */
+export const FEEDBACK_RATING_EVENTS: Readonly<Record<number, string>> = {
+  1: 'feedback_rating_bad',
+  2: 'feedback_rating_fine',
+  3: 'feedback_rating_good',
+  4: 'feedback_rating_excellent',
+};
+
+/** The per-option event for a rating, or undefined if it is not one of the four. */
+export function feedbackRatingEvent(rating: number): string | undefined {
+  return FEEDBACK_RATING_EVENTS[rating];
+}
+
 /** `lifecycle-send.ts:22-24`. */
 export const EVENT_INSTALLED       = 'nexpath_installed';
 export const EVENT_ADVISORY_FIRED  = 'advisory_fired';

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -638,3 +638,26 @@ describe('feedback persistence — PE-BR-11 closed (the CLI feedback store, brow
     expect(result.state).toBe('selected_original');
   });
 });
+
+describe('⭐ wrong-stage rating command', () => {
+  it('a rating command must NOT close the PE popup', async () => {
+    const { log } = makeLog();
+    let seq = 0;
+    const tab = async (msg: unknown): Promise<unknown> => {
+      const m = msg as { type?: string; payload?: PePanelViewV1 };
+      if (m.type === 'nexpath:show-pe' && m.payload) {
+        seq = m.payload.viewSeq;
+        setTimeout(() => {
+          deliverPePanelCommand(log, ROOT, seq, { type: 'rating', rating: 3 });
+          setTimeout(() => { deliverPePanelCommand(log, ROOT, seq, { type: 'use_original' }); }, 0);
+        }, 0);
+      }
+      return { ok: true };
+    };
+    const { result } = await runBrowserPePopup({
+      log, projectRoot: ROOT, apiKey: null, record, sendToTab: tab,
+      onFirstRendered: vi.fn().mockResolvedValue(undefined),
+    });
+    expect(result.state).toBe('selected_original');
+  });
+});

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -7,7 +7,7 @@
  * the synthesized edit_body, F2 smooth send and the terminal outcomes are all
  * proven against the engine's own popup logic, not a mock of it.
  */
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LogPort } from '../../core/ports/log.port.js';
 import type { PendingPeRecord } from '../adapters/pe-pending-store.js';
@@ -17,7 +17,10 @@ import {
   deliverPePanelCommand,
   isPePopupOpen,
   runBrowserPePopup,
+  runBrowserRatingPopup,
 } from './pe-popup-host.js';
+import { recordSignal, readSignals } from '../adapters/lifecycle-signals.js';
+import { _resetIdentityInFlight } from '../adapters/rating-identity.js';
 import type { PePanelCommandV1, PePanelViewV1 } from '../ui/pe-contract.js';
 
 function makeLog(): { log: LogPort; events: Array<[string, Record<string, unknown> | undefined]> } {
@@ -659,5 +662,170 @@ describe('⭐ wrong-stage rating command', () => {
       onFirstRendered: vi.fn().mockResolvedValue(undefined),
     });
     expect(result.state).toBe('selected_original');
+  });
+});
+
+// ── the rating popup loop (Phase 5) ─────────────────────────────────────────
+
+describe('runBrowserRatingPopup', () => {
+  /** A storage.local stand-in; the same shape the other suites here use. */
+  function memoryStore() {
+    const data = new Map<string, string>();
+    return {
+      data,
+      getKey: async (n: string) => data.get(n) ?? null,
+      setKey: async (n: string, v: string) => { data.set(n, v); },
+    };
+  }
+
+  beforeEach(() => { _resetIdentityInFlight(); });
+
+  /** Records every POST so the tests assert the real envelope, not a mock. */
+  function wire(ok = true) {
+    const posts: Record<string, unknown>[] = [];
+    const fetch = (async (_url: string, init: { body: string }) => {
+      posts.push(JSON.parse(init.body) as Record<string, unknown>);
+      return { ok, status: ok ? 200 : 500 };
+    }) as never;
+    return { fetch, posts, events: () => posts.map((p) => p['event'] as string) };
+  }
+
+  /** Show the popup and answer it with `command` once the view has gone out. */
+  async function run(
+    command: unknown,
+    opts: { ok?: boolean; seq?: number; store?: ReturnType<typeof memoryStore>; failPush?: boolean } = {},
+  ) {
+    const { log, events } = makeLog();
+    const store = opts.store ?? memoryStore();
+    const w = wire(opts.ok ?? true);
+    const sent: unknown[] = [];
+    const sendToTab = async (msg: unknown): Promise<unknown> => {
+      sent.push(msg);
+      const m = msg as { type?: string; payload?: { viewSeq: number } };
+      if (m.type === 'nexpath:show-rating') {
+        if (opts.failPush) throw new Error('no content script');
+        const seq = opts.seq ?? m.payload!.viewSeq;
+        if (command !== null) setTimeout(() => { deliverPePanelCommand(log, ROOT, seq, command); }, 0);
+      }
+      return { ok: true };
+    };
+
+    const outcome = await runBrowserRatingPopup({
+      log, projectRoot: ROOT, store, sendToTab, fetch: w.fetch, now: () => 1_700_000_000_000,
+    });
+    return { outcome, store, posts: w.posts, events: w.events(), sent, logEvents: events };
+  }
+
+  it('⭐ a selection sends the rating and marks the popup shown', async () => {
+    const { outcome, store, events, posts } = await run({ type: 'rating', rating: 3 });
+
+    expect(outcome).toEqual({ state: 'rated', rating: 3 });
+    expect(events).toContain('feedback_submitted');
+    const rating = posts.find((p) => p['event'] === 'feedback_submitted');
+    expect((rating!['properties'] as Record<string, unknown>)['rating']).toBe(3);
+    expect(store.data.get('feedback_last_shown_at')).toBe('1700000000000');
+  });
+
+  it('⭐ the lifecycle buffer is flushed BEFORE the rating — denominator first', async () => {
+    const store = memoryStore();
+    await recordSignal(store, 'pe_shorter', 1_699_999_000_000);
+
+    const { events } = await run({ type: 'rating', rating: 4 }, { store });
+
+    // install event, then the buffered action, then the rating — in that order.
+    expect(events[events.length - 1]).toBe('feedback_submitted');
+    expect(events).toContain('pe_shorter');
+    expect(events.indexOf('pe_shorter')).toBeLessThan(events.indexOf('feedback_submitted'));
+    expect(await readSignals(store)).toEqual([]);      // pruned after their sends
+  });
+
+  it('⭐ a dismissal marks it shown and sends NOTHING — CLI parity', async () => {
+    const store = memoryStore();
+    await recordSignal(store, 'pe_close', 1_699_999_000_000);
+
+    const { outcome, posts } = await run({ type: 'close' }, { store });
+
+    expect(outcome).toEqual({ state: 'dismissed' });
+    expect(posts).toEqual([]);                          // no send AND no flush
+    expect(store.data.get('feedback_last_shown_at')).toBe('1700000000000');
+    expect(await readSignals(store)).toHaveLength(1);   // the buffer is untouched
+  });
+
+  it('⭐ a failed push marks NOTHING shown — §4.1 M3, cadence is not spent on a popup nobody saw', async () => {
+    const { outcome, store, posts } = await run(null, { failPush: true });
+
+    expect(outcome).toEqual({ state: 'not_shown', reasonCodes: ['panel_unreachable'] });
+    expect(store.data.get('feedback_last_shown_at')).toBeUndefined();
+    expect(posts).toEqual([]);
+  });
+
+  it('⭐ a command with a stale viewSeq is dropped, not acted on', async () => {
+    // §4.1 M1: the seq guard is why the view carries one and the box expects it
+    // before the push. A stale reply must not send a rating.
+    const store = memoryStore();
+    const { log } = makeLog();
+    const sendToTab = async (msg: unknown): Promise<unknown> => {
+      const m = msg as { type?: string };
+      if (m.type === 'nexpath:show-rating') {
+        setTimeout(() => {
+          // wrong seq first — dropped; then the right one
+          deliverPePanelCommand(log, ROOT, 99, { type: 'rating', rating: 1 });
+          deliverPePanelCommand(log, ROOT, 1, { type: 'rating', rating: 4 });
+        }, 0);
+      }
+      return { ok: true };
+    };
+    const w = wire();
+
+    const outcome = await runBrowserRatingPopup({
+      log, projectRoot: ROOT, store, sendToTab, fetch: w.fetch, now: () => 1_700_000_000_000,
+    });
+
+    expect(outcome).toEqual({ state: 'rated', rating: 4 });   // NOT 1
+    const rating = w.posts.find((p) => p['event'] === 'feedback_submitted');
+    expect((rating!['properties'] as Record<string, unknown>)['rating']).toBe(4);
+  });
+
+  it('⭐ refuses to open when a PE popup already owns the root — §4.1 M2', async () => {
+    const { log } = makeLog();
+    const store = memoryStore();
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((r) => { release = r; });
+
+    // A PE popup holding the mailbox for ROOT.
+    const pe = runBrowserPePopup({
+      log, projectRoot: ROOT, apiKey: null, record,
+      sendToTab: async (msg: unknown) => {
+        const m = msg as { type?: string; payload?: PePanelViewV1 };
+        if (m.type === 'nexpath:show-pe' && m.payload) {
+          const seq = m.payload.viewSeq;
+          void held.then(() => { deliverPePanelCommand(log, ROOT, seq, { type: 'close' }); });
+        }
+        return { ok: true };
+      },
+      onFirstRendered: vi.fn().mockResolvedValue(undefined),
+    });
+    await vi.waitFor(() => expect(isPePopupOpen(ROOT)).toBe(true));
+
+    const outcome = await runBrowserRatingPopup({
+      log, projectRoot: ROOT, store,
+      sendToTab: async () => ({ ok: true }),
+      now: () => 1_700_000_000_000,
+    });
+
+    expect(outcome).toEqual({ state: 'not_shown', reasonCodes: ['popup_already_open'] });
+    expect(store.data.get('feedback_last_shown_at')).toBeUndefined();  // no cadence spent
+    release!();
+    await pe;
+  });
+
+  it('releases the mailbox afterwards, so the next stop can open one', async () => {
+    await run({ type: 'rating', rating: 2 });
+    expect(isPePopupOpen(ROOT)).toBe(false);
+  });
+
+  it('closes the panel on the way out', async () => {
+    const { sent } = await run({ type: 'close' });
+    expect((sent as { type?: string }[]).some((m) => m.type === 'nexpath:pe-close')).toBe(true);
   });
 });

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -778,14 +778,19 @@ describe('runBrowserRatingPopup', () => {
     expect(await readSignals(store)).toEqual([]);      // pruned after their sends
   });
 
-  it('⭐ a dismissal marks it shown and sends NOTHING — CLI parity', async () => {
+  it('⭐ a dismissal reports ONLY the dismissal — no rating, no flush', async () => {
     const store = memoryStore();
     await recordSignal(store, 'pe_close', 1_699_999_000_000);
 
-    const { outcome, posts } = await run({ type: 'close' }, { store });
+    const { outcome, posts, events } = await run({ type: 'close' }, { store });
 
     expect(outcome).toEqual({ state: 'dismissed' });
-    expect(posts).toEqual([]);                          // no send AND no flush
+    // Exactly one envelope: the dismissal. Not the rating, and NOT the buffer —
+    // releasing that is what the rating click consents to (§4.2).
+    expect(events).toEqual(['feedback_dismissed']);
+    const props = posts[0]!['properties'] as Record<string, unknown>;
+    expect(Object.keys(props).sort())
+      .toEqual(['$lib', '$lib_version', 'dismissed_at', 'installation_id', 'surface']);
     expect(store.data.get('feedback_last_shown_at')).toBe('1700000000000');
     expect(await readSignals(store)).toHaveLength(1);   // the buffer is untouched
   });

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -621,6 +621,45 @@ describe('feedback persistence — PE-BR-11 closed (the CLI feedback store, brow
     }
   });
 
+  /**
+   * The details merge — the one browser action whose signal was missing.
+   *
+   * The CLI's Enter on "Additional details" sends `apply_details` and the engine
+   * maps it to `pe_apply_details`. The browser's dock merges locally and sends
+   * `edit_body`, which is NOT in that map (in the CLI it means an inline body
+   * edit), so the action was recorded on one surface and not the other.
+   */
+  it('⭐ a details merge records pe_apply_details — the CLI records it, so the browser must too', async () => {
+    const { log } = makeLog();
+    const store = memoryStore();
+    let shows = 0;
+    const tab = async (msg: unknown): Promise<unknown> => {
+      const m = msg as { type?: string; payload?: PePanelViewV1 };
+      if (m.type === 'nexpath:show-pe' && m.payload) {
+        const seq = m.payload.viewSeq;
+        shows += 1;
+        // First frame: merge details. Second frame (the engine's echo): finish.
+        const cmd: PePanelCommandV1 = shows === 1
+          ? { type: 'edit_body', bodyText: 'body plus the merged details' }
+          : { type: 'use_original' };
+        setTimeout(() => { deliverPePanelCommand(log, ROOT, seq, cmd); }, 0);
+      }
+      return { ok: true };
+    };
+
+    await runBrowserPePopup({
+      log, projectRoot: ROOT, apiKey: null, record, sendToTab: tab,
+      feedbackStore: store,
+      onFirstRendered: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await vi.waitFor(() => {
+      const raw = store.data.get('nexpath_lifecycle_signals');
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw!).map((s: { kind: string }) => s.kind)).toContain('pe_apply_details');
+    });
+  });
+
   it('with no store wired, an action still completes — buffering is best-effort', async () => {
     const { log } = makeLog();
     let seq = 0;

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -772,7 +772,8 @@ describe('runBrowserRatingPopup', () => {
     const { events } = await run({ type: 'rating', rating: 4 }, { store });
 
     // install event, then the buffered action, then the rating — in that order.
-    expect(events[events.length - 1]).toBe('feedback_submitted');
+    // The per-option event (r16) trails the rating on the same consent.
+    expect(events.slice(-2)).toEqual(['feedback_submitted', 'feedback_rating_excellent']);
     expect(events).toContain('pe_shorter');
     expect(events.indexOf('pe_shorter')).toBeLessThan(events.indexOf('feedback_submitted'));
     expect(await readSignals(store)).toEqual([]);      // pruned after their sends

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -603,8 +603,13 @@ describe('feedback persistence — PE-BR-11 closed (the CLI feedback store, brow
       onFirstRendered: vi.fn().mockResolvedValue(undefined),
     });
 
+    // The sink is fire-and-forget (`void recordSignal(...)`) and the buffer's
+    // writes are serialised, so the write lands a microtask or two after the
+    // popup resolves. Waiting for it is the honest assertion; asserting
+    // immediately would only pass by accident of scheduling.
+    await vi.waitFor(() => expect(store.data.get('nexpath_lifecycle_signals')).toBeTruthy());
+
     const raw = store.data.get('nexpath_lifecycle_signals');
-    expect(raw).toBeTruthy();
     const signals = JSON.parse(raw!) as Array<{ kind: string; occurredAt: number }>;
     expect(signals.map((s) => s.kind)).toContain('pe_use_original');
     for (const s of signals) {

--- a/src/ext-browser/background/pe-popup-host.test.ts
+++ b/src/ext-browser/background/pe-popup-host.test.ts
@@ -574,4 +574,62 @@ describe('feedback persistence — PE-BR-11 closed (the CLI feedback store, brow
     const list = JSON.parse(store.data.get('nexpath_pe_feedback_events')!) as Array<{ event: unknown }>;
     expect(JSON.stringify(list[0]!.event)).toContain('too_much_or_too_long');
   });
+  /**
+   * CLI parity for the per-action signals (§4.2). The CLI wires its
+   * `actionSignalSink` to the STORE — `auto.ts:841`,
+   * `prompt-enhancement-popup-host.ts:216`, `:259`, `stop.ts:817`, `:899`. The
+   * browser used to wire it to `log.debug` alone, so every action was observable
+   * for a moment and then gone, and the flush had nothing to send.
+   *
+   * A wire test, because losing the call again would look like nothing: no error,
+   * no failing assertion, just lifecycle events that never arrive.
+   */
+  it('⭐ a popup action is BUFFERED, not merely logged — the CLI records these', async () => {
+    const { log } = makeLog();
+    const store = memoryStore();
+    let seq = 0;
+    const tab = async (msg: unknown): Promise<unknown> => {
+      const m = msg as { type?: string; payload?: PePanelViewV1 };
+      if (m.type === 'nexpath:show-pe' && m.payload) {
+        seq = m.payload.viewSeq;
+        setTimeout(() => { deliverPePanelCommand(log, ROOT, seq, { type: 'use_original' }); }, 0);
+      }
+      return { ok: true };
+    };
+
+    await runBrowserPePopup({
+      log, projectRoot: ROOT, apiKey: null, record, sendToTab: tab,
+      feedbackStore: store,
+      onFirstRendered: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const raw = store.data.get('nexpath_lifecycle_signals');
+    expect(raw).toBeTruthy();
+    const signals = JSON.parse(raw!) as Array<{ kind: string; occurredAt: number }>;
+    expect(signals.map((s) => s.kind)).toContain('pe_use_original');
+    for (const s of signals) {
+      expect(Object.keys(s).sort()).toEqual(['kind', 'occurredAt']);   // content-free
+      expect(typeof s.occurredAt).toBe('number');
+    }
+  });
+
+  it('with no store wired, an action still completes — buffering is best-effort', async () => {
+    const { log } = makeLog();
+    let seq = 0;
+    const tab = async (msg: unknown): Promise<unknown> => {
+      const m = msg as { type?: string; payload?: PePanelViewV1 };
+      if (m.type === 'nexpath:show-pe' && m.payload) {
+        seq = m.payload.viewSeq;
+        setTimeout(() => { deliverPePanelCommand(log, ROOT, seq, { type: 'use_original' }); }, 0);
+      }
+      return { ok: true };
+    };
+
+    const { result } = await runBrowserPePopup({
+      log, projectRoot: ROOT, apiKey: null, record, sendToTab: tab,
+      onFirstRendered: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(result.state).toBe('selected_original');
+  });
 });

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -44,6 +44,7 @@ import {
   type PromptEnhancementMpsFirstPopupModelV1,
 } from './pe-engine.js';
 import { recordPeFeedbackEvent, type PeFeedbackKeyStore } from '../adapters/pe-feedback-store.js';
+import { recordSignal } from '../adapters/lifecycle-signals.js';
 import {
   PE_PANEL_SCHEMA_VERSION,
   isPePanelCommandV1,
@@ -464,7 +465,13 @@ export async function runBrowserPePopup(
       const signalKind = promptEnhancementMpsActionSignalKindV1(
         offerOutcome === 'send' ? 'send' : offerOutcome,
       );
-      if (signalKind) log.debug('pe_action_signal', { kind: signalKind });
+      if (signalKind) {
+        log.debug('pe_action_signal', { kind: signalKind });
+        // CLI parity: `prompt-enhancement-popup-host.ts:222` records this same
+        // MPS kind rather than only logging it. Buffered locally; nothing is
+        // sent until the user consents by rating (§4.2).
+        if (deps.feedbackStore) void recordSignal(deps.feedbackStore, signalKind, Date.now());
+      }
       if (offerOutcome === 'send') {
         return {
           result: { state: 'selected_current', bodyText: sentBody },
@@ -539,7 +546,19 @@ export async function runBrowserPePopup(
         reasonCodes: event.reasonCodes.slice(0, 8),
       }),
       // NF Plan B: content-free per-action signals (kind + timestamp only).
-      actionSignalSink: (kind, occurredAt) => log.debug('pe_action_signal', { kind, occurredAt }),
+      //
+      // CLI parity: the sink is wired to the STORE, not just the log —
+      // `auto.ts:841`, `prompt-enhancement-popup-host.ts:216`, `:259`,
+      // `stop.ts:817`, `:899` all do `recordActionSignal(store, …, kind,
+      // occurredAt)`. The log stays because it was already there.
+      //
+      // Buffering is not sending: these sit in storage.local until the user
+      // clicks a rating, which is this extension's consent moment (§4.2). The
+      // kind is a fixed UI-action enum — no prompt or option text.
+      actionSignalSink: (kind, occurredAt) => {
+        log.debug('pe_action_signal', { kind, occurredAt });
+        if (deps.feedbackStore) void recordSignal(deps.feedbackStore, kind, occurredAt);
+      },
     });
     if (suppressedUneditable) {
       log.debug('pe_popup_suppressed_uneditable_body', { projectRoot });

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -57,6 +57,7 @@ import { markFeedbackShown } from '../adapters/rating-cadence.js';
 import {
   flushLifecycle,
   sendRating,
+  sendRatingDismissed,
   type FetchLike,
   type TelemetryKeyStore,
 } from '../adapters/telemetry-send.js';
@@ -724,8 +725,11 @@ export async function runBrowserRatingPopup(
     // `close` (there is no "skipped" command; not answering IS closing).
     // CLI parity, `stop.ts:530`: `markFeedbackShown` runs on EITHER outcome, and
     // a dismissal sends nothing and flushes nothing.
+    // Reported, but NOT by flushing: the buffer stays for a future consent.
+    // Only the rating click releases it (§4.2).
+    const reported = await sendRatingDismissed(store, deps.fetch ? { fetch: deps.fetch } : {});
     await markFeedbackShown(store, now());
-    log.debug('rating_dismissed', { projectRoot, via: command.type });
+    log.debug('rating_dismissed', { projectRoot, via: command.type, reported });
     return { state: 'dismissed' };
   } finally {
     void deps.sendToTab({ type: 'nexpath:pe-close', projectRoot }).catch(() => { /* panel gone */ });

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -516,7 +516,17 @@ export async function runBrowserPePopup(
         // Drop any MPS command arriving mid-PE-loop (stale/hostile) — only the
         // offer stage may consume those.
         let received = await awaitPanelCommand();
-        while (received.type === 'mps_send' || received.type === 'mps_decline' || received.type === 'mps_cancel') {
+        // Wrong-stage commands are IGNORED here, never acted on — the same rule
+        // the MPS loop applies in the other direction.
+        //
+        // `rating` joined this list the moment it became an accepted command
+        // (Phase 4, #7). Before that the validator refused it at both gates, so
+        // it could not reach this loop at all; after it, `translate()` would have
+        // swept it into its catch-all `{ type: 'close' }` and CLOSED the PE
+        // popup, throwing away the user's enhanced prompt. A rating belongs to
+        // the rating surface and means nothing here.
+        const WRONG_STAGE = new Set(['mps_send', 'mps_decline', 'mps_cancel', 'rating']);
+        while (WRONG_STAGE.has(received.type)) {
           log.debug('pe_command_ignored_wrong_stage', { projectRoot, type: received.type });
           received = await awaitPanelCommand();
         }

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -58,6 +58,7 @@ import {
   flushLifecycle,
   sendRating,
   sendRatingDismissed,
+  sendRatingOption,
   type FetchLike,
   type TelemetryKeyStore,
 } from '../adapters/telemetry-send.js';
@@ -712,12 +713,23 @@ export async function runBrowserRatingPopup(
       // rating first would put a numerator on the wire ahead of its denominator,
       // and a flush that then failed would leave the two permanently unmatched.
       await flushLifecycle(store, deps.fetch ? { fetch: deps.fetch } : {});
-      const sent = await sendRating(store, command.rating, deps.fetch ? { fetch: deps.fetch } : {});
-      // Marked shown whether or not the POST succeeded: the user was asked and
+      // ONE timestamp for both envelopes. They describe a single click, so they
+      // must agree: letting each sender call `Date.now()` put them 1 ms apart
+      // under load (caught by the end-to-end suite, which asserts the payloads
+      // are equal), and anything joining them on time would have missed.
+      const answeredAt = now();
+      const opts = deps.fetch ? { fetch: deps.fetch, now: answeredAt } : { now: answeredAt };
+      const sent = await sendRating(store, command.rating, opts);
+      // The same answer under its own event name, AFTER the rating and on the
+      // same consent — CLI parity (`stop.ts`, Phase 2 of r16). The rating is the
+      // record the dashboards were built on; this is the convenience. If one of
+      // the two has to fail, it should be this one, so it goes second.
+      const named = await sendRatingOption(store, command.rating, opts);
+      // Marked shown whether or not the POSTs succeeded: the user was asked and
       // answered. Re-asking because a network call failed would punish them for
-      // the network. `sent` is logged, not acted on.
-      await markFeedbackShown(store, now());
-      log.debug('rating_recorded', { projectRoot, sent });
+      // the network. Both results are logged, neither is acted on.
+      await markFeedbackShown(store, answeredAt);
+      log.debug('rating_recorded', { projectRoot, sent, named });
       return { state: 'rated', rating: command.rating };
     }
 

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -541,6 +541,25 @@ export async function runBrowserPePopup(
           log.debug('pe_command_ignored_wrong_stage', { projectRoot, type: received.type });
           received = await awaitPanelCommand();
         }
+        // The details merge — the one user action whose signal the browser was
+        // losing.
+        //
+        // In the CLI, Enter on "Additional details" sends `apply_details`, which
+        // the engine maps to `pe_apply_details`
+        // (`cli-submit-popup.ts:64-73`). The browser's dock merges LOCALLY and
+        // sends `edit_body` instead (`pe-dock-adapter.ts:393`), and `edit_body`
+        // is deliberately NOT in that map — in the CLI it is an inline body edit,
+        // which would emit a signal per keystroke-commit.
+        //
+        // So the signal has to be recorded HERE, where the browser knows the
+        // command means a details merge and nothing else: `:393` is the only
+        // panel-side emitter of `edit_body`, and it sits in `case 'apply-details'`.
+        // Same kind the CLI records, so the two surfaces report the same action
+        // under the same name.
+        if (received.type === 'edit_body' && deps.feedbackStore) {
+          void recordSignal(deps.feedbackStore, 'pe_apply_details', Date.now());
+          log.debug('pe_action_signal', { kind: 'pe_apply_details' });
+        }
         const { first, stash } = translate(received, view);
         if (stash) stashed = stash;
         return first;

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -51,7 +51,18 @@ import {
   type PePanelCommandV1,
   type PeSequenceOfferViewV1,
   type PePanelViewV1,
+  type PeRatingViewV1,
 } from '../ui/pe-contract.js';
+import { markFeedbackShown } from '../adapters/rating-cadence.js';
+import {
+  flushLifecycle,
+  sendRating,
+  type FetchLike,
+  type TelemetryKeyStore,
+} from '../adapters/telemetry-send.js';
+
+/** Cadence + identity + buffer + sender all read one `storage.local` adapter. */
+type RatingStore = TelemetryKeyStore;
 
 // ── Command mailbox ─────────────────────────────────────────────────────────────
 //
@@ -580,6 +591,125 @@ export async function runBrowserPePopup(
     return { result, mpsFirstPopupSent: false };
   } finally {
     closePanel();
+    mailboxes.delete(projectRoot);
+  }
+}
+
+
+// ── The advisory rating popup ───────────────────────────────────────────────────
+
+export interface BrowserRatingPopupDeps {
+  log: LogPort;
+  projectRoot: string;
+  /** Same transport the PE popup uses — `browser.tabs.sendMessage(tabId, …)`. */
+  sendToTab: (msg: unknown) => Promise<unknown>;
+  /** Cadence, identity, signal buffer and the sender all read this one store. */
+  store: RatingStore;
+  /** Injected in tests so the real envelope builder runs against a fake wire. */
+  fetch?: FetchLike;
+  now?: () => number;
+}
+
+export type BrowserRatingOutcome =
+  | { state: 'rated'; rating: number }
+  | { state: 'dismissed' }
+  | { state: 'not_shown'; reasonCodes: string[] };
+
+/**
+ * Show the rating surface and act on the answer — the browser's
+ * `stop.ts:513-534`, which is where the CLI reads cadence and shows its own
+ * feedback popup.
+ *
+ * ── WHY THIS SHARES THE PE MAILBOX (§4.1 M1, M2) ────────────────────────────
+ *
+ * Item #7 put `rating` on `PePanelCommandV1`, so a rating click travels the
+ * EXISTING `nexpath:pe-command` route into `deliverPePanelCommand` — which
+ * drops anything whose echoed `viewSeq` does not match `box.expectedSeq`. So the
+ * view has to carry a seq and the box has to expect it before the push, or every
+ * click logs `pe_command_stale` and nothing happens.
+ *
+ * And it must be the SAME `mailboxes` map, not a second one: `isPePopupOpen` is
+ * `mailboxes.has(root)`, the dock is mount-once, and two maps would let a rating
+ * and a PE popup open onto one dock and clobber each other.
+ *
+ * ── WHAT IT DOES NOT DO ─────────────────────────────────────────────────────
+ *
+ * No timeout of its own. The CLI's popup waits for the user indefinitely, and so
+ * does this; if the tab goes away the panel's keepalive stops, the service
+ * worker is torn down, and the map goes with it (§4.1 M4 — the panel already
+ * owns teardown, do not rebuild it here).
+ */
+export async function runBrowserRatingPopup(
+  deps: BrowserRatingPopupDeps,
+): Promise<BrowserRatingOutcome> {
+  const { log, projectRoot, store } = deps;
+  const now = deps.now ?? (() => Date.now());
+
+  // §4.1 M2 — one surface per root, through the one map.
+  if (mailboxes.has(projectRoot)) {
+    log.debug('rating_popup_already_open', { projectRoot });
+    return { state: 'not_shown', reasonCodes: ['popup_already_open'] };
+  }
+
+  const box: Mailbox = { expectedSeq: 0, waiter: null, queued: null };
+  mailboxes.set(projectRoot, box);
+
+  try {
+    // One view, one seq. §4.1 M1: expected BEFORE the push, or the reply that
+    // comes back is dropped as stale.
+    const viewSeq = 1;
+    box.expectedSeq = viewSeq;
+    box.queued = null;
+
+    try {
+      await deps.sendToTab({
+        type: 'nexpath:show-rating',
+        projectRoot,
+        payload: { schemaVersion: PE_PANEL_SCHEMA_VERSION, kind: 'rating', viewSeq } satisfies PeRatingViewV1,
+      });
+    } catch (err) {
+      // §4.1 M3 — the push never rendered, so NO `markFeedbackShown`. Burning
+      // the two-day gap on a popup nobody saw is the one outcome worse than not
+      // asking: the user is not asked now, and not asked again for two days.
+      log.debug('rating_popup_render_failed', { projectRoot, error: String(err) });
+      return { state: 'not_shown', reasonCodes: ['panel_unreachable'] };
+    }
+    log.debug('rating_popup_shown', { projectRoot });
+
+    const command = await new Promise<PePanelCommandV1>((resolve) => {
+      if (box.queued !== null) {
+        const q = box.queued;
+        box.queued = null;
+        resolve(q);
+        return;
+      }
+      box.waiter = resolve;
+    });
+
+    if (command.type === 'rating') {
+      // §4.2 — ORDER MATTERS. The click is the consent for everything buffered,
+      // so the buffer is released FIRST and the rating follows it. Sending the
+      // rating first would put a numerator on the wire ahead of its denominator,
+      // and a flush that then failed would leave the two permanently unmatched.
+      await flushLifecycle(store, deps.fetch ? { fetch: deps.fetch } : {});
+      const sent = await sendRating(store, command.rating, deps.fetch ? { fetch: deps.fetch } : {});
+      // Marked shown whether or not the POST succeeded: the user was asked and
+      // answered. Re-asking because a network call failed would punish them for
+      // the network. `sent` is logged, not acted on.
+      await markFeedbackShown(store, now());
+      log.debug('rating_recorded', { projectRoot, sent });
+      return { state: 'rated', rating: command.rating };
+    }
+
+    // Anything else is a dismissal — Esc and the dock's ✕ both arrive as
+    // `close` (there is no "skipped" command; not answering IS closing).
+    // CLI parity, `stop.ts:530`: `markFeedbackShown` runs on EITHER outcome, and
+    // a dismissal sends nothing and flushes nothing.
+    await markFeedbackShown(store, now());
+    log.debug('rating_dismissed', { projectRoot, via: command.type });
+    return { state: 'dismissed' };
+  } finally {
+    void deps.sendToTab({ type: 'nexpath:pe-close', projectRoot }).catch(() => { /* panel gone */ });
     mailboxes.delete(projectRoot);
   }
 }

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -1725,37 +1725,7 @@ describe('service-worker.ts', () => {
         expect(keyStoreSetKey).toHaveBeenCalledWith(PENDING_KEY, '');
       });
 
-      /**
-       * The options page's kill switch (Phase 6). These exist because deleting
-       * `await isRatingEnabled() &&` from the gate left all 1,436 tests green —
-       * the toggle would have gone on advertising a control that did nothing,
-       * which is the exact reason advisory frequency was taken off that page
-       * (`options/options.ts:31-35`).
-       */
-      it('⭐ switched OFF: the rating is never opened, and PE runs as usual', async () => {
-        eligible({ nexpath_rating_enabled: 'off' });
-        idbLoadSessionState.mockResolvedValue({ sessionId: 's1', promptCount: 9 });
-        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
-        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
-
-        stopPe(messageListener, 7);
-
-        await vi.waitFor(() => expect(runBrowserPePopup).toHaveBeenCalledTimes(1));
-        expect(runBrowserRatingPopup).not.toHaveBeenCalled();
-      });
-
-      it('⭐ only the exact string "off" disables it — anything else fails OPEN', async () => {
-        // A damaged value must not silently switch off a feature the user never
-        // turned off. The options page defaults the same way, so the two cannot
-        // disagree about what a missing or junk value means.
-        eligible({ nexpath_rating_enabled: 'OFF' });
-        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'rated', rating: 3 });
-        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
-
-        stopPe(messageListener, 7);
-
-        await vi.waitFor(() => expect(runBrowserRatingPopup).toHaveBeenCalledTimes(1));
-      });
+      
 
       it('with no tab there is nothing to render into, so the gate is skipped', async () => {
         eligible();

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -49,6 +49,7 @@ vi.mock('../adapters/pe-config.js', () => ({ resolvePePopupCooldown: vi.fn(), re
 vi.mock('../adapters/pe-sequence-store.js', () => ({ recordPendingSequence: vi.fn(), getPendingSequence: vi.fn() }));
 vi.mock('./pe-popup-host.js', () => ({
   runBrowserPePopup: vi.fn(),
+  runBrowserRatingPopup: vi.fn(),
   deliverPePanelCommand: vi.fn(),
 }));
 
@@ -74,7 +75,7 @@ const { isPromptEnhancementSequenceShapedTextV1 } = await import('./pe-engine.js
 const { getPendingPe, markPendingPeShown } = await import('../adapters/pe-pending-store.js');
 const { resolvePePopupCooldown, resolvePeSequenceEnabled } = await import('../adapters/pe-config.js');
 const { recordPendingSequence, getPendingSequence } = await import('../adapters/pe-sequence-store.js');
-const { runBrowserPePopup } = await import('./pe-popup-host.js');
+const { runBrowserPePopup, runBrowserRatingPopup } = await import('./pe-popup-host.js');
 
 const idbLoadSessionState = vi.fn();
 const idbGetProjectDetectedLanguage = vi.fn();
@@ -1646,6 +1647,94 @@ describe('service-worker.ts', () => {
       vi.mocked(markPendingPeShown).mockResolvedValue(undefined);
       vi.mocked(recordPendingSequence).mockResolvedValue(undefined);
       vi.mocked(getPendingSequence).mockResolvedValue(null);
+      vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'not_shown', reasonCodes: ['x'] });
+    });
+
+    /**
+     * The rating gate (Phase 5, item #14). Cadence is empty in every other test
+     * here, so the gate is skipped and nothing else in this file changes.
+     */
+    describe('rating popup gate', () => {
+      /** Enough banked usage that `isFeedbackEligible` says yes. */
+      const eligible = (extra: Record<string, string> = {}) => {
+        keyStoreGetKey.mockImplementation(async (name: string) => {
+          if (name === 'feedback_active_ms') return String(3 * 60 * 60 * 1000);
+          if (name === 'feedback_last_activity_at') return String(Date.now());
+          return extra[name] ?? null;
+        });
+      };
+
+      it('⭐ eligible: the rating is shown, PE is DEFERRED, and the pending row is left intact', async () => {
+        eligible();
+        idbLoadSessionState.mockResolvedValue({ sessionId: 's1', promptCount: 9 });
+        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
+        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'rated', rating: 3 });
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserRatingPopup).toHaveBeenCalledTimes(1));
+        expect(runBrowserPePopup).not.toHaveBeenCalled();          // PE deferred one turn
+        expect(vi.mocked(markPendingPeShown)).not.toHaveBeenCalled(); // ...row untouched
+        expect(vi.mocked(getPendingPe)).not.toHaveBeenCalled();     // gate is BEFORE that section
+      });
+
+      it('a dismissal also takes the turn — the dock is mount-once', async () => {
+        eligible();
+        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
+        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'dismissed' });
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserRatingPopup).toHaveBeenCalledTimes(1));
+        expect(runBrowserPePopup).not.toHaveBeenCalled();
+      });
+
+      it('⭐ not_shown falls THROUGH to the PE popup — nothing is lost', async () => {
+        eligible();
+        idbLoadSessionState.mockResolvedValue({ sessionId: 's1', promptCount: 9 });
+        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
+        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'not_shown', reasonCodes: ['panel_unreachable'] });
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserPePopup).toHaveBeenCalledTimes(1));
+      });
+
+      it('not eligible: the rating is never opened and PE runs as before', async () => {
+        idbLoadSessionState.mockResolvedValue({ sessionId: 's1', promptCount: 9 });
+        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserPePopup).toHaveBeenCalledTimes(1));
+        expect(runBrowserRatingPopup).not.toHaveBeenCalled();
+      });
+
+      it('⭐ the gate runs AFTER the advisory consume — the advisory is not left for another turn', async () => {
+        eligible({ [PENDING_KEY]: '{"advisoryId":"a1"}' });
+        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'rated', rating: 4 });
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserRatingPopup).toHaveBeenCalledTimes(1));
+        expect(keyStoreSetKey).toHaveBeenCalledWith(PENDING_KEY, '');
+      });
+
+      it('with no tab there is nothing to render into, so the gate is skipped', async () => {
+        eligible();
+        vi.mocked(getPendingPe).mockResolvedValue(null);
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        messageListener({ type: 'nexpath:response-stop', projectRoot: P, agent: 'replit' }, {}, vi.fn());
+
+        await vi.waitFor(() => expect(vi.mocked(getPendingPe)).toHaveBeenCalled());
+        expect(runBrowserRatingPopup).not.toHaveBeenCalled();
+      });
     });
 
     it('consumes a queued advisory SILENTLY (MPS-7: the advisory surface is removed by default)', async () => {

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -275,6 +275,44 @@ describe('service-worker.ts', () => {
       expect(tabsReloadMock).toHaveBeenCalledWith(22);
     });
 
+    /**
+     * The install stamp for the rating popup's lifecycle events (Phase 3, §4.2).
+     *
+     * This is a WIRE test, and it exists because the consequence of the call
+     * going missing is not "no stamp" — it is a WRONG one. `getInstalledAt`
+     * backfills at flush time, so with nothing stamped at install the
+     * `nexpath_installed` event reports the moment of the user's FIRST RATING
+     * as their install date, silently and plausibly.
+     */
+    it('⭐ stamps the install time on a fresh install', async () => {
+      const { installedListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+      installedListener({ reason: 'install' });
+
+      await vi.waitFor(() =>
+        expect(keyStoreSetKey.mock.calls.map((c) => c[0])).toContain('installed_at'));
+    });
+
+    it('stamps on UPDATE too — that is what backfills an install predating the field', async () => {
+      const { installedListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+      installedListener({ reason: 'update' });
+
+      await vi.waitFor(() =>
+        expect(keyStoreSetKey.mock.calls.map((c) => c[0])).toContain('installed_at'));
+    });
+
+    it('does not re-stamp when a stamp is already there', async () => {
+      keyStoreGetKey.mockImplementation(async (name: string) =>
+        name === 'installed_at' ? '1700000000000' : null);
+      const { installedListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+      installedListener({ reason: 'update' });
+
+      await vi.waitFor(() => expect(tabsQueryMock).toHaveBeenCalled());   // the listener ran
+      expect(keyStoreSetKey.mock.calls.map((c) => c[0])).not.toContain('installed_at');
+    });
+
     it('reloads agent tabs on fresh install too (any onInstalled = new generation)', async () => {
       tabsQueryMock.mockResolvedValue([{ id: 7 }]);
       const { installedListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -1725,6 +1725,38 @@ describe('service-worker.ts', () => {
         expect(keyStoreSetKey).toHaveBeenCalledWith(PENDING_KEY, '');
       });
 
+      /**
+       * The options page's kill switch (Phase 6). These exist because deleting
+       * `await isRatingEnabled() &&` from the gate left all 1,436 tests green —
+       * the toggle would have gone on advertising a control that did nothing,
+       * which is the exact reason advisory frequency was taken off that page
+       * (`options/options.ts:31-35`).
+       */
+      it('⭐ switched OFF: the rating is never opened, and PE runs as usual', async () => {
+        eligible({ nexpath_rating_enabled: 'off' });
+        idbLoadSessionState.mockResolvedValue({ sessionId: 's1', promptCount: 9 });
+        vi.mocked(getPendingPe).mockResolvedValue(peRecord as never);
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserPePopup).toHaveBeenCalledTimes(1));
+        expect(runBrowserRatingPopup).not.toHaveBeenCalled();
+      });
+
+      it('⭐ only the exact string "off" disables it — anything else fails OPEN', async () => {
+        // A damaged value must not silently switch off a feature the user never
+        // turned off. The options page defaults the same way, so the two cannot
+        // disagree about what a missing or junk value means.
+        eligible({ nexpath_rating_enabled: 'OFF' });
+        vi.mocked(runBrowserRatingPopup).mockResolvedValue({ state: 'rated', rating: 3 });
+        const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+
+        stopPe(messageListener, 7);
+
+        await vi.waitFor(() => expect(runBrowserRatingPopup).toHaveBeenCalledTimes(1));
+      });
+
       it('with no tab there is nothing to render into, so the gate is skipped', async () => {
         eligible();
         vi.mocked(getPendingPe).mockResolvedValue(null);

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -2697,4 +2697,71 @@ describe('service-worker.ts', () => {
     });
   });
 
+  /**
+   * The rating-popup cadence heartbeats (Phase 1, item #18).
+   *
+   * These exist because deleting BOTH calls from the worker left the whole suite
+   * green: the adapter is well covered on its own, and nothing observed whether
+   * the worker ever calls it. A cadence that is never fed simply never reaches
+   * its threshold, and the popup silently never appears — the quietest possible
+   * failure. So these assert the WIRE, not the arithmetic.
+   */
+  describe('rating cadence heartbeats', () => {
+    const cadenceWrites = (): string[] => keyStoreSetKey.mock.calls
+      .map((c) => c[0] as string)
+      .filter((k) => k.startsWith('feedback_'));
+
+    it('a genuine prompt submit records activity', async () => {
+      const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+      const sendResponse = vi.fn();
+
+      messageListener(
+        { type: 'nexpath:prompt-submit', promptText: 'hi', projectRoot: 'https://replit.com', agent: 'replit', tabId: 7 },
+        {},
+        sendResponse,
+      );
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalledWith({ ok: true }));
+
+      expect(cadenceWrites()).toContain('feedback_active_ms');
+      expect(cadenceWrites()).toContain('feedback_last_activity_at');
+    });
+
+    it('a response stop records activity too', async () => {
+      const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+      const sendResponse = vi.fn();
+
+      messageListener(
+        { type: 'nexpath:response-stop', projectRoot: 'https://replit.com', agent: 'replit', tabId: 1 },
+        {},
+        sendResponse,
+      );
+
+      // The stop handler is DETACHED (`void handleResponseStop(...)`) and the ack
+      // is sent before it starts, so waiting on sendResponse would race past the
+      // heartbeat. Wait for the write itself.
+      await vi.waitFor(() => expect(cadenceWrites()).toContain('feedback_last_activity_at'));
+    });
+
+    it('⭐ a DUPLICATE submit does not — the extension must not inflate the usage it measures', async () => {
+      // The dedup guard returns before the heartbeat, which is why the call sits
+      // below it (mirroring auto.ts:936-938 sitting below the injected-prompt guard).
+      // An enhanced prompt we injected ourselves comes back through this path.
+      keyStoreGetKey.mockImplementation(async (name: string) =>
+        name.startsWith('nexpath_last_prompt::')
+          ? JSON.stringify({ text: 'hi', at: Date.now() })
+          : null);
+      const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
+      const sendResponse = vi.fn();
+
+      messageListener(
+        { type: 'nexpath:prompt-submit', promptText: 'hi', projectRoot: 'https://replit.com', agent: 'replit', tabId: 7 },
+        {},
+        sendResponse,
+      );
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalledWith({ ok: true }));
+
+      expect(cadenceWrites()).toEqual([]);
+    });
+  });
+
 });

--- a/src/ext-browser/background/service-worker.test.ts
+++ b/src/ext-browser/background/service-worker.test.ts
@@ -2700,11 +2700,15 @@ describe('service-worker.ts', () => {
   /**
    * The rating-popup cadence heartbeats (Phase 1, item #18).
    *
-   * These exist because deleting BOTH calls from the worker left the whole suite
+   * These exist because deleting the call from the worker left the whole suite
    * green: the adapter is well covered on its own, and nothing observed whether
    * the worker ever calls it. A cadence that is never fed simply never reaches
    * its threshold, and the popup silently never appears — the quietest possible
    * failure. So these assert the WIRE, not the arithmetic.
+   *
+   * Two of the three are NEGATIVE. Where the heartbeat must NOT fire, an extra
+   * call is just as silent as a missing one: the numbers still move, they are
+   * simply wrong, and the popup comes due earlier than the CLI would ask.
    */
   describe('rating cadence heartbeats', () => {
     const cadenceWrites = (): string[] => keyStoreSetKey.mock.calls
@@ -2726,7 +2730,13 @@ describe('service-worker.ts', () => {
       expect(cadenceWrites()).toContain('feedback_last_activity_at');
     });
 
-    it('a response stop records activity too', async () => {
+    it('⭐ a response stop does NOT — stop is the READ side, exactly as in the CLI', async () => {
+      // The CLI has ONE production `recordActivity` call site, the submit hook
+      // (auto.ts:938); stop consumes instead (stop.ts:513,530 — isFeedbackEligible
+      // / markFeedbackShown). Feeding on stop as well counts one slow turn twice:
+      // a prompt→stop→prompt spanning 20 minutes in two 10-minute halves banks
+      // both halves, where the CLI sees a single 20-minute gap and discards it as
+      // an idle break past IDLE_CAP_MS.
       const { messageListener } = await importFreshServiceWorker({ hasDocument: hasDocumentMock, createDocument: createDocumentMock });
       const sendResponse = vi.fn();
 
@@ -2736,10 +2746,12 @@ describe('service-worker.ts', () => {
         sendResponse,
       );
 
-      // The stop handler is DETACHED (`void handleResponseStop(...)`) and the ack
-      // is sent before it starts, so waiting on sendResponse would race past the
-      // heartbeat. Wait for the write itself.
-      await vi.waitFor(() => expect(cadenceWrites()).toContain('feedback_last_activity_at'));
+      // The stop handler is DETACHED (`void handleResponseStop(...)`) and acks
+      // before it starts, so an immediate assertion would pass on a handler that
+      // has not run yet. Wait for a write this path DOES make, then check that no
+      // cadence write rode along with it.
+      await vi.waitFor(() => expect(keyStoreGetKey).toHaveBeenCalledWith('nexpath_advisory_legacy_surface'));
+      expect(cadenceWrites()).toEqual([]);
     });
 
     it('⭐ a DUPLICATE submit does not — the extension must not inflate the usage it measures', async () => {

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -81,7 +81,10 @@ log.debug('build_identity', { build: BUILD_ID, peEngine: PE_ENGINE_READY });
 
 // ── First-install: open options page ──────────────────────────────────────────
 
-// Must stay in sync with the manifests' host_permissions/content-script matches.
+// The AGENT sites only — must stay in sync with the manifests' content-script
+// matches. NOT the whole of `host_permissions`: that also carries
+// `us.i.posthog.com`, which the extension talks TO and never runs ON, and
+// reloading a tab there would be nonsense.
 const AGENT_TAB_URL_PATTERNS = [
   'https://*.replit.com/*',
   'https://bolt.new/*',

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -54,7 +54,8 @@ import { prepareAndStoreBrowserPe, type BrowserPeContext } from './pe-prepare.js
 import { getPendingPe, markPendingPeShown, upsertPendingPe } from '../adapters/pe-pending-store.js';
 import { resolvePePopupCooldown, resolvePeSequenceEnabled } from '../adapters/pe-config.js';
 import { getPendingSequence, recordPendingSequence } from '../adapters/pe-sequence-store.js';
-import { deliverPePanelCommand, runBrowserPePopup } from './pe-popup-host.js';
+import { deliverPePanelCommand, runBrowserPePopup, runBrowserRatingPopup } from './pe-popup-host.js';
+import { isFeedbackEligible as isRatingEligible } from '../adapters/rating-cadence.js';
 // Rating-popup cadence (Phase 1). Aliased on import: `recordActivity` is a
 // generic name in a 1,900-line worker, and this one measures exactly one thing.
 import { recordActivity as recordRatingActivity } from '../adapters/rating-cadence.js';
@@ -1553,6 +1554,45 @@ async function handleResponseStopPeFirst(projectRoot: string, tabId: number | un
       keyStore.setKey(pendingAdvisoryOgKeyFor(projectRoot), ''),
     ]);
     log.debug('advisory_removed_surface', { projectRoot });
+  }
+
+  // ── The rating popup gate (Phase 5, item #14) ─────────────────────────────
+  //
+  // PLACEMENT IS EXACT, and it is not "before the PE popup". It sits AFTER the
+  // silent advisory consume above and BEFORE the pending-PE section below:
+  //
+  //   - earlier, and the advisory row survives an extra turn — a behaviour
+  //     change nobody asked for;
+  //   - later, and it would run after `markPendingPeShown` has consumed the
+  //     pending PE row, so preempting would DESTROY the enhancement instead of
+  //     deferring it.
+  //
+  // Here, `getPendingPe` has not even been read yet, so an early return leaves
+  // the row exactly as it was and the PE popup opens on the next stop.
+  //
+  // §4.1 M5, accepted: that deferral ages the row against
+  // PE_PENDING_MAX_AGE_MS. If the user's next agent response is more than 30
+  // minutes away the enhancement is consumed silently as stale. Refreshing
+  // `createdAt` on preempt would re-open the cross-sitting resurrection that
+  // gate exists to prevent, so the trade is taken as-is.
+  //
+  // No tab, no popup: a rating cannot render into nothing, and asking the
+  // cadence to spend itself on an impossible render is exactly what §4.1 M3
+  // forbids. `not_shown` falls through to PE, so nothing is lost either way.
+  if (tabId !== undefined && await isRatingEligible(keyStore, clock.now())) {
+    const rating = await runBrowserRatingPopup({
+      log,
+      projectRoot,
+      store: keyStore,
+      sendToTab: (m) => browser.tabs.sendMessage(tabId, m),
+      now: () => clock.now(),
+    });
+    // Shown at all — answered or dismissed — means this turn belonged to the
+    // rating. The dock is mount-once, so PE cannot also open now.
+    if (rating.state !== 'not_shown') {
+      log.debug('pe_deferred_for_rating', { projectRoot, outcome: rating.state });
+      return;
+    }
   }
 
   const state = await idb.loadSessionState(projectRoot);

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -1540,30 +1540,6 @@ async function handleResponseStop(projectRoot: string, tabId: number | undefined
  * stop (stop.ts:614–616); a cooldown hit consumes it with a ring event
  * (stop.ts:552–561).
  */
-/**
- * The options page's rating kill switch (Phase 6).
- *
- * This read is the whole reason that control is allowed on the page at all.
- * Advisory frequency was removed from it (`options/options.ts:31-35`) because it
- * "advertised a control over a surface this extension no longer shows … so the
- * setting read as broken" — a toggle that changes nothing is worse than no
- * toggle. If this call ever goes away, the control must come off the page.
- *
- * FAIL-OPEN, and only the exact string 'off' disables: an unreadable or
- * corrupted setting leaves the popup working rather than silently switching off
- * a feature the user never turned off. The options page defaults the same way,
- * so the two cannot disagree about what a missing value means.
- */
-const RATING_ENABLED_KEY = 'nexpath_rating_enabled';
-
-async function isRatingEnabled(): Promise<boolean> {
-  try {
-    return (await keyStore.getKey(RATING_ENABLED_KEY)) !== 'off';
-  } catch {
-    return true;
-  }
-}
-
 async function handleResponseStopPeFirst(projectRoot: string, tabId: number | undefined): Promise<void> {
   // The submit pipeline queues the advisory AND parks the PE before clearing
   // its inflight marker — wait for the MARKER here (not for a row: the PE
@@ -1603,7 +1579,12 @@ async function handleResponseStopPeFirst(projectRoot: string, tabId: number | un
   // No tab, no popup: a rating cannot render into nothing, and asking the
   // cadence to spend itself on an impossible render is exactly what §4.1 M3
   // forbids. `not_shown` falls through to PE, so nothing is lost either way.
-  if (tabId !== undefined && await isRatingEnabled() && await isRatingEligible(keyStore, clock.now())) {
+  // No enable/disable switch, deliberately (owner decision 2026-09-01): the
+  // rating prompt is shown to every user. The control that used to live on the
+  // options page is gone, and so is the stored key — an installation that set it
+  // before is NOT honoured, because a setting nothing reads is the exact failure
+  // that took advisory frequency off that page (`options/options.ts:31-35`).
+  if (tabId !== undefined && await isRatingEligible(keyStore, clock.now())) {
     const rating = await runBrowserRatingPopup({
       log,
       projectRoot,

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -1490,10 +1490,15 @@ async function handleResponseStop(projectRoot: string, tabId: number | undefined
     log.debug('response_stop_quiet_window', { projectRoot });
     return;
   }
-  // Second cadence heartbeat, below the echo guard for the same reason the
-  // submit one sits below the dedup guard: a stop this extension provoked must
-  // not count as the user working. See adapters/rating-cadence.ts.
-  await recordRatingActivity(keyStore, clock.now());
+  // NO cadence heartbeat here, deliberately. The CLI splits the two sides:
+  // `recordActivity` has exactly one production call site, the submit hook
+  // (auto.ts:938), and stop is the READ side (stop.ts:513,530 —
+  // isFeedbackEligible / markFeedbackShown). Feeding here too would count one
+  // slow turn twice: a prompt→stop→prompt spanning 20 minutes in two 10-minute
+  // halves banks both halves, where the CLI sees one 20-minute gap and discards
+  // it as an idle break past IDLE_CAP_MS. The popup would come due sooner in the
+  // browser than in the CLI on exactly the sessions agents are slowest.
+  // A test in service-worker.test.ts pins this absence.
   let legacySurface = false;
   try {
     legacySurface = (await keyStore.getKey(ADVISORY_LEGACY_SURFACE_KEY)) === 'enabled';

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -58,6 +58,7 @@ import { deliverPePanelCommand, runBrowserPePopup } from './pe-popup-host.js';
 // Rating-popup cadence (Phase 1). Aliased on import: `recordActivity` is a
 // generic name in a 1,900-line worker, and this one measures exactly one thing.
 import { recordActivity as recordRatingActivity } from '../adapters/rating-cadence.js';
+import { setInstalledAtIfMissing } from '../adapters/lifecycle-signals.js';
 
 const idb = new IdbStorageAdapter();
 const keyStore = new ChromeStorageKeyAdapter();
@@ -92,6 +93,17 @@ browser.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === 'install') {
     browser.runtime.openOptionsPage();
   }
+
+  // The install stamp for the rating popup's lifecycle events (Phase 3, §4.2).
+  //
+  // Written on UPDATE as well as install, and deliberately so: the helper is
+  // if-missing, so this is what backfills a stamp for an installation that
+  // predates the field. It mirrors the CLI's `setInstalledAtIfMissing`.
+  //
+  // Storing it sends nothing. The stamp sits in storage.local until the user
+  // clicks a rating, which is this extension's consent moment — see
+  // adapters/telemetry-send.ts.
+  void setInstalledAtIfMissing(keyStore);
 
   // Every install/update starts a NEW extension generation; content scripts already
   // running in open agent tabs belong to the dead one — their runtime.sendMessage

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -1540,6 +1540,30 @@ async function handleResponseStop(projectRoot: string, tabId: number | undefined
  * stop (stop.ts:614–616); a cooldown hit consumes it with a ring event
  * (stop.ts:552–561).
  */
+/**
+ * The options page's rating kill switch (Phase 6).
+ *
+ * This read is the whole reason that control is allowed on the page at all.
+ * Advisory frequency was removed from it (`options/options.ts:31-35`) because it
+ * "advertised a control over a surface this extension no longer shows … so the
+ * setting read as broken" — a toggle that changes nothing is worse than no
+ * toggle. If this call ever goes away, the control must come off the page.
+ *
+ * FAIL-OPEN, and only the exact string 'off' disables: an unreadable or
+ * corrupted setting leaves the popup working rather than silently switching off
+ * a feature the user never turned off. The options page defaults the same way,
+ * so the two cannot disagree about what a missing value means.
+ */
+const RATING_ENABLED_KEY = 'nexpath_rating_enabled';
+
+async function isRatingEnabled(): Promise<boolean> {
+  try {
+    return (await keyStore.getKey(RATING_ENABLED_KEY)) !== 'off';
+  } catch {
+    return true;
+  }
+}
+
 async function handleResponseStopPeFirst(projectRoot: string, tabId: number | undefined): Promise<void> {
   // The submit pipeline queues the advisory AND parks the PE before clearing
   // its inflight marker — wait for the MARKER here (not for a row: the PE
@@ -1579,7 +1603,7 @@ async function handleResponseStopPeFirst(projectRoot: string, tabId: number | un
   // No tab, no popup: a rating cannot render into nothing, and asking the
   // cadence to spend itself on an impossible render is exactly what §4.1 M3
   // forbids. `not_shown` falls through to PE, so nothing is lost either way.
-  if (tabId !== undefined && await isRatingEligible(keyStore, clock.now())) {
+  if (tabId !== undefined && await isRatingEnabled() && await isRatingEligible(keyStore, clock.now())) {
     const rating = await runBrowserRatingPopup({
       log,
       projectRoot,

--- a/src/ext-browser/background/service-worker.ts
+++ b/src/ext-browser/background/service-worker.ts
@@ -55,6 +55,9 @@ import { getPendingPe, markPendingPeShown, upsertPendingPe } from '../adapters/p
 import { resolvePePopupCooldown, resolvePeSequenceEnabled } from '../adapters/pe-config.js';
 import { getPendingSequence, recordPendingSequence } from '../adapters/pe-sequence-store.js';
 import { deliverPePanelCommand, runBrowserPePopup } from './pe-popup-host.js';
+// Rating-popup cadence (Phase 1). Aliased on import: `recordActivity` is a
+// generic name in a 1,900-line worker, and this one measures exactly one thing.
+import { recordActivity as recordRatingActivity } from '../adapters/rating-cadence.js';
 
 const idb = new IdbStorageAdapter();
 const keyStore = new ChromeStorageKeyAdapter();
@@ -884,6 +887,19 @@ async function runPromptSubmitPipeline(
   }
   await keyStore.setKey(lastPromptKeyFor(projectRoot), JSON.stringify({ text: promptText, at: now }));
 
+  // ── Step 1.3: Record active usage — one heartbeat per genuine user prompt,
+  //     feeding the rating-popup cadence (adapters/rating-cadence.ts).
+  //
+  //     Placed HERE, below the dedup guard, for the reason auto.ts:936-938 puts
+  //     its own call below the injected-prompt guard: an enhanced prompt we
+  //     injected ourselves comes back through this path as a fresh submit, and
+  //     counting it would let the extension inflate the user's usage with its
+  //     own traffic. Everything above returns before reaching this line.
+  //
+  //     Best-effort by contract — the cadence functions never throw, and this is
+  //     measurement, not a gate on the pipeline it measures.
+  await recordRatingActivity(keyStore, now);
+
   // ── Step 1.5: Resolve frequency + role config — mirrors cli/commands/auto.ts's
   // step 1.5 exactly (same fallback default, same resolveFrequencyConfig call) so
   // the browser's advisory-firing gating is the same logic as the CLI's, just fed
@@ -1474,6 +1490,10 @@ async function handleResponseStop(projectRoot: string, tabId: number | undefined
     log.debug('response_stop_quiet_window', { projectRoot });
     return;
   }
+  // Second cadence heartbeat, below the echo guard for the same reason the
+  // submit one sits below the dedup guard: a stop this extension provoked must
+  // not count as the user working. See adapters/rating-cadence.ts.
+  await recordRatingActivity(keyStore, clock.now());
   let legacySurface = false;
   try {
     legacySurface = (await keyStore.getKey(ADVISORY_LEGACY_SURFACE_KEY)) === 'enabled';

--- a/src/ext-browser/content/ipc.test.ts
+++ b/src/ext-browser/content/ipc.test.ts
@@ -16,6 +16,7 @@ import {
   isShowPeMsg,
   isPeCloseMsg,
   isPeInjectMsg,
+  isShowRatingMsg,
 } from './ipc.js';
 
 describe('IPC type guards', () => {
@@ -201,7 +202,7 @@ describe('IPC type guards', () => {
       isPanelEventMsg, isPromptCapturedMsg, isResponseStoppedMsg,
       isAdvisoryFooterIntentMsg,
       isPeCommandMsg, isPeTerminalNoticeMsg, isPeKeepaliveMsg,
-      isShowPeMsg, isPeCloseMsg, isPeInjectMsg,
+      isShowPeMsg, isPeCloseMsg, isPeInjectMsg, isShowRatingMsg,
     ];
     for (const guard of guards) {
       expect(guard({})).toBe(false);
@@ -239,5 +240,31 @@ describe('IPC type guards', () => {
       expect(isPeInjectMsg({ type: 'nexpath:pe-inject', projectRoot: 'r', text: 't' })).toBe(true);
       expect(isPeInjectMsg({ type: 'nexpath:pe-inject', projectRoot: 'r' })).toBe(false);
     });
+  });
+});
+
+describe('isShowRatingMsg', () => {
+  const ok = { type: 'nexpath:show-rating', projectRoot: 'https://bolt.new', payload: { schemaVersion: 1, kind: 'rating', viewSeq: 3 } };
+
+  it('accepts a well-formed rating view', () => {
+    expect(isShowRatingMsg(ok)).toBe(true);
+  });
+
+  it.each([
+    ['a PE show message',        { ...ok, type: 'nexpath:show-pe' }],
+    ['no projectRoot',           { type: 'nexpath:show-rating', payload: ok.payload }],
+    ['no payload',               { type: 'nexpath:show-rating', projectRoot: 'r' }],
+    ['a null payload',           { ...ok, payload: null }],
+    ['a payload of the wrong kind', { ...ok, payload: { schemaVersion: 1, kind: 'sequence_offer', viewSeq: 3 } }],
+    ['no viewSeq',               { ...ok, payload: { schemaVersion: 1, kind: 'rating' } }],
+    ['a non-numeric viewSeq',    { ...ok, payload: { schemaVersion: 1, kind: 'rating', viewSeq: '3' } }],
+  ])('refuses %s', (_label, msg) => {
+    expect(isShowRatingMsg(msg)).toBe(false);
+  });
+
+  it('⭐ does not accept a rating view sent as a PE show message', () => {
+    // The two are separate messages on purpose (#11): a rating has no body and
+    // must not go through the PE panel's body/caret preservation.
+    expect(isShowRatingMsg({ ...ok, type: 'nexpath:show-pe' })).toBe(false);
   });
 });

--- a/src/ext-browser/content/ipc.ts
+++ b/src/ext-browser/content/ipc.ts
@@ -1,5 +1,5 @@
 import type { AdvisoryPayload, PanelEvent } from '../../core/ports/ui.port.js';
-import type { PePanelViewV1 } from '../ui/pe-contract.js';
+import type { PePanelViewV1, PeRatingViewV1 } from '../ui/pe-contract.js';
 import { isPePanelCommandV1, type PePanelCommandV1 } from '../ui/pe-contract.js';
 
 /**
@@ -224,7 +224,25 @@ export interface PeInjectMsg {
   text: string;
 }
 
-export type SwToContentMsg = ShowAdvisoryMsg | ShowPeMsg | PeCloseMsg | PeInjectMsg | PePreparingMsg;
+/**
+ * Render the advisory rating surface. A message of its own rather than another
+ * `nexpath:show-pe` payload, because the two have nothing in common downstream:
+ * this one carries no body, cannot be re-rendered by an engine echo, and must
+ * not go through the PE panel's body/caret preservation. Change-map #11
+ * ("recommended for separation") and #12 measured the cost at one branch, one
+ * guard and one union member — which is what this is.
+ *
+ * The command comes BACK on the existing `nexpath:pe-command`: the rating is a
+ * `PePanelCommandV1` variant, and forking the command channel would fork the
+ * popup host's mailbox with it.
+ */
+export interface ShowRatingMsg {
+  type: 'nexpath:show-rating';
+  projectRoot: string;
+  payload: PeRatingViewV1;
+}
+
+export type SwToContentMsg = ShowAdvisoryMsg | ShowPeMsg | ShowRatingMsg | PeCloseMsg | PeInjectMsg | PePreparingMsg;
 
 // ── Content → Service Worker (panel event) ────────────────────────────────────
 
@@ -250,6 +268,7 @@ export type ExtensionMsg =
   | SubmitFlowEventMsg
   | SubmitDecisionRequestMsg
   | ShowPeMsg
+  | ShowRatingMsg
   | PeCloseMsg
   | PeInjectMsg;
 
@@ -346,6 +365,19 @@ export function isShowPeMsg(msg: unknown): msg is ShowPeMsg {
   return m['type'] === 'nexpath:show-pe' &&
     typeof m['projectRoot'] === 'string' &&
     typeof m['payload'] === 'object' && m['payload'] !== null;
+}
+
+export function isShowRatingMsg(msg: unknown): msg is ShowRatingMsg {
+  if (typeof msg !== 'object' || msg === null) return false;
+  const m = msg as Record<string, unknown>;
+  if (m['type'] !== 'nexpath:show-rating' || typeof m['projectRoot'] !== 'string') return false;
+  const p = m['payload'];
+  if (typeof p !== 'object' || p === null) return false;
+  // Stricter than `isShowPeMsg`, which only checks that a payload object
+  // exists: this view has exactly three fields and the content script acts on
+  // two of them, so there is nothing to gain by accepting a looser shape.
+  const v = p as Record<string, unknown>;
+  return v['kind'] === 'rating' && typeof v['viewSeq'] === 'number';
 }
 
 export function isPePreparingMsg(msg: unknown): msg is PePreparingMsg {

--- a/src/ext-browser/content/main-world-injector.test.ts
+++ b/src/ext-browser/content/main-world-injector.test.ts
@@ -659,6 +659,43 @@ describe('PE panel channels (PB4)', () => {
     await expect(result).resolves.toEqual({ rendered: true });
   });
 
+  const ratingMsg = { type: 'nexpath:show-rating', projectRoot: 'r', payload: { schemaVersion: 1, kind: 'rating', viewSeq: 1 } };
+
+  it('⭐ show-rating takes the same ack path and resolves {rendered:true}', () => {
+    const listener = capturedOnMessage.fn!;
+
+    const result = listener(ratingMsg);
+
+    expect(result).toBeInstanceOf(Promise);
+    window.dispatchEvent(new CustomEvent('nexpath:pe-view-ack'));
+    return expect(result).resolves.toEqual({ rendered: true });
+  });
+
+  it('⭐ show-rating REJECTS after 3s with no ack — §4.1 M3 needs a failed push to be visible', async () => {
+    // Without this the message fell through to the plain re-dispatch and
+    // resolved immediately: an ack that proves nothing, and a host that would
+    // consume cadence for a popup nobody saw.
+    vi.useFakeTimers();
+    try {
+      const listener = capturedOnMessage.fn!;
+      const result = listener(ratingMsg) as Promise<unknown>;
+      const settled = result.then(() => 'resolved', () => 'rejected');
+      vi.advanceTimersByTime(3_000);
+      await expect(settled).resolves.toBe('rejected');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a malformed rating message is NOT given an ack promise — it re-dispatches like any other', () => {
+    const listener = capturedOnMessage.fn!;
+
+    const result = listener({ type: 'nexpath:show-rating', projectRoot: 'r', payload: { kind: 'rating' } });
+
+    // No viewSeq → not a rating show message → no "did it render" contract.
+    return expect(result).resolves.toBeUndefined();
+  });
+
   it('show-pe REJECTS after 3s with no ack — a page whose PE wiring is absent must fail the send, not silently ack', async () => {
     vi.useFakeTimers();
     try {

--- a/src/ext-browser/content/main-world-injector.ts
+++ b/src/ext-browser/content/main-world-injector.ts
@@ -1,6 +1,6 @@
 import browser from 'webextension-polyfill';
 import { resolveAgentFromHostname, resolveProjectRootFromLocation } from './agents/agent-hosts.js';
-import { isPromptCapturedMsg, isResponseStoppedMsg, isShowAdvisoryMsg, isShowPeMsg } from './ipc.js';
+import { isPromptCapturedMsg, isResponseStoppedMsg, isShowAdvisoryMsg, isShowPeMsg, isShowRatingMsg } from './ipc.js';
 import { setupSubmitFlowBridge } from './submit-flow-bridge.js';
 import type { PromptSubmitMsg, ResponseStopMsg, AdvisoryFooterIntentMsg, PromptInjectedMsg, AdvisoryTerminalMsg, PeCommandMsg, PeTerminalNoticeMsg, PeKeepaliveMsg } from './ipc.js';
 import { isPePanelCommandV1 } from '../ui/pe-contract.js';
@@ -368,7 +368,15 @@ function setupListeners(): void {
     // row, mark cooldown), so a page whose PE wiring is absent/stale must FAIL
     // the send, not silently ack it — hence the reject on timeout. The listener
     // must be registered BEFORE the re-dispatch below or a same-tick ack races.
-    if (isShowPeMsg(msg)) {
+    //
+    // The RATING view takes the same path, and needs it for the same reason
+    // turned around: §4.1 M3 says a failed push must not consume cadence, and
+    // the host can only know a push failed if a missing panel rejects instead of
+    // resolving. Without this branch a `show-rating` fell through to the plain
+    // re-dispatch below and resolved immediately — an ack that proves nothing.
+    // Both views ack on the SAME event, so the machinery is shared rather than
+    // copied; `pe-inject.ts` dispatches it from both branches.
+    if (isShowPeMsg(msg) || isShowRatingMsg(msg)) {
       const ack = new Promise<unknown>((resolve, reject) => {
         const timer = setTimeout(() => {
           window.removeEventListener('nexpath:pe-view-ack', onAck);

--- a/src/ext-browser/content/pe-inject.test.ts
+++ b/src/ext-browser/content/pe-inject.test.ts
@@ -299,3 +299,57 @@ describe('announcing a terminal decision early', () => {
     expect(onTerminalIntent).toBeTypeOf('function');
   });
 });
+
+/**
+ * Content-side routing for the rating surface (Phase 4, change-map #12).
+ *
+ * A wire test, and it exists because deleting the whole branch left all 1,413
+ * tests green: the message would arrive, nothing would mount, and there would be
+ * no error to notice — the popup simply never appears.
+ */
+describe('show-rating handling', () => {
+  function showRating(seq = 1, extra: Record<string, unknown> = {}): void {
+    dispatchSwMessage({
+      type: 'nexpath:show-rating',
+      projectRoot: 'https://bolt.new/~/p',
+      payload: { schemaVersion: 1, kind: 'rating', viewSeq: seq, ...extra },
+    });
+  }
+
+  it('⭐ mounts and shows the rating view', () => {
+    showRating(4);
+
+    expect(mountMock).toHaveBeenCalledTimes(1);
+    expect(controller.show).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'rating', viewSeq: 4 }),
+    );
+  });
+
+  it('reuses the mount, exactly as a PE re-render does', () => {
+    showPe();
+    showRating(2);
+
+    expect(mountMock).toHaveBeenCalledTimes(1);
+    expect(controller.show).toHaveBeenCalledTimes(2);
+  });
+
+  it('a schemaVersion mismatch is ignored — no show', () => {
+    showRating(1, { schemaVersion: 99 });
+
+    expect(controller.show).not.toHaveBeenCalled();
+  });
+
+  it('⭐ does NOT dismiss the sticky notice — that notice belongs to a held prompt', () => {
+    // Erasing it would tell the user a hold ended when it had not. The PE branch
+    // dismisses because the PE popup IS the thing the hold was waiting for.
+    showRating();
+
+    expect(dismissStickyNoticeMock).not.toHaveBeenCalled();
+  });
+
+  it('a malformed rating message is ignored rather than mounting something empty', () => {
+    dispatchSwMessage({ type: 'nexpath:show-rating', projectRoot: 'r', payload: { kind: 'rating' } });
+
+    expect(controller.show).not.toHaveBeenCalled();
+  });
+});

--- a/src/ext-browser/content/pe-inject.ts
+++ b/src/ext-browser/content/pe-inject.ts
@@ -19,7 +19,7 @@
  *    rare in the first place.
  */
 
-import { isPeCloseMsg, isPeInjectMsg, isPePreparingMsg, isShowPeMsg } from './ipc.js';
+import { isPeCloseMsg, isPeInjectMsg, isPePreparingMsg, isShowPeMsg, isShowRatingMsg } from './ipc.js';
 // The renderer is the UI developer's dock (PR #1) behind the pe-dock-adapter
 // bridge — same PePanelControllerV1 contract the retired pe-panel implemented,
 // so nothing else in this file or SW-side changed for the swap.
@@ -181,6 +181,29 @@ export function setupPeListener(): void {
       startKeepalive();
       // Ack AFTER the mount so the SW's first-render bookkeeping (consume row,
       // mark cooldown) reflects a panel that actually exists on screen.
+      window.dispatchEvent(new CustomEvent('nexpath:pe-view-ack'));
+      return;
+    }
+
+    if (isShowRatingMsg(msg)) {
+      // Deliberately NOT dismissing the sticky notice: it belongs to a held
+      // prompt, and a rating has nothing to do with one. If a hold really is in
+      // flight, erasing its notice would tell the user the hold ended.
+      if (msg.payload.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+        console.warn(`[nexpath] rating view schemaVersion mismatch: got ${String(msg.payload.schemaVersion)}, expected ${SUPPORTED_SCHEMA_VERSION}. Ignoring.`);
+        return;
+      }
+      clearWatchdog();
+      const ctrl = ensureMounted();
+      ctrl.show(msg.payload);
+      // MV3 teardown: the same keepalive the PE panel uses (§4.1 M4 — already
+      // handled, do not rebuild it).
+      startKeepalive();
+      // Dispatched for symmetry with the PE branch. NOTE: nothing awaits it yet
+      // — `main-world-injector.ts:371` gates the ack promise on `isShowPeMsg`,
+      // so a rating currently resolves immediately with no proof of render.
+      // That matters for §4.1 M3 ("a failed push must not consume cadence") and
+      // belongs with the host wiring in Phase 5.
       window.dispatchEvent(new CustomEvent('nexpath:pe-view-ack'));
       return;
     }

--- a/src/ext-browser/content/pe-inject.ts
+++ b/src/ext-browser/content/pe-inject.ts
@@ -199,11 +199,11 @@ export function setupPeListener(): void {
       // MV3 teardown: the same keepalive the PE panel uses (§4.1 M4 — already
       // handled, do not rebuild it).
       startKeepalive();
-      // Dispatched for symmetry with the PE branch. NOTE: nothing awaits it yet
-      // — `main-world-injector.ts:371` gates the ack promise on `isShowPeMsg`,
-      // so a rating currently resolves immediately with no proof of render.
-      // That matters for §4.1 M3 ("a failed push must not consume cadence") and
-      // belongs with the host wiring in Phase 5.
+      // The SW awaits this as its "the panel really exists" signal — the same
+      // event and the same promise the PE branch uses
+      // (`main-world-injector.ts`). It is what lets §4.1 M3 hold: a push that
+      // never rendered rejects, so the host can decline to consume cadence for
+      // a popup nobody saw.
       window.dispatchEvent(new CustomEvent('nexpath:pe-view-ack'));
       return;
     }

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -11,8 +11,7 @@
     "https://*.replit.com/*",
     "https://bolt.new/*",
     "https://*.stackblitz.com/*",
-    "https://lovable.dev/*",
-    "https://us.i.posthog.com/*"
+    "https://lovable.dev/*"
   ],
   "background": {
     "service_worker": "service-worker.js",

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -11,7 +11,8 @@
     "https://*.replit.com/*",
     "https://bolt.new/*",
     "https://*.stackblitz.com/*",
-    "https://lovable.dev/*"
+    "https://lovable.dev/*",
+    "https://us.i.posthog.com/*"
   ],
   "background": {
     "service_worker": "service-worker.js",

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -11,7 +11,8 @@
     "https://*.replit.com/*",
     "https://bolt.new/*",
     "https://*.stackblitz.com/*",
-    "https://lovable.dev/*"
+    "https://lovable.dev/*",
+    "https://us.i.posthog.com/*"
   ],
   "background": {
     "scripts": ["service-worker.js"],
@@ -61,7 +62,7 @@
       "id": "{80f4c1c7-1fb2-41d9-a4a1-7c2f4981d286}",
       "strict_min_version": "112.0",
       "data_collection_permissions": {
-        "required": ["authenticationInfo", "websiteContent"]
+        "required": ["authenticationInfo", "websiteContent", "technicalAndInteraction"]
       }
     }
   },

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -11,8 +11,7 @@
     "https://*.replit.com/*",
     "https://bolt.new/*",
     "https://*.stackblitz.com/*",
-    "https://lovable.dev/*",
-    "https://us.i.posthog.com/*"
+    "https://lovable.dev/*"
   ],
   "background": {
     "scripts": ["service-worker.js"],

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -13,7 +13,7 @@ const load = (target: 'chrome' | 'firefox') =>
   JSON.parse(readFileSync(new URL(`./manifest.${target}.json`, import.meta.url), 'utf8'));
 
 const EXPECTED_PERMISSIONS = ['storage', 'tabs'];
-/** The four agent sites the extension actually runs on. */
+/** The four agent sites the extension runs on — and the whole of `host_permissions`. */
 const EXPECTED_AGENT_HOSTS = [
   'https://*.replit.com/*',
   'https://bolt.new/*',
@@ -22,17 +22,22 @@ const EXPECTED_AGENT_HOSTS = [
 ];
 
 /**
- * The ONLY non-agent host, and the only one the extension talks to rather than
- * runs on: the PostHog capture endpoint the rating popup posts to
- * (`adapters/telemetry-send.ts`).
+ * The rating popup POSTs to this host (`adapters/telemetry-send.ts`), and it is
+ * deliberately NOT in `host_permissions`.
  *
- * It is listed separately because the distinction is the whole point of this
- * file — every entry here is a line in the install dialog. Adding this one took
- * that dialog from "4 domains" to "5", which is user-visible and store-reviewed.
+ * `host_permissions` exists to bypass CORS. Measured against the live endpoint
+ * (OPTIONS preflight, 2026-08-31): `us.i.posthog.com/capture/` reflects a
+ * `chrome-extension://` origin, allows `POST`, and allows the `content-type`
+ * header — so an ordinary CORS request from the worker succeeds without it.
+ *
+ * Declaring it anyway would request a permission the extension does not need and
+ * add a fifth line to the install dialog for nothing. Least privilege, and the
+ * store reviewers' preference. If a future endpoint stops sending CORS headers,
+ * THAT is when this has to be added — and the user-visible cost paid.
  */
-const EXPECTED_TELEMETRY_HOST = 'https://us.i.posthog.com/*';
+const TELEMETRY_HOST_NOT_REQUESTED = 'https://us.i.posthog.com/*';
 
-const EXPECTED_HOSTS = [...EXPECTED_AGENT_HOSTS, EXPECTED_TELEMETRY_HOST];
+const EXPECTED_HOSTS = EXPECTED_AGENT_HOSTS;
 
 describe('ext-browser manifests — permission surface', () => {
   for (const target of ['chrome', 'firefox'] as const) {
@@ -47,18 +52,17 @@ describe('ext-browser manifests — permission surface', () => {
         expect(manifest.permissions).not.toContain('scripting');
       });
 
-      it('scopes host_permissions to the supported agents plus the one telemetry host', () => {
+      it('scopes host_permissions to the supported agents only', () => {
         expect(manifest.host_permissions).toEqual(EXPECTED_HOSTS);
       });
 
-      it('runs on exactly four agent sites — the telemetry host is talked TO, not run on', () => {
-        // A content script matching the PostHog host would be a different kind of
-        // permission entirely; the send is a fetch from the worker.
+      it('⭐ does NOT request the telemetry host — the send works over plain CORS', () => {
+        // Re-adding it would cost a fifth line in the install dialog and buy
+        // nothing. See the constant's comment for the measurement.
+        expect(manifest.host_permissions).not.toContain(TELEMETRY_HOST_NOT_REQUESTED);
         const matches = (manifest.content_scripts ?? [])
           .flatMap((cs: { matches?: string[] }) => cs.matches ?? []);
-        expect(matches).not.toContain(EXPECTED_TELEMETRY_HOST);
-        expect(manifest.host_permissions.filter((h: string) => h !== EXPECTED_TELEMETRY_HOST))
-          .toEqual(EXPECTED_AGENT_HOSTS);
+        expect(matches).not.toContain(TELEMETRY_HOST_NOT_REQUESTED);
       });
 
       it('is MV3 and version-locked', () => {

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -13,12 +13,26 @@ const load = (target: 'chrome' | 'firefox') =>
   JSON.parse(readFileSync(new URL(`./manifest.${target}.json`, import.meta.url), 'utf8'));
 
 const EXPECTED_PERMISSIONS = ['storage', 'tabs'];
-const EXPECTED_HOSTS = [
+/** The four agent sites the extension actually runs on. */
+const EXPECTED_AGENT_HOSTS = [
   'https://*.replit.com/*',
   'https://bolt.new/*',
   'https://*.stackblitz.com/*',
   'https://lovable.dev/*',
 ];
+
+/**
+ * The ONLY non-agent host, and the only one the extension talks to rather than
+ * runs on: the PostHog capture endpoint the rating popup posts to
+ * (`adapters/telemetry-send.ts`).
+ *
+ * It is listed separately because the distinction is the whole point of this
+ * file — every entry here is a line in the install dialog. Adding this one took
+ * that dialog from "4 domains" to "5", which is user-visible and store-reviewed.
+ */
+const EXPECTED_TELEMETRY_HOST = 'https://us.i.posthog.com/*';
+
+const EXPECTED_HOSTS = [...EXPECTED_AGENT_HOSTS, EXPECTED_TELEMETRY_HOST];
 
 describe('ext-browser manifests — permission surface', () => {
   for (const target of ['chrome', 'firefox'] as const) {
@@ -33,8 +47,18 @@ describe('ext-browser manifests — permission surface', () => {
         expect(manifest.permissions).not.toContain('scripting');
       });
 
-      it('scopes host_permissions to the supported agents only', () => {
+      it('scopes host_permissions to the supported agents plus the one telemetry host', () => {
         expect(manifest.host_permissions).toEqual(EXPECTED_HOSTS);
+      });
+
+      it('runs on exactly four agent sites — the telemetry host is talked TO, not run on', () => {
+        // A content script matching the PostHog host would be a different kind of
+        // permission entirely; the send is a fetch from the worker.
+        const matches = (manifest.content_scripts ?? [])
+          .flatMap((cs: { matches?: string[] }) => cs.matches ?? []);
+        expect(matches).not.toContain(EXPECTED_TELEMETRY_HOST);
+        expect(manifest.host_permissions.filter((h: string) => h !== EXPECTED_TELEMETRY_HOST))
+          .toEqual(EXPECTED_AGENT_HOSTS);
       });
 
       it('is MV3 and version-locked', () => {

--- a/src/ext-browser/options/options.html
+++ b/src/ext-browser/options/options.html
@@ -44,6 +44,16 @@
       </section>
 
       <section class="card">
+        <label>Feedback</label>
+        <p class="field-hint">
+          Now and then nexpath asks how it is working out for you. Answering sends a
+          random installation ID, your 1–4 rating and timestamps — never your prompt
+          text, the sites you use, or anything you typed. Dismissing it sends nothing.
+        </p>
+        <div id="rating-group" class="radio-group" role="radiogroup" aria-label="Feedback prompt"></div>
+      </section>
+
+      <section class="card">
         <label>Status</label>
         <div id="self-check" class="self-check"></div>
       </section>

--- a/src/ext-browser/options/options.html
+++ b/src/ext-browser/options/options.html
@@ -44,16 +44,6 @@
       </section>
 
       <section class="card">
-        <label>Feedback</label>
-        <p class="field-hint">
-          Now and then nexpath asks how it is working out for you. Answering sends a
-          random installation ID, your 1–4 rating and timestamps — never your prompt
-          text, the sites you use, or anything you typed. Dismissing it sends nothing.
-        </p>
-        <div id="rating-group" class="radio-group" role="radiogroup" aria-label="Feedback prompt"></div>
-      </section>
-
-      <section class="card">
         <label>Status</label>
         <div id="self-check" class="self-check"></div>
       </section>

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -323,4 +325,53 @@ describe('options.ts', () => {
     });
   });
 
+});
+
+/**
+ * The docs describe this control to users and to store reviewers, and they have
+ * gone stale twice on this branch already — once claiming "No telemetry …
+ * nothing is sent" after the sender shipped, once claiming the extension had no
+ * opt-out after this very switch shipped. Both were caught by reading, which is
+ * not a mechanism.
+ *
+ * So: the same discipline the adapters use against the CLI, pointed at the docs.
+ * If a label here is reworded, the sentence that names it has to be reworded
+ * too.
+ */
+describe('the docs still describe this page accurately', () => {
+  const cwd = process.cwd();
+  const readme  = readFileSync(join(cwd, 'src', 'ext-browser', 'README.md'), 'utf8');
+  const publish = readFileSync(join(cwd, 'src', 'ext-browser', 'PUBLISH.md'), 'utf8');
+  const html    = readFileSync(join(cwd, 'src', 'ext-browser', 'options', 'options.html'), 'utf8');
+  const page    = readFileSync(join(cwd, 'src', 'ext-browser', 'options', 'options.ts'), 'utf8');
+
+  it('the card and option the docs name actually exist on the page', () => {
+    expect(html).toContain('<title>Nexpath Settings</title>');
+    expect(html).toContain('<label>Feedback</label>');
+    expect(page).toContain("label: 'Never ask'");
+  });
+
+  it('⭐ the privacy policy tells the user the prompt can be turned off', () => {
+    // The README's Privacy section IS the store privacy-policy target
+    // (PUBLISH.md), so an undisclosed control is a listing problem, not a typo.
+    // Whitespace-normalised: markdown wraps the sentence, and the wrap point is
+    // not the contract.
+    expect(readme.replace(/\s+/g, ' ')).toContain('Settings → Feedback → "Never ask"');
+  });
+
+  it('the store data disclosure names the same control', () => {
+    expect(publish).toContain('Settings → Feedback →');
+    expect(publish).toContain('"Never ask"');
+  });
+
+  it('⭐ PUBLISH.md no longer claims the extension has no opt-out', () => {
+    // The exact stale sentence this switch invalidated.
+    expect(publish).not.toContain('and this one has none');
+  });
+
+  it('⭐ the README does not claim nothing is sent', () => {
+    // The other stale claim, kept pinned so it cannot come back.
+    expect(readme).not.toContain('No telemetry');
+    expect(readme).not.toContain('Nothing is sent to any Nexpath or third-party server');
+  });
 });

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -386,3 +386,54 @@ describe('the docs still describe this page accurately', () => {
     expect(readme).not.toContain('Nothing is sent to any Nexpath or third-party server');
   });
 });
+
+/**
+ * The store-disclosure event list, against the code that sends them.
+ *
+ * A list a reviewer reads is only worth having if it cannot drift, and this one
+ * has two ways to go wrong: an event ships that the table does not name, or the
+ * table names one that no longer exists. Both are checked.
+ */
+describe('the store disclosure lists exactly the events the code sends', () => {
+  const cwd = process.cwd();
+  const publish = readFileSync(join(cwd, 'src', 'ext-browser', 'PUBLISH.md'), 'utf8');
+  const sender = readFileSync(join(cwd, 'src', 'ext-browser', 'adapters', 'telemetry-send.ts'), 'utf8');
+  const buffer = readFileSync(join(cwd, 'src', 'ext-browser', 'adapters', 'lifecycle-signals.ts'), 'utf8');
+
+  /** Every event name the shipped code can put on the wire. */
+  const SENT = [
+    'nexpath_installed',
+    'feedback_submitted', 'feedback_dismissed',
+    'feedback_rating_bad', 'feedback_rating_fine', 'feedback_rating_good', 'feedback_rating_excellent',
+    'pe_use_current', 'pe_use_original', 'pe_apply_details', 'pe_close',
+    'mps_send', 'mps_cancel', 'mps_decline', 'mps_interruption', 'mps_apply_details',
+  ];
+
+  it('⭐ every event the code can send is named in the table', () => {
+    const flat = publish.replace(/\s+/g, ' ');
+    for (const name of SENT) {
+      // `_fine`-style shorthand counts: the table groups the four ratings.
+      const named = flat.includes(name) || flat.includes(name.replace('feedback_rating_', '_'));
+      expect(named, name).toBe(true);
+    }
+  });
+
+  it('⭐ and every name in the table still exists in the code', () => {
+    // The table names PROPERTIES too (`feedback_at`, `action_ts`); those are not
+    // events and are excluded rather than matched loosely.
+    const PROPERTIES = new Set(['feedback_at', 'installed_at', 'dismissed_at', 'action_ts']);
+    const inTable = [...publish.matchAll(/`(nexpath_[a-z_]+|feedback_[a-z_]+|pe_[a-z_]+|mps_[a-z_]+)`/g)]
+      .map((m) => m[1]!)
+      .filter((n) => !PROPERTIES.has(n));
+    expect(inTable.length).toBeGreaterThan(10);          // the table is actually there
+    const code = sender + buffer;
+    for (const name of new Set(inTable)) {
+      expect(code.includes(`'${name}'`), name).toBe(true);
+    }
+  });
+
+  it('the table says the sixteen are all of them', () => {
+    expect(publish).toContain('Sixteen, and no others');
+    expect(SENT).toHaveLength(16);
+  });
+});

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -369,6 +369,17 @@ describe('the docs still describe this page accurately', () => {
     expect(publish).not.toContain('and this one has none');
   });
 
+  it('⭐ the privacy policy discloses the dismissal send', () => {
+    // The dismissal is the ONE event that goes out without the rating click, so
+    // it is the one the policy must name. The README said "Dismissing the
+    // prompt sends nothing" until the event shipped — pinned so that sentence
+    // cannot come back while the send exists.
+    const flat = readme.replace(/\s+/g, ' ');
+    expect(flat).toContain('If you dismiss the prompt, one line goes out');
+    expect(flat).not.toContain('Dismissing the prompt sends nothing');
+    expect(publish.replace(/\s+/g, ' ')).toContain('Dismissing the prompt sends ONE line');
+  });
+
   it('⭐ the README does not claim nothing is sent', () => {
     // The other stale claim, kept pinned so it cannot come back.
     expect(readme).not.toContain('No telemetry');

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -19,6 +19,7 @@ function setupDom(): void {
     <p id="key-status"></p>
     <div id="frequency-group"></div>
     <div id="role-group"></div>
+    <div id="rating-group"></div>
     <div id="self-check"></div>
   `;
 }
@@ -44,6 +45,7 @@ function els() {
     selfCheck: document.getElementById('self-check') as HTMLDivElement,
     freqGroup: document.getElementById('frequency-group') as HTMLDivElement,
     roleGroup: document.getElementById('role-group') as HTMLDivElement,
+    ratingGroup: document.getElementById('rating-group') as HTMLDivElement,
   };
 }
 
@@ -257,4 +259,68 @@ describe('options.ts', () => {
       expect(els().status.textContent).toContain("Couldn't refresh settings");
     });
   });
+  /**
+   * The rating kill switch (Phase 6).
+   *
+   * Read `options.ts:31-35` before changing any of this: advisory frequency was
+   * taken off this page because it "advertised a control over a surface this
+   * extension no longer shows … so the setting read as broken". This control
+   * only belongs here while the service worker honours the value — the test for
+   * that half lives in `service-worker.test.ts`.
+   */
+  describe('feedback rating switch', () => {
+    it('renders exactly two options', async () => {
+      mockGet.mockResolvedValue({});
+      await loadOptionsModule();
+
+      const { ratingGroup } = els();
+      expect(ratingGroup.querySelectorAll('input[type="radio"]').length).toBe(2);
+      expect(radioFor(ratingGroup, 'on')).not.toBeNull();
+      expect(radioFor(ratingGroup, 'off')).not.toBeNull();
+    });
+
+    it('⭐ defaults to ON when nothing is stored — the popup ships enabled', async () => {
+      mockGet.mockResolvedValue({});
+      await loadOptionsModule();
+
+      expect(radioFor(els().ratingGroup, 'on').checked).toBe(true);
+    });
+
+    it('pre-selects OFF when the user has turned it off', async () => {
+      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'off' });
+      await loadOptionsModule();
+
+      expect(radioFor(els().ratingGroup, 'off').checked).toBe(true);
+    });
+
+    it('⭐ anything other than the exact string "off" reads as ON', async () => {
+      // Fail-open, and the worker's read agrees — a damaged value must not
+      // silently disable a feature the user never turned off.
+      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'nonsense' });
+      await loadOptionsModule();
+
+      expect(radioFor(els().ratingGroup, 'on').checked).toBe(true);
+    });
+
+    it('persists the choice to the key the worker reads', async () => {
+      mockGet.mockResolvedValue({});
+      await loadOptionsModule();
+
+      radioFor(els().ratingGroup, 'off').click();
+      await flush();
+
+      expect(mockSet).toHaveBeenCalledWith({ nexpath_rating_enabled: 'off' });
+    });
+
+    it('turning it back on persists that too', async () => {
+      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'off' });
+      await loadOptionsModule();
+
+      radioFor(els().ratingGroup, 'on').click();
+      await flush();
+
+      expect(mockSet).toHaveBeenCalledWith({ nexpath_rating_enabled: 'on' });
+    });
+  });
+
 });

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -21,7 +21,6 @@ function setupDom(): void {
     <p id="key-status"></p>
     <div id="frequency-group"></div>
     <div id="role-group"></div>
-    <div id="rating-group"></div>
     <div id="self-check"></div>
   `;
 }
@@ -47,7 +46,6 @@ function els() {
     selfCheck: document.getElementById('self-check') as HTMLDivElement,
     freqGroup: document.getElementById('frequency-group') as HTMLDivElement,
     roleGroup: document.getElementById('role-group') as HTMLDivElement,
-    ratingGroup: document.getElementById('rating-group') as HTMLDivElement,
   };
 }
 
@@ -261,70 +259,7 @@ describe('options.ts', () => {
       expect(els().status.textContent).toContain("Couldn't refresh settings");
     });
   });
-  /**
-   * The rating kill switch (Phase 6).
-   *
-   * Read `options.ts:31-35` before changing any of this: advisory frequency was
-   * taken off this page because it "advertised a control over a surface this
-   * extension no longer shows … so the setting read as broken". This control
-   * only belongs here while the service worker honours the value — the test for
-   * that half lives in `service-worker.test.ts`.
-   */
-  describe('feedback rating switch', () => {
-    it('renders exactly two options', async () => {
-      mockGet.mockResolvedValue({});
-      await loadOptionsModule();
-
-      const { ratingGroup } = els();
-      expect(ratingGroup.querySelectorAll('input[type="radio"]').length).toBe(2);
-      expect(radioFor(ratingGroup, 'on')).not.toBeNull();
-      expect(radioFor(ratingGroup, 'off')).not.toBeNull();
-    });
-
-    it('⭐ defaults to ON when nothing is stored — the popup ships enabled', async () => {
-      mockGet.mockResolvedValue({});
-      await loadOptionsModule();
-
-      expect(radioFor(els().ratingGroup, 'on').checked).toBe(true);
-    });
-
-    it('pre-selects OFF when the user has turned it off', async () => {
-      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'off' });
-      await loadOptionsModule();
-
-      expect(radioFor(els().ratingGroup, 'off').checked).toBe(true);
-    });
-
-    it('⭐ anything other than the exact string "off" reads as ON', async () => {
-      // Fail-open, and the worker's read agrees — a damaged value must not
-      // silently disable a feature the user never turned off.
-      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'nonsense' });
-      await loadOptionsModule();
-
-      expect(radioFor(els().ratingGroup, 'on').checked).toBe(true);
-    });
-
-    it('persists the choice to the key the worker reads', async () => {
-      mockGet.mockResolvedValue({});
-      await loadOptionsModule();
-
-      radioFor(els().ratingGroup, 'off').click();
-      await flush();
-
-      expect(mockSet).toHaveBeenCalledWith({ nexpath_rating_enabled: 'off' });
-    });
-
-    it('turning it back on persists that too', async () => {
-      mockGet.mockResolvedValue({ nexpath_rating_enabled: 'off' });
-      await loadOptionsModule();
-
-      radioFor(els().ratingGroup, 'on').click();
-      await flush();
-
-      expect(mockSet).toHaveBeenCalledWith({ nexpath_rating_enabled: 'on' });
-    });
-  });
-
+  
 });
 
 /**
@@ -345,26 +280,33 @@ describe('the docs still describe this page accurately', () => {
   const html    = readFileSync(join(cwd, 'src', 'ext-browser', 'options', 'options.html'), 'utf8');
   const page    = readFileSync(join(cwd, 'src', 'ext-browser', 'options', 'options.ts'), 'utf8');
 
-  it('the card and option the docs name actually exist on the page', () => {
-    expect(html).toContain('<title>Nexpath Settings</title>');
-    expect(html).toContain('<label>Feedback</label>');
-    expect(page).toContain("label: 'Never ask'");
+
+  it('⭐ neither document claims a control the extension does not have', () => {
+    // The toggle was removed on 2026-09-01 — the prompt is shown to every user.
+    // These two sentences were true for exactly one release, and a privacy
+    // policy that promises a switch nobody can find is the worst kind of stale.
+    for (const doc of [readme, publish]) {
+      const flat = doc.replace(/\s+/g, ' ');
+      expect(flat).not.toContain('Never ask');
+      expect(flat).not.toContain('Settings → Feedback →');
+      expect(flat).not.toContain('turn the prompt off');
+    }
   });
 
-  it('⭐ the privacy policy tells the user the prompt can be turned off', () => {
-    // The README's Privacy section IS the store privacy-policy target
-    // (PUBLISH.md), so an undisclosed control is a listing problem, not a typo.
-    // Whitespace-normalised: markdown wraps the sentence, and the wrap point is
-    // not the contract.
-    expect(readme.replace(/\s+/g, ' ')).toContain('Settings → Feedback → "Never ask"');
+  it('⭐ the page really has no feedback toggle to claim', () => {
+    // The other half: if the control ever comes back, the sentences above have
+    // to come back with it, and this fails until they do.
+    expect(page).not.toContain('nexpath_rating_enabled');
+    expect(html).not.toContain('rating-group');
+    const worker = readFileSync(join(cwd, 'src', 'ext-browser', 'background', 'service-worker.ts'), 'utf8');
+    expect(worker).not.toContain('nexpath_rating_enabled');
   });
 
-  it('the store data disclosure names the same control', () => {
-    expect(publish).toContain('Settings → Feedback →');
-    expect(publish).toContain('"Never ask"');
+  it('⭐ the store disclosure says plainly that there is no opt-out', () => {
+    expect(publish.replace(/\s+/g, ' ')).toContain('There is NO per-user opt-out');
   });
 
-  it('⭐ PUBLISH.md no longer claims the extension has no opt-out', () => {
+  it('PUBLISH.md no longer claims the extension has no opt-out for the OLD reason', () => {
     // The exact stale sentence this switch invalidated.
     expect(publish).not.toContain('and this one has none');
   });

--- a/src/ext-browser/options/options.ts
+++ b/src/ext-browser/options/options.ts
@@ -4,12 +4,30 @@ const KEY_NAME = 'openai_api_key';
 const MODELS_URL = 'https://api.openai.com/v1/models';
 const ROLE_KEY = 'role';
 
+/**
+ * Kill switch for the rating popup.
+ *
+ * A `nexpath_*` key because it is browser-only state: the CLI has no setting
+ * that gates its feedback popup either — `telemetry.enabled` exists there, and
+ * the feedback send deliberately bypasses it ("this explicit action is the
+ * consent", `stop.ts:526`). Folding this into `advisory_frequency` was rejected
+ * for the same reason that key is not bypassed for PE: two unrelated surfaces.
+ *
+ * ⚠️ READ `options.ts:31-35` BEFORE TOUCHING THIS. Advisory frequency was taken
+ * off this page because it "advertised a control over a surface this extension
+ * no longer shows … so the setting read as broken". This toggle only earns its
+ * place because the rating popup is live and the service worker HONOURS the
+ * value — if either stops being true, the control has to come off the page.
+ */
+const RATING_KEY = 'nexpath_rating_enabled';
+
 const input    = document.getElementById('api-key')      as HTMLInputElement;
 const saveBtn  = document.getElementById('save-key')     as HTMLButtonElement;
 const testBtn  = document.getElementById('test-key')     as HTMLButtonElement;
 const keyStatus = document.getElementById('key-status')  as HTMLParagraphElement;
 const checkEl  = document.getElementById('self-check')   as HTMLDivElement;
 const roleGroup = document.getElementById('role-group')      as HTMLDivElement;
+const ratingGroup = document.getElementById('rating-group')  as HTMLDivElement;
 const versionEl = document.getElementById('ext-version')     as HTMLSpanElement | null;
 
 // The footer version is read from the manifest, never written into the markup.
@@ -42,6 +60,17 @@ const ROLE_OPTIONS = [
   { value: 'pm',           label: 'product manager' },
 ] as const;
 const DEFAULT_ROLE = 'founder';
+
+/**
+ * On unless the stored value is exactly 'off'. A missing or damaged value keeps
+ * the popup — the same fail-open direction the worker's read uses, so the two
+ * cannot disagree about what an unreadable setting means.
+ */
+const RATING_OPTIONS = [
+  { value: 'on',  label: 'Ask me occasionally' },
+  { value: 'off', label: 'Never ask' },
+] as const;
+const DEFAULT_RATING = 'on';
 
 function buildRadioGroup(
   container: HTMLDivElement,
@@ -87,6 +116,7 @@ async function loadKey(): Promise<void> {
     setKeyStatus('Key saved — click Test to validate', '');
   }
   await loadRole();
+  await loadRating();
   await renderSelfCheck();
 }
 
@@ -99,6 +129,17 @@ async function loadRole(): Promise<void> {
   buildRadioGroup(roleGroup, 'role', ROLE_OPTIONS, role, async (value) => {
     await browser.storage.local.set({ [ROLE_KEY]: value });
     await renderSelfCheck();
+  });
+}
+
+// ── Rating popup switch ───────────────────────────────────────────────────────
+
+async function loadRating(): Promise<void> {
+  const result = await browser.storage.local.get([RATING_KEY]);
+  const current = result[RATING_KEY] === 'off' ? 'off' : DEFAULT_RATING;
+
+  buildRadioGroup(ratingGroup, 'rating', RATING_OPTIONS, current, async (value) => {
+    await browser.storage.local.set({ [RATING_KEY]: value });
   });
 }
 

--- a/src/ext-browser/options/options.ts
+++ b/src/ext-browser/options/options.ts
@@ -4,30 +4,12 @@ const KEY_NAME = 'openai_api_key';
 const MODELS_URL = 'https://api.openai.com/v1/models';
 const ROLE_KEY = 'role';
 
-/**
- * Kill switch for the rating popup.
- *
- * A `nexpath_*` key because it is browser-only state: the CLI has no setting
- * that gates its feedback popup either — `telemetry.enabled` exists there, and
- * the feedback send deliberately bypasses it ("this explicit action is the
- * consent", `stop.ts:526`). Folding this into `advisory_frequency` was rejected
- * for the same reason that key is not bypassed for PE: two unrelated surfaces.
- *
- * ⚠️ READ `options.ts:31-35` BEFORE TOUCHING THIS. Advisory frequency was taken
- * off this page because it "advertised a control over a surface this extension
- * no longer shows … so the setting read as broken". This toggle only earns its
- * place because the rating popup is live and the service worker HONOURS the
- * value — if either stops being true, the control has to come off the page.
- */
-const RATING_KEY = 'nexpath_rating_enabled';
-
 const input    = document.getElementById('api-key')      as HTMLInputElement;
 const saveBtn  = document.getElementById('save-key')     as HTMLButtonElement;
 const testBtn  = document.getElementById('test-key')     as HTMLButtonElement;
 const keyStatus = document.getElementById('key-status')  as HTMLParagraphElement;
 const checkEl  = document.getElementById('self-check')   as HTMLDivElement;
 const roleGroup = document.getElementById('role-group')      as HTMLDivElement;
-const ratingGroup = document.getElementById('rating-group')  as HTMLDivElement;
 const versionEl = document.getElementById('ext-version')     as HTMLSpanElement | null;
 
 // The footer version is read from the manifest, never written into the markup.
@@ -60,17 +42,6 @@ const ROLE_OPTIONS = [
   { value: 'pm',           label: 'product manager' },
 ] as const;
 const DEFAULT_ROLE = 'founder';
-
-/**
- * On unless the stored value is exactly 'off'. A missing or damaged value keeps
- * the popup — the same fail-open direction the worker's read uses, so the two
- * cannot disagree about what an unreadable setting means.
- */
-const RATING_OPTIONS = [
-  { value: 'on',  label: 'Ask me occasionally' },
-  { value: 'off', label: 'Never ask' },
-] as const;
-const DEFAULT_RATING = 'on';
 
 function buildRadioGroup(
   container: HTMLDivElement,
@@ -116,7 +87,6 @@ async function loadKey(): Promise<void> {
     setKeyStatus('Key saved — click Test to validate', '');
   }
   await loadRole();
-  await loadRating();
   await renderSelfCheck();
 }
 
@@ -129,17 +99,6 @@ async function loadRole(): Promise<void> {
   buildRadioGroup(roleGroup, 'role', ROLE_OPTIONS, role, async (value) => {
     await browser.storage.local.set({ [ROLE_KEY]: value });
     await renderSelfCheck();
-  });
-}
-
-// ── Rating popup switch ───────────────────────────────────────────────────────
-
-async function loadRating(): Promise<void> {
-  const result = await browser.storage.local.get([RATING_KEY]);
-  const current = result[RATING_KEY] === 'off' ? 'off' : DEFAULT_RATING;
-
-  buildRadioGroup(ratingGroup, 'rating', RATING_OPTIONS, current, async (value) => {
-    await browser.storage.local.set({ [RATING_KEY]: value });
   });
 }
 

--- a/src/ext-browser/rating-flow.e2e.test.ts
+++ b/src/ext-browser/rating-flow.e2e.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+/**
+ * The rating popup, end to end — every layer this feature crosses, wired to the
+ * real thing.
+ *
+ * Every other test in this feature is per-LAYER: the cadence knows nothing about
+ * the surface, the surface nothing about the sender. That leaves the seams
+ * untested, and a seam is where this kind of feature dies — a view whose
+ * `viewSeq` the mailbox drops, a command the dock never emits, a flush that runs
+ * after the send instead of before. All of those pass a layer test and produce a
+ * popup that does nothing.
+ *
+ * So this file mocks NOTHING of its own code. It uses the real cadence, the real
+ * signal buffer, the real popup host and mailbox, the real dock adapter, the real
+ * surface controller and view (rendered into jsdom), and the real sender. Only
+ * two things are stand-ins, and both are things the browser itself provides:
+ * `storage.local` (a Map) and `fetch` (a recorder).
+ *
+ * The chain each test drives:
+ *
+ *   cadence eligible ─▶ runBrowserRatingPopup ─▶ show-rating ─▶ dock adapter
+ *        ▲                                                          │
+ *        │                                                    real DOM click
+ *   markFeedbackShown ◀─ sendRating ◀─ flushLifecycle ◀─ deliverPePanelCommand
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { recordActivity, isFeedbackEligible, markFeedbackShown } from './adapters/rating-cadence.js';
+import { recordSignal, readSignals } from './adapters/lifecycle-signals.js';
+import { _resetIdentityInFlight } from './adapters/rating-identity.js';
+import { runBrowserRatingPopup, deliverPePanelCommand, isPePopupOpen } from './background/pe-popup-host.js';
+import { mountNexpathPeDock } from './ui/pe-dock-adapter.js';
+import type { PePanelControllerV1, PePanelEventV1, PeRatingViewV1 } from './ui/pe-contract.js';
+import type { LogPort } from '../core/ports/log.port.js';
+
+const ROOT = 'https://bolt.new/~/project';
+const T0 = 1_700_000_000_000;
+
+const log: LogPort = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as LogPort;
+
+/** The extension's storage.local, as the adapters actually use it. */
+function store() {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getKey: async (n: string) => data.get(n) ?? null,
+    setKey: async (n: string, v: string) => { data.set(n, v); },
+  };
+}
+
+/** Records every envelope that would reach PostHog, in order. */
+function wire(ok = true) {
+  const posts: Record<string, unknown>[] = [];
+  const fetch = (async (_url: string, init: { body: string }) => {
+    posts.push(JSON.parse(init.body) as Record<string, unknown>);
+    return { ok, status: ok ? 200 : 500 };
+  }) as never;
+  return { fetch, posts, events: () => posts.map((p) => p['event'] as string) };
+}
+
+/**
+ * The content script's job, done for real: take the worker's `show-rating`, mount
+ * the dock, render the view through it, and post the panel's commands back into
+ * the worker's mailbox.
+ */
+/**
+ * Mounted docks, torn down after each test.
+ *
+ * `dock.ts:366` keeps `current` at MODULE level (the D1.5 re-attach guard), so a
+ * second `mountNexpathDock` hands back the first — detached, with no new shadow
+ * root — and every later test sees an empty page. Destroying releases it.
+ */
+let liveAdapters: PePanelControllerV1[] = [];
+
+function mountFor(root: string): PePanelControllerV1 {
+  const a = mountNexpathPeDock({
+    onEvent: (e: PePanelEventV1) => {
+      if (e.type === 'command') deliverPePanelCommand(log, root, e.viewSeq, e.command);
+    },
+  });
+  liveAdapters.push(a);
+  return a;
+}
+
+function contentScript(root: string = ROOT): { sendToTab: (m: unknown) => Promise<unknown>; adapter: () => PePanelControllerV1 | null } {
+  let adapter: PePanelControllerV1 | null = null;
+  const sendToTab = async (msg: unknown): Promise<unknown> => {
+    const m = msg as { type?: string; payload?: PeRatingViewV1 };
+    if (m.type === 'nexpath:show-rating' && m.payload) {
+      adapter ??= mountFor(root);
+      adapter.show(m.payload);
+    }
+    if (m.type === 'nexpath:pe-close') adapter?.hide();
+    return { ok: true };
+  };
+  return { sendToTab, adapter: () => adapter };
+}
+
+/** The surface DOM, reached the way the dock exposes it. */
+let shadowRoots: ShadowRoot[];
+const realAttachShadow = HTMLElement.prototype.attachShadow;
+
+function surfaceEl(): HTMLElement {
+  return shadowRoots.at(-1)!.querySelector('.np-surface-root') as HTMLElement;
+}
+function rowByLabel(label: string): HTMLElement {
+  const hit = [...surfaceEl().querySelectorAll('.np-row')].find((r) => r.textContent?.includes(label));
+  if (!hit) throw new Error(`no row containing "${label}"`);
+  return hit as HTMLElement;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  shadowRoots = [];
+  HTMLElement.prototype.attachShadow = function (init: ShadowRootInit): ShadowRoot {
+    const root = realAttachShadow.call(this, init);
+    shadowRoots.push(root);
+    return root;
+  };
+  _resetIdentityInFlight();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const a of liveAdapters.splice(0)) { try { a.destroy(); } catch { /* already gone */ } }
+  HTMLElement.prototype.attachShadow = realAttachShadow;
+});
+
+describe('rating popup — end to end', () => {
+  it('⭐ two hours of use, a rating clicked, and the whole chain reports', async () => {
+    const s = store();
+    const w = wire();
+
+    // 1. The worker feeds cadence on each submit, as service-worker.ts does.
+    //    Fifteen minutes at a time, because a longer gap is an idle break.
+    for (let i = 0; i <= 8; i++) await recordActivity(s, T0 + i * 15 * 60_000);
+    const at = T0 + 8 * 15 * 60_000;
+    expect(await isFeedbackEligible(s, at)).toBe(true);   // the gate would open
+
+    // 2. The user did things in the PE popup along the way; those buffered.
+    await recordSignal(s, 'pe_shorter', at - 60_000);
+    await recordSignal(s, 'pe_apply_details', at - 30_000);
+
+    // 3. The stop handler opens the rating. The content script renders it for real.
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => at,
+    });
+
+    // 4. It is on screen — the real surface, in the real dock.
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+    const text = surfaceEl().textContent ?? '';
+    expect(text).toContain("How's nexpath working out for you?");
+    expect(text).toContain('no prompt text');
+    for (const l of ['Bad', 'Fine', 'Good', 'Excellent']) expect(text).toContain(l);
+
+    // 5. The user clicks Good.
+    rowByLabel('Good').click();
+    const outcome = await run;
+
+    expect(outcome).toEqual({ state: 'rated', rating: 3 });
+
+    // 6. EVERY event, in the order the wire saw them. The buffer is released
+    //    first — a numerator must not arrive before its denominator.
+    expect(w.events()).toEqual([
+      'nexpath_installed',
+      'pe_shorter',
+      'pe_apply_details',
+      'feedback_submitted',
+    ]);
+
+    const rating = w.posts.at(-1)!;
+    expect(rating['event']).toBe('feedback_submitted');
+    const props = rating['properties'] as Record<string, unknown>;
+    expect(props['rating']).toBe(3);
+    expect(props['surface']).toBe('browser');
+    expect(props['$lib']).toBe('nexpath');
+
+    // 7. One installation id across every envelope, and nothing else identifying.
+    const ids = new Set(w.posts.map((p) => p['distinct_id']));
+    expect(ids.size).toBe(1);
+
+    // 8. The buffer is drained and the cadence reset — no second ask this window.
+    expect(await readSignals(s)).toEqual([]);
+    expect(await isFeedbackEligible(s, at)).toBe(false);
+    expect(isPePopupOpen(ROOT)).toBe(false);           // mailbox released
+  });
+
+  it('⭐ nothing a user typed can reach the wire', async () => {
+    const s = store();
+    const w = wire();
+    await recordSignal(s, 'pe_close', T0);
+
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0,
+    });
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+    rowByLabel('Excellent').click();
+    await run;
+
+    const body = JSON.stringify(w.posts);
+    for (const secret of [ROOT, 'bolt.new', 'project', 'How\'s nexpath']) {
+      expect(body).not.toContain(secret);
+    }
+    // Only these property names ever appear.
+    const ALLOWED = new Set(['$lib', '$lib_version', 'surface', 'installation_id',
+      'rating', 'feedback_at', 'installed_at', 'action_ts']);
+    for (const p of w.posts) {
+      for (const k of Object.keys(p['properties'] as Record<string, unknown>)) {
+        expect(ALLOWED.has(k)).toBe(true);
+      }
+    }
+  });
+
+  it('⭐ Escape sends nothing and keeps the buffer for a later consent', async () => {
+    const s = store();
+    const w = wire();
+    await recordSignal(s, 'mps_send', T0);
+
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0,
+    });
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+
+    surfaceEl().dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape', bubbles: true, composed: true, cancelable: true,
+    }));
+
+    expect(await run).toEqual({ state: 'dismissed' });
+    expect(w.posts).toEqual([]);                       // not one request
+    expect(await readSignals(s)).toHaveLength(1);      // still there for next time
+    expect(s.data.get('feedback_last_shown_at')).toBe(String(T0));  // but asked
+  });
+
+  it('a failed network leaves the buffer intact and still marks the popup shown', async () => {
+    const s = store();
+    const w = wire(false);                             // every POST fails
+    await recordSignal(s, 'pe_use_original', T0);
+
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0,
+    });
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+    rowByLabel('Bad').click();
+
+    expect(await run).toEqual({ state: 'rated', rating: 1 });
+    expect(await readSignals(s)).toHaveLength(1);      // nothing pruned on failure
+    expect(s.data.get('feedback_last_shown_at')).toBe(String(T0));  // not re-asked
+  });
+
+  it.each(['https://bolt.new/~/p', 'https://replit.com/@u/p', 'https://lovable.dev/projects/p'])(
+    'runs the same on %s — the flow is site-agnostic',
+    async (root) => {
+      const s = store();
+      const w = wire();
+      const cs = contentScript(root);
+
+      const run = runBrowserRatingPopup({
+        log, projectRoot: root, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0,
+      });
+      await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+      rowByLabel('Fine').click();
+
+      expect(await run).toEqual({ state: 'rated', rating: 2 });
+      expect(w.events()).toContain('feedback_submitted');
+      expect(isPePopupOpen(root)).toBe(false);
+    },
+  );
+});

--- a/src/ext-browser/rating-flow.e2e.test.ts
+++ b/src/ext-browser/rating-flow.e2e.test.ts
@@ -167,10 +167,14 @@ describe('rating popup — end to end', () => {
       'pe_shorter',
       'pe_apply_details',
       'feedback_submitted',
+      'feedback_rating_good',      // the same answer under its own name (r16)
     ]);
 
-    const rating = w.posts.at(-1)!;
-    expect(rating['event']).toBe('feedback_submitted');
+    // The two rating envelopes carry the SAME payload — either can answer the
+    // same question; only the event name differs.
+    const rating = w.posts.find((p) => p['event'] === 'feedback_submitted')!;
+    const named  = w.posts.find((p) => p['event'] === 'feedback_rating_good')!;
+    expect(named['properties']).toEqual(rating['properties']);
     const props = rating['properties'] as Record<string, unknown>;
     expect(props['rating']).toBe(3);
     expect(props['surface']).toBe('browser');
@@ -316,6 +320,7 @@ describe('the whole event inventory', () => {
       'nexpath_installed',
       ...LIVE_ACTIONS,
       'feedback_submitted',
+      'feedback_rating_excellent',
     ]);
 
     // ── 2. Each carries what it should, and nothing more ───────────────────

--- a/src/ext-browser/rating-flow.e2e.test.ts
+++ b/src/ext-browser/rating-flow.e2e.test.ts
@@ -229,7 +229,9 @@ describe('rating popup — end to end', () => {
     }));
 
     expect(await run).toEqual({ state: 'dismissed' });
-    expect(w.posts).toEqual([]);                       // not one request
+    // One envelope, and it is the dismissal — the buffered mps_send is NOT
+    // released, because only the rating click consents to that.
+    expect(w.events()).toEqual(['feedback_dismissed']);
     expect(await readSignals(s)).toHaveLength(1);      // still there for next time
     expect(s.data.get('feedback_last_shown_at')).toBe(String(T0));  // but asked
   });

--- a/src/ext-browser/rating-flow.e2e.test.ts
+++ b/src/ext-browser/rating-flow.e2e.test.ts
@@ -270,3 +270,124 @@ describe('rating popup — end to end', () => {
     },
   );
 });
+
+/**
+ * Every event this extension can emit, driven through the real chain in one run.
+ *
+ * The suite above proves the SEAMS hold; this proves the INVENTORY is complete —
+ * that each of the eleven live events reaches the wire with the right name and
+ * the right shape, and that the six that exist in code but are unreachable stay
+ * unreachable.
+ */
+describe('the whole event inventory', () => {
+  /** The nine action kinds a browser user can actually produce. */
+  const LIVE_ACTIONS = [
+    'pe_use_current', 'pe_use_original', 'pe_apply_details', 'pe_close',
+    'mps_send', 'mps_cancel', 'mps_decline', 'mps_interruption', 'mps_apply_details',
+  ] as const;
+
+  /** In the code, but no browser UI can reach them — see the commit for why. */
+  const UNREACHABLE = [
+    'pe_shorter', 'pe_more_thorough', 'pe_more_project_grounded', 'pe_back',
+    'advisory_fired', 'option_selected',
+  ] as const;
+
+  it('⭐ all eleven live events reach the wire, each with the right shape', async () => {
+    const s = store();
+    const w = wire();
+
+    // Nine actions, buffered by the real buffer exactly as the popup host does.
+    for (const [i, kind] of LIVE_ACTIONS.entries()) {
+      await recordSignal(s, kind, T0 - 10_000 + i);
+    }
+
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0,
+    });
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+    rowByLabel('Excellent').click();
+    expect(await run).toEqual({ state: 'rated', rating: 4 });
+
+    // ── 1. Every one of the eleven, in the order the wire saw them ──────────
+    expect(w.events()).toEqual([
+      'nexpath_installed',
+      ...LIVE_ACTIONS,
+      'feedback_submitted',
+    ]);
+
+    // ── 2. Each carries what it should, and nothing more ───────────────────
+    const byEvent = new Map(w.posts.map((p) => [p['event'] as string, p]));
+    const props = (name: string) => byEvent.get(name)!['properties'] as Record<string, unknown>;
+    const COMMON = ['$lib', '$lib_version', 'installation_id', 'surface'];
+
+    expect(Object.keys(props('nexpath_installed')).sort())
+      .toEqual([...COMMON, 'installed_at'].sort());
+
+    expect(Object.keys(props('feedback_submitted')).sort())
+      .toEqual([...COMMON, 'feedback_at', 'rating'].sort());
+    expect(props('feedback_submitted')['rating']).toBe(4);
+
+    for (const kind of LIVE_ACTIONS) {
+      expect(Object.keys(props(kind)).sort(), kind)
+        .toEqual([...COMMON, 'action_ts'].sort());
+      expect(props(kind)['surface'], kind).toBe('browser');
+      expect(props(kind)['$lib'], kind).toBe('nexpath');
+    }
+
+    // ── 3. Backdated, not stamped at flush time ────────────────────────────
+    for (const [i, kind] of LIVE_ACTIONS.entries()) {
+      expect(props(kind)['action_ts'], kind).toBe(T0 - 10_000 + i);
+      expect(byEvent.get(kind)!['timestamp'], kind)
+        .toBe(new Date(T0 - 10_000 + i).toISOString());
+    }
+
+    // ── 4. Nothing unreachable slipped in ──────────────────────────────────
+    for (const kind of UNREACHABLE) expect(w.events(), kind).not.toContain(kind);
+
+    // ── 5. One identity, and the buffer is empty afterwards ────────────────
+    expect(new Set(w.posts.map((p) => p['distinct_id'])).size).toBe(1);
+    expect(await readSignals(s)).toEqual([]);
+  });
+
+  it('⭐ the install event fires ONCE, however many ratings follow', async () => {
+    const s = store();
+
+    for (const round of [1, 2, 3]) {
+      const w = wire();
+      await recordSignal(s, 'pe_close', T0 + round);
+      // A fresh window each time: cadence is reset by the previous rating.
+      await markFeedbackShown(s, T0 - 10 * 24 * 60 * 60_000);
+      const cs = contentScript();
+      const run = runBrowserRatingPopup({
+        log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: w.fetch, now: () => T0 + round,
+      });
+      await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+      rowByLabel('Fine').click();
+      await run;
+
+      const installs = w.events().filter((e) => e === 'nexpath_installed').length;
+      expect(installs, `round ${round}`).toBe(round === 1 ? 1 : 0);
+      expect(w.events()).toContain('feedback_submitted');
+      for (const a of liveAdapters.splice(0)) a.destroy();
+    }
+  });
+
+  it('a signal recorded while the popup is open still goes out on the NEXT rating', async () => {
+    const s = store();
+    const first = wire();
+    const cs = contentScript();
+    const run = runBrowserRatingPopup({
+      log, projectRoot: ROOT, store: s, sendToTab: cs.sendToTab, fetch: first.fetch, now: () => T0,
+    });
+    await vi.waitFor(() => expect(surfaceEl()).toBeTruthy());
+    await recordSignal(s, 'mps_decline', T0);          // arrives mid-popup
+    rowByLabel('Bad').click();
+    await run;
+
+    // It may or may not have made this flush — but it must not be LOST.
+    const sentNow = first.events().includes('mps_decline');
+    const stillBuffered = (await readSignals(s)).some((x) => x.kind === 'mps_decline');
+    expect(sentNow || stillBuffered).toBe(true);
+  });
+});

--- a/src/ext-browser/ui/pe-contract.test.ts
+++ b/src/ext-browser/ui/pe-contract.test.ts
@@ -24,6 +24,8 @@ describe('isPePanelCommandV1 — accepts exactly the command union', () => {
     ['mps_send', { type: 'mps_send', bodyText: 'b' }],
     ['mps_decline', { type: 'mps_decline' }],
     ['mps_cancel', { type: 'mps_cancel' }],
+    ['rating 1', { type: 'rating', rating: 1 }],
+    ['rating 4', { type: 'rating', rating: 4 }],
   ];
   for (const [name, value] of VALID) {
     it(`accepts ${name}`, () => { expect(isPePanelCommandV1(value)).toBe(true); });
@@ -43,6 +45,24 @@ describe('isPePanelCommandV1 — accepts exactly the command union', () => {
     ['feedback with free text as category', { type: 'feedback_suggested', category: 'the body was wrong about auth' }],
     ['type as non-string', { type: 3 }],
   ];
+  // The rating is the ONLY user-influenced number that reaches the analytics
+  // envelope, so its bounds are checked here, at the trust boundary, and not
+  // left to the sender.
+  const INVALID_RATINGS: ReadonlyArray<[string, unknown]> = [
+    ['rating missing',      { type: 'rating' }],
+    ['rating 0',            { type: 'rating', rating: 0 }],
+    ['rating 5',            { type: 'rating', rating: 5 }],
+    ['rating -1',           { type: 'rating', rating: -1 }],
+    ['rating 1.5',          { type: 'rating', rating: 1.5 }],
+    ['rating NaN',          { type: 'rating', rating: Number.NaN }],
+    ['rating Infinity',     { type: 'rating', rating: Number.POSITIVE_INFINITY }],
+    ['rating as a string',  { type: 'rating', rating: '3' }],
+    ['rating as null',      { type: 'rating', rating: null }],
+  ];
+  for (const [name, value] of INVALID_RATINGS) {
+    it(`refuses ${name}`, () => { expect(isPePanelCommandV1(value)).toBe(false); });
+  }
+
   for (const [name, value] of INVALID) {
     it(`refuses ${name}`, () => { expect(isPePanelCommandV1(value)).toBe(false); });
   }

--- a/src/ext-browser/ui/pe-contract.ts
+++ b/src/ext-browser/ui/pe-contract.ts
@@ -97,7 +97,29 @@ export interface PeSequenceOfferViewV1 {
   cancelLabel: string;
 }
 
-export type PePanelAnyViewV1 = PePanelViewV1 | PeSequenceOfferViewV1;
+/**
+ * The advisory rating surface's view.
+ *
+ * Almost empty on purpose: the surface is wholly static (its question, note,
+ * four scores and footer are constants in `ui/surfaces/fixtures/rating.ts`), so
+ * the only thing the worker has to pass is the sequence number a command echoes
+ * back. There is no body, no title and no engine state — which is also why
+ * `pefSurfaceModel`'s producer took no arguments and this one takes none either.
+ */
+export interface PeRatingViewV1 {
+  schemaVersion: typeof PE_PANEL_SCHEMA_VERSION;
+  kind: 'rating';
+  viewSeq: number;
+}
+
+/**
+ * ⚠️ `'kind' in v` is NOT a test for "is this the sequence offer" any more.
+ * Two views now carry a `kind`, so every discriminant must name the one it
+ * means — `v.kind === 'sequence_offer'`. `pe-dock-adapter.ts` used the loose
+ * form in four places; the two that decide behaviour were made explicit when
+ * this type was added (the ✕ button's command, and the surface registry).
+ */
+export type PePanelAnyViewV1 = PePanelViewV1 | PeSequenceOfferViewV1 | PeRatingViewV1;
 
 export type PePanelCommandV1 =
   | { type: 'use_current'; bodyText: string }
@@ -121,7 +143,15 @@ export type PePanelCommandV1 =
   // MPS-1 offer outcomes (valid only while a sequence-offer view is live).
   | { type: 'mps_send'; bodyText: string }
   | { type: 'mps_decline' }
-  | { type: 'mps_cancel' };
+  | { type: 'mps_cancel' }
+  /**
+   * The advisory rating surface's answer: the 1-4 score the user picked
+   * (`decision-session/feedback-popup.ts:38-43`, 1 = Bad … 4 = Excellent).
+   *
+   * There is no matching "skipped" command. Esc and the dock's ✕ both mean no
+   * rating, and both already have one: `close`.
+   */
+  | { type: 'rating'; rating: number };
 
 /** Panel → host events (same driving pattern as the advisory panel's onEvent). */
 export type PePanelEventV1 =
@@ -151,7 +181,12 @@ const COMMAND_TYPES = new Set([
   'more_thorough', 'more_project_grounded', 'go_back', 'close',
   'edit_body', 'feedback_suggested', 'feedback_other',
   'mps_send', 'mps_decline', 'mps_cancel',
+  'rating',
 ]);
+
+/** The CLI's scale is 1..4 and nothing else — `feedback-popup.ts:38-43`. */
+const RATING_MIN = 1;
+const RATING_MAX = 4;
 const TEXT_FREE_COMMANDS = new Set(['use_original', 'go_back', 'close', 'mps_decline', 'mps_cancel']);
 const FEEDBACK_CATEGORIES = new Set(['not_relevant_enough', 'too_much_or_too_long']);
 /** The CLI's Other-feedback bound (`cli-submit-popup.ts:136`, enforced :1165). */
@@ -164,6 +199,13 @@ export function isPePanelCommandV1(value: unknown): value is PePanelCommandV1 {
   if (TEXT_FREE_COMMANDS.has(v['type'])) return true;
   if (v['type'] === 'feedback_suggested') {
     return typeof v['category'] === 'string' && FEEDBACK_CATEGORIES.has(v['category']);
+  }
+  if (v['type'] === 'rating') {
+    // Bounded here, at the trust boundary, because this number is the ONLY
+    // user-influenced value that reaches the analytics envelope. A page that
+    // forged a command must not be able to post rating 0, 99 or 1.5.
+    const r = v['rating'];
+    return typeof r === 'number' && Number.isInteger(r) && r >= RATING_MIN && r <= RATING_MAX;
   }
   if (v['type'] === 'feedback_other') {
     return typeof v['text'] === 'string'

--- a/src/ext-browser/ui/pe-dock-adapter.test.ts
+++ b/src/ext-browser/ui/pe-dock-adapter.test.ts
@@ -9,7 +9,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mountNexpathPeDock, mpsSurfaceModel, peSurfaceModel, pefSurfaceModel } from './pe-dock-adapter.js';
 import { NEXPATH_DOCK_HOST_ID } from './surfaces/dock.js';
-import type { PePanelControllerV1, PePanelEventV1, PeSequenceOfferViewV1, PePanelViewV1 } from './pe-contract.js';
+import type { PePanelControllerV1, PePanelEventV1, PeSequenceOfferViewV1, PePanelViewV1, PeRatingViewV1 } from './pe-contract.js';
 
 let events: PePanelEventV1[];
 let adapter: PePanelControllerV1;
@@ -605,5 +605,92 @@ describe('locked bodies explain themselves (tester read a silent read-only popup
     body.focus();
     const text = surfaceEl().textContent ?? '';
     expect(text).not.toContain('Read-only');
+  });
+});
+
+// ── the advisory rating surface (Phase 4) ────────────────────────────────────
+
+function ratingView(overrides: Partial<PeRatingViewV1> = {}): PeRatingViewV1 {
+  return { schemaVersion: 1, kind: 'rating', viewSeq: 1, ...overrides };
+}
+
+describe('advisory rating (real dock + controller)', () => {
+  it('show() renders the note and exactly the four scores, worst to best', () => {
+    adapter.show(ratingView());
+
+    expect(document.getElementById(NEXPATH_DOCK_HOST_ID)).toBeTruthy();
+    const text = surfaceEl().textContent ?? '';
+    expect(text).toContain("How's nexpath working out for you?");
+    expect(text).toContain('no prompt text');                 // the transparency note
+    for (const label of ['Bad', 'Fine', 'Good', 'Excellent']) expect(text).toContain(label);
+    expect(surfaceEl().querySelector('textarea')).toBeNull(); // never a text box
+  });
+
+  it('⭐ clicking Good sends {type:"rating", rating:3}', () => {
+    adapter.show(ratingView());
+
+    rowByLabel('Good').click();
+
+    expect(commands()).toEqual([{ type: 'rating', rating: 3 }]);
+  });
+
+  it.each([['Bad', 1], ['Fine', 2], ['Good', 3], ['Excellent', 4]] as const)(
+    'Enter on %s sends rating %i',
+    (label, rating) => {
+      adapter.show(ratingView());
+      rowByLabel(label).click();
+      expect(commands()).toEqual([{ type: 'rating', rating }]);
+    },
+  );
+
+  it('⭐ Escape skips — one `close`, and no rating', () => {
+    adapter.show(ratingView());
+
+    pressOn(surfaceEl(), 'Escape');
+
+    expect(commands()).toEqual([{ type: 'close' }]);
+  });
+
+  it('the command echoes the view it came from', () => {
+    adapter.show(ratingView({ viewSeq: 7 }));
+
+    rowByLabel('Excellent').click();
+
+    expect(events).toEqual([{ type: 'command', viewSeq: 7, command: { type: 'rating', rating: 4 } }]);
+  });
+
+  it('⭐ the dock ✕ on a rating sends `close`, NOT `mps_decline`', () => {
+    // The rating view carries a `kind`, and the ✕ handler used to branch on
+    // `'kind' in view` — which would have sent a SEQUENCE DECLINE for a rating.
+    // Both commands typecheck, so nothing but this test catches it. The comment
+    // on that handler explains what a wrong close costs: one wedged mailbox and
+    // no popups again for that project until the worker restarts.
+    adapter.show(ratingView());
+    const root = shadowRoots.find((r) => r.querySelector('button'));
+    const closeBtn = [...(root?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent?.includes('✕') || b.getAttribute('aria-label')?.toLowerCase().includes('close'));
+
+    closeBtn!.click();
+
+    expect(commands()).toEqual([{ type: 'close' }]);
+  });
+
+  it('the rating registry holds ONE surface — no feedback form to fall into', () => {
+    adapter.show(ratingView());
+
+    pressOn(surfaceEl(), 'Escape');
+
+    // PEF's rows must never appear: a rating has nowhere to transition to.
+    expect(surfaceEl().textContent ?? '').not.toContain('Not relevant enough');
+  });
+
+  it('a PE view after a rating still behaves like PE — the third branch changed nothing', () => {
+    adapter.show(ratingView());
+    adapter.show(view());
+
+    pressOn(surfaceEl(), 'Escape');
+
+    expect(commands()).toEqual([{ type: 'close' }]);
+    expect(bodyField()).toBeTruthy();          // the PE body is back
   });
 });

--- a/src/ext-browser/ui/pe-dock-adapter.ts
+++ b/src/ext-browser/ui/pe-dock-adapter.ts
@@ -306,6 +306,21 @@ export function mountNexpathPeDock(opts: PeDockAdapterOptions): PePanelControlle
   ): { model: SurfaceModel } | 'refuse' | null => {
     if (row.kind === 'note') return 'refuse';
 
+    if (model.id === 'advisory_rating') {
+      // Same structure as the PEF block below — match on the surface, emit, and
+      // `refuse` so the controller's own branch never also fires. One
+      // difference, and it is deliberate: PEF maps its LABEL to a category
+      // (`PEF_CATEGORY_BY_LABEL`), while the score is read off the ROW. See
+      // `SurfaceRow`'s `rating` — a reworded label must not be able to move it.
+      //
+      // A row without a score is refused rather than guessed at: it would send
+      // a number nobody chose.
+      if (row.kind === 'action' && typeof row.rating === 'number') {
+        emitCommand({ type: 'rating', rating: row.rating });
+      }
+      return 'refuse';
+    }
+
     if (model.id === 'prompt_enhancement_feedback') {
       if (row.kind === 'action') {
         const category = PEF_CATEGORY_BY_LABEL[row.label];
@@ -391,8 +406,18 @@ export function mountNexpathPeDock(opts: PeDockAdapterOptions): PePanelControlle
       case 'feedback-skipped':
         completePending();
         return;
+      case 'rating-skipped':
+        // Esc on the rating surface. There is no "skipped" command and none is
+        // needed: not answering is the same outcome as closing the window, and
+        // `close` already says that. The worker distinguishes the two by which
+        // command arrives — `rating` or `close`.
+        emitCommand({ type: 'close' });
+        return;
       default:
-        return; // send/use-original/cancel-sequence/feedback are hook-intercepted
+        // send/use-original/cancel-sequence/feedback/rating are hook-intercepted:
+        // `resolveActivation` handles them and returns 'refuse', so the
+        // controller returns before emitting its own event for them.
+        return;
     }
   };
 
@@ -424,7 +449,14 @@ export function mountNexpathPeDock(opts: PeDockAdapterOptions): PePanelControlle
           opts.onEvent({
             type: 'command',
             viewSeq: view.viewSeq,
-            command: 'kind' in view ? { type: 'mps_decline' } : { type: 'close' },
+            // Named, not `'kind' in view`: the rating view carries a `kind` too,
+            // and the loose test would have sent `mps_decline` — a sequence
+            // decline — for a rating popup. Both commands typecheck, so nothing
+            // would have caught it. ✕ on a rating means no rating, which is
+            // exactly `close`.
+            command: 'kind' in view && view.kind === 'sequence_offer'
+              ? { type: 'mps_decline' }
+              : { type: 'close' },
           });
         }
         dock?.hide();
@@ -491,13 +523,28 @@ export function mountNexpathPeDock(opts: PeDockAdapterOptions): PePanelControlle
       // runs in the same task, so no intermediate frame ever paints.
       d.show();
       surfaces?.destroy();
-      const isOffer = 'kind' in v;
-      const registry = isOffer
-        ? { mps_first: mpsSurfaceModel(v), prompt_enhancement_feedback: pefSurfaceModel() }
-        : { prompt_enhancement: peSurfaceModel(v), prompt_enhancement_feedback: pefSurfaceModel() };
+      // Three view shapes now, so the discriminant names the one it means.
+      // The rating registry holds ONE surface: it has nowhere to transition to,
+      // and giving it the PEF entry would let a stray `switchTo` open a feedback
+      // form on top of a rating.
+      // Written as ONE nested ternary on `v` itself rather than via `isOffer` /
+      // `isRating` booleans: TypeScript narrows the union through the inline
+      // checks, and through a stored boolean it does not — `peSurfaceModel(v)`
+      // stops compiling the moment the union gains a third member. Keeping the
+      // narrowing here is what makes the compiler the guard.
+      const registry = !('kind' in v)
+        ? { prompt_enhancement: peSurfaceModel(v), prompt_enhancement_feedback: pefSurfaceModel() }
+        : v.kind === 'rating'
+          // ONE surface, deliberately: a rating has nowhere to transition to,
+          // and giving it the PEF entry would let a stray `switchTo` open a
+          // feedback form on top of it.
+          ? { advisory_rating: ratingSurfaceModel() }
+          : { mps_first: mpsSurfaceModel(v), prompt_enhancement_feedback: pefSurfaceModel() };
       surfaces = createSurfaceController(d.mountEl, {
         registry,
-        initial: isOffer ? 'mps_first' : 'prompt_enhancement',
+        initial: !('kind' in v)
+          ? 'prompt_enhancement'
+          : v.kind === 'rating' ? 'advisory_rating' : 'mps_first',
         doc,
         onEvent: onSurfaceEvent,
         resolveActivation,

--- a/src/ext-browser/ui/pe-dock-adapter.ts
+++ b/src/ext-browser/ui/pe-dock-adapter.ts
@@ -48,6 +48,9 @@ import {
 import { fieldScroller } from './surfaces/surface-view.js';
 import { BODY_HINT, DETAILS_HINT, EDIT_KEYS_HINT, PE_FOOTER } from './surfaces/fixtures/pe.js';
 import { PEF_FOOTER } from './surfaces/fixtures/pef.js';
+import {
+  RATING_LABEL, RATING_QUESTION, RATING_FOOTER, ratingRows,
+} from './surfaces/fixtures/rating.js';
 import { MPS_FIRST_FOOTER } from './surfaces/fixtures/mps.js';
 
 const PEF_CATEGORY_BY_LABEL: Record<string, 'not_relevant_enough' | 'too_much_or_too_long'> = {
@@ -219,6 +222,27 @@ export function pefSurfaceModel(): SurfaceModel {
       },
     ],
     footer: PEF_FOOTER,
+  };
+}
+
+/**
+ * The advisory rating surface — the CLI's `runFeedbackPopup`
+ * (`decision-session/feedback-popup.ts`) as a dock surface: four scores worst →
+ * best, the transparency note above them, and a footer that makes clear
+ * skipping is free.
+ *
+ * Wholly static, unlike its three siblings here — nothing about it varies with
+ * the view — so the content lives in `fixtures/rating.ts` beside the CLI
+ * quotations, and this builds a FRESH model per call rather than handing out
+ * one shared object a caller could mutate.
+ */
+export function ratingSurfaceModel(): SurfaceModel {
+  return {
+    id: 'advisory_rating',
+    label: RATING_LABEL,
+    pinch: RATING_QUESTION,
+    rows: ratingRows(),
+    footer: RATING_FOOTER,
   };
 }
 

--- a/src/ext-browser/ui/surfaces/fixtures/rating.test.ts
+++ b/src/ext-browser/ui/surfaces/fixtures/rating.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// The rating surface's content, and the two ways it can silently go wrong:
+// drifting from the CLI wording it quotes, and the factory drifting from the
+// fixture the harness and the tests render.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import {
+  RATING_FIXTURE, RATING_SCALE, RATING_NOTE, RATING_QUESTION, RATING_FOOTER, RATING_LABEL,
+} from './rating.js';
+import { ratingSurfaceModel } from '../../pe-dock-adapter.js';
+
+describe('rating fixture', () => {
+  it('the scale is worst → best, 1 through 4', () => {
+    expect(RATING_SCALE.map((c) => [c.label, c.rating])).toEqual([
+      ['Bad', 1], ['Fine', 2], ['Good', 3], ['Excellent', 4],
+    ]);
+  });
+
+  it('every action row carries its score', () => {
+    const actions = RATING_FIXTURE.rows.filter((r) => r.kind === 'action');
+    expect(actions.every((r) => r.kind === 'action' && typeof r.rating === 'number')).toBe(true);
+  });
+
+  it('the note is a row, dim, and sits above every score', () => {
+    const rows = RATING_FIXTURE.rows;
+    const note = rows[0];
+    expect(note.kind).toBe('note');
+    expect(note.kind === 'note' && note.tone).toBe('dim');
+    expect(rows.findIndex((r) => r.kind === 'action')).toBeGreaterThan(0);
+  });
+
+  it('the surface asks its question in `pinch`, and has no field to type in', () => {
+    expect(RATING_FIXTURE.pinch).toBe(RATING_QUESTION);
+    expect(RATING_FIXTURE.label).toBe(RATING_LABEL);
+    expect(RATING_FIXTURE.footer).toBe(RATING_FOOTER);
+    expect(RATING_FIXTURE.rows.some((r) => r.kind === 'field')).toBe(false);
+  });
+});
+
+/**
+ * The harness renders RATING_FIXTURE; the dock will build ratingSurfaceModel().
+ * If they diverge, the surface that ships is not the one that was reviewed.
+ */
+describe('the factory and the fixture are the same surface', () => {
+  it('ratingSurfaceModel() equals RATING_FIXTURE', () => {
+    expect(ratingSurfaceModel()).toEqual(RATING_FIXTURE);
+  });
+
+  it('...but is a fresh object each call, so a caller cannot mutate the fixture', () => {
+    expect(ratingSurfaceModel()).not.toBe(ratingSurfaceModel());
+    expect(ratingSurfaceModel().rows).not.toBe(RATING_FIXTURE.rows);
+  });
+});
+
+/**
+ * Same discipline as `adapters/rating-cadence.test.ts` and
+ * `adapters/submit-hold-budget.test.ts`: read the shipped CLI module as text
+ * and pin what this copy quotes. The wording is decided there, not here.
+ */
+describe('contract with the shipped CLI popup (the two must not drift)', () => {
+  const shipped = readFileSync(
+    join(process.cwd(), 'src', 'decision-session', 'feedback-popup.ts'), 'utf8',
+  );
+
+  it('the question is the CLI\'s, exactly', () => {
+    expect(shipped).toContain(`export const FEEDBACK_QUESTION = "${RATING_QUESTION}";`);
+  });
+
+  it('the transparency note is the CLI\'s, exactly', () => {
+    expect(shipped).toContain(`export const FEEDBACK_NOTE = '${RATING_NOTE}';`);
+  });
+
+  it('the four labels and their scores are the CLI\'s, in the CLI\'s order', () => {
+    // Whitespace-normalised rather than a regex: the CLI's table is column-
+    // aligned, and the alignment is not the contract.
+    const flat = shipped.replace(/\s+/g, ' ');
+    for (const { label, rating } of RATING_SCALE) {
+      expect(flat).toContain(`value: 'feedback-rating-${rating}', label: '${label}', rating: ${rating}`);
+    }
+    // ...and there is no fifth.
+    expect(shipped.match(/feedback-rating-/g)).toHaveLength(RATING_SCALE.length);
+  });
+});

--- a/src/ext-browser/ui/surfaces/fixtures/rating.ts
+++ b/src/ext-browser/ui/surfaces/fixtures/rating.ts
@@ -1,0 +1,86 @@
+// ============================================================================
+// Static content for the advisory rating surface.
+// ----------------------------------------------------------------------------
+// Every string here is the CLI's own, quoted from
+// `src/decision-session/feedback-popup.ts` — that file is where the wording is
+// decided, and a contract test pins these against it so the two cannot drift.
+//
+// ── ONE DELIBERATE DEVIATION FROM THE CLI'S ORDER ────────────────────────────
+//
+// The CLI stacks: header(`feedback`) → note → blank → question → options
+// (`buildFeedbackRenderOptions`: the note is the `subtitle`, above `question`).
+//
+// The browser cannot reproduce that order without touching the view, and change
+// #3 of the dev plan is explicitly **None** for the view: everything in the
+// header block — `pinch`, `trustCues`, `whyHelp` — renders ABOVE `rows`
+// (`surface-view.ts:276-291`), and the note is a row. So the browser stacks:
+//
+//     header(`Feedback`) → question(pinch) → note(row) → blank → options
+//
+// The note and the question swap places; both still sit above the options and
+// below the header, which is what the note is FOR — it must be read before a
+// row is activated. Putting the question in `pinch` also matches what `pinch`
+// is for: PE's "Shipping something?" is the same kind of line.
+// ============================================================================
+
+import type { SurfaceModel, SurfaceRow } from '../surface-model.js';
+
+/** `FEEDBACK_QUESTION`, `feedback-popup.ts:19`. */
+export const RATING_QUESTION = "How's nexpath working out for you?";
+
+/** `FEEDBACK_NOTE`, `feedback-popup.ts:22` — what a send actually transmits. */
+export const RATING_NOTE = 'Press Enter to send: your installation ID and timestamps — no prompt text.';
+
+/**
+ * The CLI has no footer string for this popup — `renderLoop` handles Enter/Esc
+ * itself — but `SurfaceModel.footer` is required, so this follows PEF, the
+ * closest sibling (a survey where skipping is free): `PEF_FOOTER` is
+ * 'Enter submit · Esc skip'. "send" rather than "submit" because the CLI's own
+ * note above says "Press Enter to send".
+ */
+export const RATING_FOOTER = 'Enter send · Esc skip';
+
+/** Header suffix: the frame reads `◆ NEXPATH CLI · Feedback`. `FEEDBACK_PINCH_LABEL` is 'feedback'. */
+export const RATING_LABEL = 'Feedback';
+
+export interface RatingChoice {
+  label: string;
+  /** 1 = worst … 4 = best, the CLI's `rating` field. */
+  rating: number;
+}
+
+/** `FEEDBACK_OPTIONS`, `feedback-popup.ts:38-43` — worst → best, top → bottom. */
+export const RATING_SCALE: readonly RatingChoice[] = [
+  { label: 'Bad',       rating: 1 },
+  { label: 'Fine',      rating: 2 },
+  { label: 'Good',      rating: 3 },
+  { label: 'Excellent', rating: 4 },
+];
+
+/**
+ * The rows, built from the scale rather than written out again.
+ *
+ * The score rides on the ROW, not on its label. The `act` field one kind up
+ * says why: "Encoded in the model rather than matched on labels in the
+ * controller, so a reworded label cannot silently unhook a behaviour." A label
+ * lookup in the controller would make 'Good' → 3 a fact about a string.
+ */
+export function ratingRows(): SurfaceRow[] {
+  return [
+    { kind: 'note', text: RATING_NOTE, tone: 'dim' },
+    ...RATING_SCALE.map((c, i): SurfaceRow => ({
+      kind: 'action',
+      label: c.label,
+      rating: c.rating,
+      ...(i === 0 ? { blankBefore: true } : {}),
+    })),
+  ];
+}
+
+export const RATING_FIXTURE: SurfaceModel = {
+  id: 'advisory_rating',
+  label: RATING_LABEL,
+  pinch: RATING_QUESTION,
+  rows: ratingRows(),
+  footer: RATING_FOOTER,
+};

--- a/src/ext-browser/ui/surfaces/harness/harness.ts
+++ b/src/ext-browser/ui/surfaces/harness/harness.ts
@@ -26,6 +26,7 @@ import type { SurfaceId, SurfaceModel } from '../surface-model.js';
 import { PE_FIXTURE } from '../fixtures/pe.js';
 import { MPS_FIRST_FIXTURE, MPS_CONTINUATION_FIXTURE } from '../fixtures/mps.js';
 import { PEF_FIXTURE } from '../fixtures/pef.js';
+import { RATING_FIXTURE } from '../fixtures/rating.js';
 import { withBodyText } from '../refinement.js';
 import { createRefinementTransitions } from '../refinement-transitions.js';
 import { PE_REFINED_TEXT, MPS_REFINED_TEXT } from '../fixtures/directional.js';
@@ -35,6 +36,7 @@ const FIXTURES: Record<SurfaceId, SurfaceModel> = {
   mps_first: MPS_FIRST_FIXTURE,
   mps_continuation: MPS_CONTINUATION_FIXTURE,
   prompt_enhancement_feedback: PEF_FIXTURE,
+  advisory_rating: RATING_FIXTURE,
 };
 
 /** The pre-authored recompose, per surface — the static stand-in for Option B. */

--- a/src/ext-browser/ui/surfaces/surface-controller.test.ts
+++ b/src/ext-browser/ui/surfaces/surface-controller.test.ts
@@ -15,6 +15,7 @@ import { EDIT_KEYS_HINT } from './fixtures/pe.js';
 import { PE_FIXTURE } from './fixtures/pe.js';
 import { MPS_FIRST_FIXTURE, MPS_CONTINUATION_FIXTURE, MPS_CANCEL_LABEL } from './fixtures/mps.js';
 import { PEF_FIXTURE } from './fixtures/pef.js';
+import { RATING_FIXTURE, RATING_SCALE, RATING_NOTE } from './fixtures/rating.js';
 import type { SurfaceModel } from './surface-model.js';
 
 const REGISTRY = {
@@ -22,6 +23,7 @@ const REGISTRY = {
   mps_first: MPS_FIRST_FIXTURE,
   mps_continuation: MPS_CONTINUATION_FIXTURE,
   prompt_enhancement_feedback: PEF_FIXTURE,
+  advisory_rating: RATING_FIXTURE,
 };
 
 let host: HTMLElement;
@@ -1004,5 +1006,80 @@ describe('the focus guard never grabs the keyboard for a hidden panel', () => {
     expect(shadow.activeElement).toBeNull();
     c.destroy();
     outer.remove();
+  });
+});
+
+// ── advisory rating ──────────────────────────────────────────────────────────
+
+describe('advisory_rating', () => {
+  it('the model is the note plus exactly the four scores, worst to best', () => {
+    const rows = RATING_FIXTURE.rows;
+    expect(rows.filter((r) => r.kind === 'note').map((r) => r.kind === 'note' && r.text))
+      .toEqual([RATING_NOTE]);
+    expect(rows.filter((r) => r.kind === 'action').map((r) => r.label))
+      .toEqual(['Bad', 'Fine', 'Good', 'Excellent']);
+    expect(rows).toHaveLength(5);                 // nothing else on the surface
+    expect(rows.some((r) => r.kind === 'field')).toBe(false);  // never a text box
+  });
+
+  it.each(RATING_SCALE.map((c, i) => [i, c.label, c.rating] as const))(
+    'Enter on row %i (%s) emits that score',
+    (index, label, rating) => {
+      const c = mount('advisory_rating');
+      for (let i = 0; i < index; i++) key(c.element, 'ArrowDown');
+
+      key(c.element, 'Enter');
+
+      expect(events).toEqual([{ type: 'rating', surface: 'advisory_rating', rating, label }]);
+    },
+  );
+
+  it('Esc skips', () => {
+    const c = mount('advisory_rating');
+
+    key(c.element, 'Escape');
+
+    expect(events).toEqual([{ type: 'rating-skipped', surface: 'advisory_rating' }]);
+  });
+
+  it('⭐ the score comes off the ROW, not the label — renaming a label cannot move it', () => {
+    // The whole reason `rating` lives on the row. If the controller ever went
+    // back to mapping labels to numbers, this sends 3 for a row worth 1.
+    const renamed: SurfaceModel = {
+      ...RATING_FIXTURE,
+      rows: RATING_FIXTURE.rows.map((r) =>
+        r.kind === 'action' && r.label === 'Bad' ? { ...r, label: 'Not great' } : r),
+    };
+    controller = createSurfaceController(host, {
+      registry: { ...REGISTRY, advisory_rating: renamed },
+      initial: 'advisory_rating',
+      onEvent: (e) => events.push(e),
+    });
+
+    key(controller.element, 'Enter');
+
+    expect(events).toEqual([
+      { type: 'rating', surface: 'advisory_rating', rating: 1, label: 'Not great' },
+    ]);
+  });
+
+  it('an action row carrying NO score is never sent as a rating, and says so', () => {
+    // A4.3: unknown rows are never a silent no-op. It must not become rating 0.
+    const broken: SurfaceModel = {
+      ...RATING_FIXTURE,
+      rows: [{ kind: 'action', label: 'Mystery row' }],
+    };
+    controller = createSurfaceController(host, {
+      registry: { ...REGISTRY, advisory_rating: broken },
+      initial: 'advisory_rating',
+      onEvent: (e) => events.push(e),
+    });
+
+    key(controller.element, 'Enter');
+
+    expect(events).toEqual([
+      { type: 'activate', surface: 'advisory_rating', label: 'Mystery row' },
+    ]);
+    expect(host.textContent).toContain('No action wired');
   });
 });

--- a/src/ext-browser/ui/surfaces/surface-controller.ts
+++ b/src/ext-browser/ui/surfaces/surface-controller.ts
@@ -67,6 +67,13 @@ export type SurfaceEvent =
   | { type: 'declined'; surface: SurfaceId }
   | { type: 'feedback'; surface: SurfaceId; category?: string; text?: string }
   | { type: 'feedback-skipped'; surface: SurfaceId }
+  /**
+   * The advisory rating surface's answer. `rating` is the 1-4 score carried on
+   * the row; `label` rides along for logging and is NOT what the score is read
+   * from — see `SurfaceRow`'s `rating`.
+   */
+  | { type: 'rating'; surface: SurfaceId; rating: number; label: string }
+  | { type: 'rating-skipped'; surface: SurfaceId }
   | { type: 'activate'; surface: SurfaceId; label: string };
 
 /**
@@ -399,6 +406,21 @@ function scrollRowIntoView(wrapper: HTMLElement): void {
       say('Feedback recorded — static build.');
       return;
     }
+    if (surface === 'advisory_rating' && row.kind === 'action') {
+      // Mirrors the PEF branch above: a rating surface's action rows all mean
+      // one thing, so they dispatch on the SURFACE, not on `act`. The score
+      // comes off the row — a controller that mapped 'Good' to 3 itself would
+      // send the wrong number the day someone rewords the label.
+      //
+      // A row with no score is not guessed at and not silently swallowed: it
+      // falls through to the `default` below, which emits `activate` and says
+      // so out loud (A4.3).
+      if (typeof row.rating === 'number') {
+        emit?.({ type: 'rating', surface, rating: row.rating, label: row.label });
+        say('Rating recorded — static build.');
+        return;
+      }
+    }
     switch (row.act) {
       case 'use-original':
         // Cancel is where feedback opens (§8.3): Use original or Esc, never send.
@@ -460,6 +482,14 @@ function scrollRowIntoView(wrapper: HTMLElement): void {
         return;
       case 'prompt_enhancement_feedback':
         emit?.({ type: 'feedback-skipped', surface });
+        say('Feedback skipped.');
+        return;
+      case 'advisory_rating':
+        // Esc is a free skip, exactly as PEF's is. NOTE: nothing in TypeScript
+        // forces this case to exist — the switch has no exhaustiveness guard,
+        // so a missing case compiles clean and Esc would silently do nothing.
+        // `surface-controller.test.ts` is what actually holds it in place.
+        emit?.({ type: 'rating-skipped', surface });
         say('Feedback skipped.');
         return;
     }

--- a/src/ext-browser/ui/surfaces/surface-model.ts
+++ b/src/ext-browser/ui/surfaces/surface-model.ts
@@ -18,7 +18,8 @@ export type SurfaceId =
   | 'prompt_enhancement'
   | 'mps_first'
   | 'mps_continuation'
-  | 'prompt_enhancement_feedback';
+  | 'prompt_enhancement_feedback'
+  | 'advisory_rating';
 
 /**
  * The hint lines under an editable field.
@@ -82,6 +83,13 @@ export type SurfaceRow =
        * generic activate event — or to its pluggable transitions hook.
        */
       act?: 'use-original' | 'cancel-sequence' | 'interruption';
+      /**
+       * The advisory rating surface's 1-4 score (`feedback-popup.ts:38-43`,
+       * 1 = Bad … 4 = Excellent). On the row for the same reason `act` is: the
+       * controller must not learn that 'Good' means 3, or renaming the label
+       * would silently change what gets sent.
+       */
+      rating?: number;
       /** MPS's Cancel row carries the CLI's paleYellow. */
       tone?: 'plain' | 'cancel';
       /** A line under the label, like MPS-2's interruption helper. */

--- a/src/telemetry/feedback-send.test.ts
+++ b/src/telemetry/feedback-send.test.ts
@@ -161,9 +161,11 @@ describe('per-option event names — pinned to FEEDBACK_OPTIONS', () => {
     // convenience. If one has to fail, it should be the second one.
     const stop = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
     const flat = stop.replace(/\s+/g, ' ');
-    expect(flat).toContain('await flushLifecycle(store); await fbSend(store, result.rating);');
-    expect(stop.indexOf('fbRatingOption(store, result.rating)'))
-      .toBeGreaterThan(stop.indexOf('fbSend(store, result.rating)'));
+    expect(flat).toContain('await flushLifecycle(store); const answeredAt = Date.now(); await fbSend(store, result.rating, answeredAt);');
+    // ONE timestamp, shared: the two envelopes describe a single click.
+    expect(flat).toContain('await fbRatingOption(store, result.rating, answeredAt);');
+    expect(stop.indexOf('fbRatingOption(store, result.rating, answeredAt)'))
+      .toBeGreaterThan(stop.indexOf('fbSend(store, result.rating, answeredAt)'));
   });
 
   it('⭐ and it is NOT sent on a dismissal — there is no option to report', () => {
@@ -172,12 +174,11 @@ describe('per-option event names — pinned to FEEDBACK_OPTIONS', () => {
     expect(elseBranch.slice(0, 900)).not.toContain('fbRatingOption');
   });
 
-  it('⭐ the BROWSER still sends none of them — Phase 3 has not landed', () => {
+  it('⭐ the browser ships the identical four names and sends them too', () => {
     // Dropped from this guard the moment Phase 3 ships, together with the
     // browser's own tests and the Privacy section that enumerates what is sent.
     const host = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'background', 'pe-popup-host.ts'), 'utf8');
-    expect(host).not.toContain('feedbackRatingEvent');
-    expect(host).not.toContain('sendRatingOption');
+    expect(host).toContain('sendRatingOption');
   });
 });
 

--- a/src/telemetry/feedback-send.test.ts
+++ b/src/telemetry/feedback-send.test.ts
@@ -235,3 +235,24 @@ describe('sendFeedbackRatingOption', () => {
     },
   );
 });
+
+describe('the two rating envelopes describe ONE click', () => {
+  it('⭐ given one timestamp, both carry it identically', async () => {
+    // The source pin above catches someone writing `Date.now()` again; this
+    // catches a sender that simply ignores the timestamp it was handed. The
+    // browser's end-to-end suite found the original defect by comparing the two
+    // payloads — this is the same guarantee, on this side.
+    const a: Captured = { calls: 0 };
+    await sendFeedback(store, 3, { fetch: okFetch(a), now: 4_242 });
+    const rating = a.envelope!;
+
+    const b: Captured = { calls: 0 };
+    await sendFeedbackRatingOption(store, 3, { fetch: okFetch(b), now: 4_242 });
+    const option = b.envelope!;
+
+    expect(option.timestamp).toBe(rating.timestamp);
+    expect(option.properties.feedback_at).toBe(rating.properties.feedback_at);
+    expect(option.properties).toEqual(rating.properties);
+    expect(option.event).not.toBe(rating.event);   // only the name differs
+  });
+});

--- a/src/telemetry/feedback-send.test.ts
+++ b/src/telemetry/feedback-send.test.ts
@@ -2,7 +2,17 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { openStore, closeStore, type Store } from '../store/db.js';
 import { setConfig } from '../store/config.js';
 import { getInstallationId } from './identity.js';
-import { sendFeedback, FEEDBACK_EVENT } from './feedback-send.js';
+import {
+  FEEDBACK_EVENT,
+  FEEDBACK_DISMISSED_EVENT,
+  FEEDBACK_RATING_EVENTS,
+  feedbackRatingEvent,
+  sendFeedback,
+  sendFeedbackDismissed,
+} from './feedback-send.js';
+import { FEEDBACK_OPTIONS } from '../decision-session/feedback-popup.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { FetchLike } from './TelemetryClient.js';
 import type { PostHogSingleEnvelope } from './types.js';
 
@@ -105,5 +115,55 @@ describe('sendFeedback', () => {
 
   it('returns false on a 429 rate-limit', async () => {
     expect(await sendFeedback(store, 3, { fetch: rateLimitedFetch(cap) })).toBe(false);
+  });
+});
+
+/**
+ * The per-option event names against the popup that defines the options.
+ *
+ * The list in `feedback-send.ts` is a COPY — importing `feedback-popup.ts` from
+ * telemetry would close a cycle (it imports `DecisionSession.js`, which imports
+ * `telemetry/`). Same problem `submit-hold-budget.ts` has, same answer: keep the
+ * copy and pin it here, so a reworded label fails a test instead of silently
+ * renaming an event that dashboards are built on.
+ */
+describe('per-option event names — pinned to FEEDBACK_OPTIONS', () => {
+  it('there is exactly one name per option, and no extras', () => {
+    expect(Object.keys(FEEDBACK_RATING_EVENTS).map(Number).sort())
+      .toEqual(FEEDBACK_OPTIONS.map((o) => o.rating).sort());
+  });
+
+  it('⭐ each name is its own label, lowercased', () => {
+    for (const opt of FEEDBACK_OPTIONS) {
+      expect(feedbackRatingEvent(opt.rating), opt.label)
+        .toBe(`feedback_rating_${opt.label.toLowerCase()}`);
+    }
+  });
+
+  it('the four names are distinct, and none collides with the two existing events', () => {
+    const names = Object.values(FEEDBACK_RATING_EVENTS);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).not.toContain(FEEDBACK_EVENT);
+    expect(names).not.toContain(FEEDBACK_DISMISSED_EVENT);
+  });
+
+  it('a rating outside the scale has no event', () => {
+    for (const r of [0, 5, -1, 1.5, Number.NaN]) {
+      expect(feedbackRatingEvent(r), String(r)).toBeUndefined();
+    }
+  });
+
+  it('⭐ Phase 1 is naming only — nothing sends these yet', () => {
+    // The senders arrive in Phase 2 (CLI) and Phase 3 (browser). If this starts
+    // failing, a sender landed without the phase that was meant to bring its
+    // tests and its documentation with it.
+    const src = readFileSync(join(process.cwd(), 'src', 'telemetry', 'feedback-send.ts'), 'utf8');
+    // No sender for them yet, and no envelope built from one.
+    expect(src).not.toMatch(/export (async )?function sendFeedbackRating/);
+    expect(src).not.toMatch(/event: *feedbackRatingEvent/);
+    // And nothing calls them from the stop hook.
+    const stop = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
+    expect(stop).not.toContain('feedbackRatingEvent');
+    expect(stop).not.toContain('FEEDBACK_RATING_EVENTS');
   });
 });

--- a/src/telemetry/feedback-send.test.ts
+++ b/src/telemetry/feedback-send.test.ts
@@ -9,6 +9,7 @@ import {
   feedbackRatingEvent,
   sendFeedback,
   sendFeedbackDismissed,
+  sendFeedbackRatingOption,
 } from './feedback-send.js';
 import { FEEDBACK_OPTIONS } from '../decision-session/feedback-popup.js';
 import { readFileSync } from 'node:fs';
@@ -153,17 +154,83 @@ describe('per-option event names — pinned to FEEDBACK_OPTIONS', () => {
     }
   });
 
-  it('⭐ Phase 1 is naming only — nothing sends these yet', () => {
-    // The senders arrive in Phase 2 (CLI) and Phase 3 (browser). If this starts
-    // failing, a sender landed without the phase that was meant to bring its
-    // tests and its documentation with it.
-    const src = readFileSync(join(process.cwd(), 'src', 'telemetry', 'feedback-send.ts'), 'utf8');
-    // No sender for them yet, and no envelope built from one.
-    expect(src).not.toMatch(/export (async )?function sendFeedbackRating/);
-    expect(src).not.toMatch(/event: *feedbackRatingEvent/);
-    // And nothing calls them from the stop hook.
+  it('⭐ the stop hook sends the per-option event AFTER the rating, on the same consent', () => {
+    // Order matters and is asserted on the source, because a reordering here
+    // would not fail any behavioural test: both sends succeed either way. The
+    // rating is the record dashboards were built on; the per-option event is the
+    // convenience. If one has to fail, it should be the second one.
     const stop = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
-    expect(stop).not.toContain('feedbackRatingEvent');
-    expect(stop).not.toContain('FEEDBACK_RATING_EVENTS');
+    const flat = stop.replace(/\s+/g, ' ');
+    expect(flat).toContain('await flushLifecycle(store); await fbSend(store, result.rating);');
+    expect(stop.indexOf('fbRatingOption(store, result.rating)'))
+      .toBeGreaterThan(stop.indexOf('fbSend(store, result.rating)'));
   });
+
+  it('⭐ and it is NOT sent on a dismissal — there is no option to report', () => {
+    const stop = readFileSync(join(process.cwd(), 'src', 'cli', 'commands', 'stop.ts'), 'utf8');
+    const elseBranch = stop.slice(stop.indexOf('} else {', stop.indexOf('fbRatingOption')));
+    expect(elseBranch.slice(0, 900)).not.toContain('fbRatingOption');
+  });
+
+  it('⭐ the BROWSER still sends none of them — Phase 3 has not landed', () => {
+    // Dropped from this guard the moment Phase 3 ships, together with the
+    // browser's own tests and the Privacy section that enumerates what is sent.
+    const host = readFileSync(join(process.cwd(), 'src', 'ext-browser', 'background', 'pe-popup-host.ts'), 'utf8');
+    expect(host).not.toContain('feedbackRatingEvent');
+    expect(host).not.toContain('sendRatingOption');
+  });
+});
+
+describe('sendFeedbackRatingOption', () => {
+  it.each(FEEDBACK_OPTIONS.map((o) => [o.label, o.rating] as const))(
+    '⭐ %s posts feedback_rating_%s',
+    async (label, rating) => {
+      const ok = await sendFeedbackRatingOption(store, rating, { fetch: okFetch(cap), now: 7_000 });
+
+      expect(ok).toBe(true);
+      expect(cap.calls).toBe(1);
+      expect(cap.envelope?.event).toBe(`feedback_rating_${label.toLowerCase()}`);
+      expect(cap.envelope?.properties.rating).toBe(rating);
+      expect(cap.envelope?.properties.feedback_at).toBe(7_000);
+      expect(cap.envelope?.timestamp).toBe(new Date(7_000).toISOString());
+      expect(cap.envelope?.distinct_id).toBe(getInstallationId(store));
+    },
+  );
+
+  it('carries the same payload as the rating event — either can answer the same question', async () => {
+    await sendFeedbackRatingOption(store, 2, { fetch: okFetch(cap), now: 5_000 });
+    const optionProps = { ...cap.envelope?.properties };
+
+    cap = { calls: 0 };
+    await sendFeedback(store, 2, { fetch: okFetch(cap), now: 5_000 });
+
+    expect(optionProps).toEqual(cap.envelope?.properties);
+  });
+
+  it('⭐ a rating outside the scale sends NOTHING — no fifth option can be invented', async () => {
+    for (const r of [0, 5, -1, 1.5, Number.NaN]) {
+      expect(await sendFeedbackRatingOption(store, r, { fetch: okFetch(cap) }), String(r)).toBe(false);
+    }
+    expect(cap.calls).toBe(0);
+  });
+
+  it('posts even when telemetry.enabled is false — the click is the consent', async () => {
+    setConfig(store, 'telemetry.enabled', 'false');
+    expect(await sendFeedbackRatingOption(store, 3, { fetch: okFetch(cap) })).toBe(true);
+  });
+
+  it('sends nothing without an api key', async () => {
+    const bare = await openStore(':memory:');
+    setConfig(bare, 'telemetry_sync_api_key', '');
+    expect(await sendFeedbackRatingOption(bare, 3, { fetch: okFetch(cap) })).toBe(false);
+    expect(cap.calls).toBe(0);
+    closeStore(bare);
+  });
+
+  it.each([['a 500', failFetch], ['a 429', rateLimitedFetch], ['a thrown error', throwFetch]])(
+    'swallows %s and returns false',
+    async (_label, make) => {
+      expect(await sendFeedbackRatingOption(store, 4, { fetch: make(cap) })).toBe(false);
+    },
+  );
 });

--- a/src/telemetry/feedback-send.ts
+++ b/src/telemetry/feedback-send.ts
@@ -34,6 +34,36 @@ export const FEEDBACK_EVENT = 'feedback_submitted';
  */
 export const FEEDBACK_DISMISSED_EVENT = 'feedback_dismissed';
 
+/**
+ * One event NAME per rating option, on top of `feedback_submitted`'s `rating`
+ * property (plan §9.8: the property stays — replacing it would rename history
+ * and break every existing chart).
+ *
+ * Why a name and not just the property: in PostHog an event name is a
+ * first-class object with its own trend, funnel step and alert, where a property
+ * filter has to be re-applied on every chart.
+ *
+ * ⚠️ WHY THIS LIST IS DUPLICATED RATHER THAN DERIVED FROM `FEEDBACK_OPTIONS`.
+ * Importing `decision-session/feedback-popup.ts` from here would close a cycle:
+ * that module imports `DecisionSession.js`, which imports `telemetry/`. So this
+ * follows the discipline the repo already uses for exactly this problem
+ * (`submit-hold-budget.ts`, `adapters/rating-cadence.ts`): keep the copy, and
+ * pin it with a contract test that reads the shipped source as text. The names
+ * are the labels lowercased, so a reworded label fails that test rather than
+ * silently renaming an event.
+ */
+export const FEEDBACK_RATING_EVENTS: Readonly<Record<number, string>> = {
+  1: 'feedback_rating_bad',
+  2: 'feedback_rating_fine',
+  3: 'feedback_rating_good',
+  4: 'feedback_rating_excellent',
+};
+
+/** The per-option event for a rating, or undefined if it is not one of the four. */
+export function feedbackRatingEvent(rating: number): string | undefined {
+  return FEEDBACK_RATING_EVENTS[rating];
+}
+
 export interface SendFeedbackOptions {
   fetch?: FetchLike;
   now?:   number;

--- a/src/telemetry/feedback-send.ts
+++ b/src/telemetry/feedback-send.ts
@@ -21,6 +21,19 @@ import type { PostHogSingleEnvelope } from './types.js';
 
 export const FEEDBACK_EVENT = 'feedback_submitted';
 
+/**
+ * The popup was shown and the user closed it without answering.
+ *
+ * Without this, "asked and declined" and "never asked" are the same absence in
+ * the data, so the rating has no denominator of its own — `nexpath_installed`
+ * cannot say how often the prompt actually appeared.
+ *
+ * It carries the installation id and a timestamp, and nothing else: there is no
+ * rating to report, and a dismissal is not consent to release anything that was
+ * buffered. The caller must NOT flush the lifecycle buffer for it.
+ */
+export const FEEDBACK_DISMISSED_EVENT = 'feedback_dismissed';
+
 export interface SendFeedbackOptions {
   fetch?: FetchLike;
   now?:   number;
@@ -62,6 +75,48 @@ export async function sendFeedback(
     return result.ok;
   } catch {
     // Best-effort — a send failure must never crash the caller.
+    return false;
+  }
+}
+
+/**
+ * Post the dismissal. Same envelope as the rating with the rating left out —
+ * there isn't one.
+ *
+ * Deliberately does NOT flush the lifecycle buffer, and the caller must not
+ * either: the rating click is the consent that releases what was buffered
+ * (`stop.ts:526`), and closing the popup is the opposite of that click.
+ * Best-effort: never throws.
+ */
+export async function sendFeedbackDismissed(
+  store: Store,
+  opts:  SendFeedbackOptions = {},
+): Promise<boolean> {
+  try {
+    const apiKey = getConfig(store.db, 'telemetry_sync_api_key');
+    if (!apiKey) return false;   // nothing to authenticate the post with
+
+    const endpoint = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    const now      = opts.now ?? Date.now();
+
+    const installationId = getInstallationId(store);
+
+    const envelope: PostHogSingleEnvelope = {
+      api_key:     apiKey,
+      event:       FEEDBACK_DISMISSED_EVENT,
+      distinct_id: installationId,
+      timestamp:   new Date(now).toISOString(),
+      properties: {
+        $lib:            POSTHOG_LIB_NAME,
+        $lib_version:    POSTHOG_LIB_VERSION,
+        installation_id: installationId,
+        dismissed_at:    now,
+      },
+    };
+
+    const result = await postEvent(endpoint, envelope, opts.fetch ? { fetch: opts.fetch } : {});
+    return result.ok;
+  } catch {
     return false;
   }
 }

--- a/src/telemetry/feedback-send.ts
+++ b/src/telemetry/feedback-send.ts
@@ -110,6 +110,59 @@ export async function sendFeedback(
 }
 
 /**
+ * Post the per-option event for a rating — `feedback_rating_good` and its three
+ * siblings — ALONGSIDE `feedback_submitted`, never instead of it (plan §9.8).
+ *
+ * The same payload as the rating send, so either event can answer the same
+ * question; the difference is that this one is a NAME, which in PostHog is a
+ * first-class object with its own trend, funnel step and alert.
+ *
+ * A rating outside the scale has no event and sends nothing — the caller cannot
+ * invent a fifth option by passing 5.
+ *
+ * Best-effort: never throws. It is a second envelope on the same consent as the
+ * rating, so the caller sends it after the flush and after `sendFeedback`; a
+ * failure here must not affect either.
+ */
+export async function sendFeedbackRatingOption(
+  store:  Store,
+  rating: number,
+  opts:   SendFeedbackOptions = {},
+): Promise<boolean> {
+  try {
+    const event = feedbackRatingEvent(rating);
+    if (!event) return false;
+
+    const apiKey = getConfig(store.db, 'telemetry_sync_api_key');
+    if (!apiKey) return false;
+
+    const endpoint = getConfig(store.db, 'telemetry_sync_endpoint') ?? DEFAULT_POSTHOG_ENDPOINT;
+    const now      = opts.now ?? Date.now();
+
+    const installationId = getInstallationId(store);
+
+    const envelope: PostHogSingleEnvelope = {
+      api_key:     apiKey,
+      event,
+      distinct_id: installationId,
+      timestamp:   new Date(now).toISOString(),
+      properties: {
+        $lib:            POSTHOG_LIB_NAME,
+        $lib_version:    POSTHOG_LIB_VERSION,
+        rating,
+        installation_id: installationId,
+        feedback_at:     now,
+      },
+    };
+
+    const result = await postEvent(endpoint, envelope, opts.fetch ? { fetch: opts.fetch } : {});
+    return result.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Post the dismissal. Same envelope as the rating with the rating left out —
  * there isn't one.
  *


### PR DESCRIPTION
# Add Ext Browser Rating and Telemetry Support

## Summary

This PR brings the latest Ext Browser rating and telemetry updates into the `staging` branch.

The changes focus on improving rating-related functionality and adding the supporting telemetry flow, along with the related Ext Browser updates and test coverage.

## Changes Included

* Added rating support for the Ext Browser experience.
* Added telemetry handling for relevant rating and user interaction events.
* Updated the supporting Ext Browser UI and integration flow.
* Added related validation and test coverage.
* Included the latest supporting changes required for the feature to work correctly.

## Verification

The relevant implementation and supporting checks have been completed as part of this update.

I’d appreciate a review of the changes. If everything looks good, please consider merging this PR into `staging`.
