### PR TITLE
Merge Firefox Data Declaration Fix into Staging

### DIFF
--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -62,7 +62,8 @@
       "id": "{80f4c1c7-1fb2-41d9-a4a1-7c2f4981d286}",
       "strict_min_version": "112.0",
       "data_collection_permissions": {
-        "required": ["authenticationInfo", "websiteContent", "technicalAndInteraction"]
+        "required": ["websiteContent"],
+        "optional": ["technicalAndInteraction"]
       }
     }
   },

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -96,6 +96,43 @@ describe('ext-browser manifests — permission surface', () => {
     expect(firefox.description).toEqual(chrome.description);
   });
 
+  // Firefox prints `data_collection_permissions.required` verbatim in its install
+  // dialog ("The developer says this extension collects: …"), so this declaration is
+  // user-facing copy with a compliance rule attached. It had no guard, and that is
+  // exactly how an invalid value reached it: `technicalAndInteraction` was added to
+  // `required`, which Mozilla's documentation forbids outright ("This data permission
+  // must be optional" / "cannot be required").
+  describe('firefox data-collection declaration', () => {
+    const declaration = () =>
+      load('firefox').browser_specific_settings.gecko.data_collection_permissions;
+
+    it('never puts technicalAndInteraction in the required list (Mozilla forbids it)', () => {
+      expect(declaration().required ?? []).not.toContain('technicalAndInteraction');
+    });
+
+    it('declares websiteContent as required — the prompt genuinely leaves the browser', () => {
+      // The extension sends the prompt (and a window of recent prompts) to the LLM
+      // route. Declaring anything narrower here would be a false declaration, which
+      // is the class of mistake that gets a listing removed rather than corrected.
+      expect(declaration().required).toContain('websiteContent');
+    });
+
+    it('does NOT declare authenticationInfo', () => {
+      // Nothing here collects credentials: the user's OpenAI key travels only to
+      // OpenAI, and the Nexpath token is a credential our own service issued being
+      // sent back to authenticate. Neither is the harvesting that Mozilla's category
+      // ("passwords, usernames, PINs, security questions") describes. If a reviewer
+      // ever rules otherwise, re-add it here — do not quietly change the behaviour
+      // instead.
+      expect(declaration().required ?? []).not.toContain('authenticationInfo');
+      expect(declaration().optional ?? []).not.toContain('authenticationInfo');
+    });
+
+    it('is a Firefox-only key — the Chrome manifest must not carry it', () => {
+      expect(JSON.stringify(load('chrome'))).not.toContain('data_collection_permissions');
+    });
+  });
+
   // Both stores reject a re-upload of a version they already hold, and reviewers read the
   // changelog against the version they are reviewing. A bumped manifest with a changelog
   // still headed by the previous release is the exact drift that costs a submission round.


### PR DESCRIPTION
# Merge Firefox Data Declaration Fix into Staging

## Overview

This PR corrects the Firefox data-collection declaration before the 0.1.53 submission. As it
stands, the manifest would fail Mozilla's own rule and would show a three-item data block in
the install dialog; after this change it shows one line.

## What's Included

* `technicalAndInteraction` moves from `required` to `optional`. Mozilla's documentation states
  it "must be optional" and "cannot be required", so the current value is a submission risk. As
  an optional type it is still shown at install and is enabled by default, so the rating feature
  is unaffected and needs no code change.
* `authenticationInfo` is removed. No credential is collected from the user or transmitted to a
  party that did not issue it: a user-supplied OpenAI key is stored locally and sent only to
  api.openai.com as that request's own Authorization header, and a Nexpath token is issued by our
  own service and returned only to it.
* `websiteContent` stays required — the submitted prompt genuinely leaves the browser, and
  declaring anything narrower would be inaccurate.
* Four new guard tests pin the whole declaration, which previously had none — including one that
  fails if `technicalAndInteraction` ever returns to the required list.

## Verification

The manifest suite passes (22 tests), the built Firefox package was unzipped and its manifest
confirmed to carry the new declaration, and the full suite runs clean apart from one
`telemetry-send` action-kind assertion that fails identically on `staging` without this change
(the in-flight `pe_shown` signal-kind addition — unrelated to this PR).

Please review the changes and merge this PR into `staging` if everything looks good.