### PR TITLE
Merge Footer and Privacy Page Corrections into Staging

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Nexpath Browser Extension — Privacy Policy</title>
-<meta name="description" content="Privacy policy for the Nexpath browser extension — an AI coding assistant for Replit, Lovable and Bolt.new. Your API key or Nexpath token and your settings stay in your browser; prompt context goes to OpenAI with your own key, or through Nexpath's own service in token mode. No telemetry, no tracking.">
+<meta name="description" content="Privacy policy for the Nexpath browser extension — an AI coding assistant for Replit, Lovable and Bolt.new. Your API key or Nexpath token and your settings stay in your browser; prompt context goes to OpenAI with your own key, or through Nexpath's own service in token mode. No tracking network, no remote code; content-free usage signals leave only if you answer the rating prompt.">
 <style>
   :root{
     --bg:#ffffff; --fg:#1a1d1f; --muted:#5b6266; --rule:#e3e6e8;
@@ -78,7 +78,9 @@
     <strong>OpenAI</strong>, under your own OpenAI account — ParseOS receives nothing. With an
     optional <strong>Nexpath token</strong> from a Nexpath account, prompt context is sent to
     <strong>Nexpath's own service</strong> instead, which forwards it to OpenAI to generate the
-    answer and meters your account credit. No telemetry and no tracking in either mode.
+    answer and meters your account credit. There is no tracking network and no remote code;
+    content-free usage signals leave your machine only if you answer the occasional rating prompt
+    (see "Usage signals and the rating prompt" below).
   </div>
 
   <h2>What Nexpath handles</h2>
@@ -130,12 +132,37 @@
     </li>
   </ul>
 
+  <h2>Usage signals and the rating prompt</h2>
+  <ul>
+    <li>
+      <strong>Usage signals stay on your machine until you choose to send them.</strong> Nexpath
+      keeps a local, content-free record of <em>which</em> popup buttons you press and <em>when</em>
+      — a fixed list of action names and timestamps. It never records prompt text, the text of an
+      option, which site you are on, or your project path.
+    </li>
+    <li>
+      <strong>The only thing that sends is the rating prompt, and only when you answer it.</strong>
+      Occasionally Nexpath asks how it is working out for you. Choosing a rating is what sends —
+      and it sends only a random installation ID (not tied to you or your machine), your 1–4
+      rating, and the timestamps above.
+    </li>
+    <li>
+      <strong>If you dismiss the prompt, one line goes out saying just that</strong> — your
+      installation ID and the time, so we can tell "asked and declined" apart from "never asked".
+      The local usage signals above stay on your machine: only answering releases those.
+    </li>
+    <li>
+      <strong>Your prompt text is never part of any of this.</strong> Prompt text goes only over
+      the two routes described above — OpenAI with your key, or the Nexpath service with your token.
+    </li>
+  </ul>
+
   <h2>What Nexpath does not do</h2>
   <ul class="never">
-    <li><strong>No telemetry, no tracking, no remote code.</strong></li>
-    <li>No analytics services, advertising, or third-party trackers of any kind.</li>
+    <li><strong>No tracking network, no ads, no remote code.</strong></li>
+    <li>No advertising or third-party tracking scripts of any kind.</li>
     <li>No selling or transferring of your data to anyone.</li>
-    <li>No use of your data for anything unrelated to generating your suggestions.</li>
+    <li>No use of your data for anything unrelated to generating your suggestions or improving Nexpath.</li>
     <li>No running on websites other than the three supported AI coding sites.</li>
   </ul>
 

--- a/src/ext-browser/options/options.css
+++ b/src/ext-browser/options/options.css
@@ -233,13 +233,18 @@ footer a:hover { color: #6c7086; }
 .token-steps li { margin: 3px 0; }
 .token-steps a { color: inherit; text-decoration: underline; }
 
-/* Footer branding (owner 2026-09-01): wordmark + muted "web" qualifier, one click
-   target linking home. No version text, no icons. */
+/* Footer branding (team lead 2026-09-02): "Nexpath Website", whole label bold,
+   one click target linking home. No version text, no icons. Hover must be
+   clearly visible — a bright accent, never a muted grey. */
 .footer-brand {
   color: #ffffff;
   font-weight: 600;
   text-decoration: none;
   letter-spacing: 0.01em;
 }
-.footer-brand:hover { text-decoration: underline; }
-.footer-brand .footer-web { font-weight: 400; color: #6c7086; }
+.footer-brand:hover,
+.footer-brand:focus-visible {
+  color: #b4befe;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}

--- a/src/ext-browser/options/options.html
+++ b/src/ext-browser/options/options.html
@@ -93,7 +93,7 @@
       </section>
 
       <footer>
-        <p><a class="footer-brand" href="https://parseos.tech/nexpath/" target="_blank" rel="noopener" title="Visit the Nexpath website">Nexpath <span class="footer-web">web</span></a></p>
+        <p><a class="footer-brand" href="https://parseos.tech/nexpath/" target="_blank" rel="noopener" title="Visit the Nexpath website">Nexpath Website</a></p>
       </footer>
     </main>
     <script type="module" src="options.js"></script>

--- a/src/ext-browser/options/options.test.ts
+++ b/src/ext-browser/options/options.test.ts
@@ -233,7 +233,10 @@ describe('options.ts', () => {
       expect(html).toContain('href="https://parseos.tech/nexpath/"');
       // The wordmark and the "web" qualifier live inside ONE anchor: the whole
       // "Nexpath web" is the click target.
-      expect(html).toMatch(/<a class="footer-brand"[^>]*>Nexpath <span class="footer-web">web<\/span><\/a>/);
+      // Team lead 2026-09-02: the label is "Nexpath Website", ONE bold anchor —
+      // no muted qualifier span (its grey hover read as broken).
+      expect(html).toMatch(/<a class="footer-brand"[^>]*>Nexpath Website<\/a>/);
+      expect(html).not.toContain('footer-web');
       expect(html).not.toContain('nexpath.dev');
       // Version display removed (owner 2026-09-01) — and no glyph/icon characters.
       expect(html).not.toContain('ext-version');


### PR DESCRIPTION
# Merge Footer and Privacy Page Corrections into Staging

## Overview

This PR brings two small pre-release corrections into `staging` while testing continues:
the settings-page footer label requested in review, and a privacy-page update so the
policy the store listings link to matches everything 0.1.53 actually ships.

## What's Included

* Settings footer — the link now reads **"Nexpath Website"**, the whole label bold, and
  hover/focus turns a bright accent with underline so the state is clearly visible. The
  test pins the exact new markup.
* Privacy page — adds the "Usage signals and the rating prompt" section (signals stay
  local until a rating is answered; answering sends a random installation ID, the 1–4
  rating, and content-free action names + timestamps; dismissing sends one line; never
  any text) and retires the old "no telemetry" absolutes, which the rating work made
  inaccurate.

## Verification

Options and manifest guard suites pass (50 tests), the build was rebuilt and the new
footer verified in the built page, and the privacy page passes the user-facing copy
guards. No behaviour changes outside the footer styling.

Please review the changes and merge this PR into `staging` if everything looks good.