### PR TITLE
 Merge Privacy Page Update into Staging

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -123,8 +123,10 @@
     <li>
       <strong>In token mode: Nexpath's own service.</strong> Prompt context goes to the service to be
       answered (it forwards the request to OpenAI). The service stores your account email, payment
-      records for Pro purchases, and technical usage metadata — token counts, timestamps, and which
-      model answered. <strong>PayPal</strong> processes Pro payments and never sees your prompts.
+      records for Pro purchases, technical usage metadata — token counts, timestamps, and which
+      model answered — and a recent record of the requests handled for your account, kept to
+      operate and improve the service. Recognised credentials are removed before anything is
+      written. <strong>PayPal</strong> processes Pro payments and never sees your prompts.
     </li>
     <li>
       <strong>With your own OpenAI key: no one else.</strong> ParseOS does not receive, store, sell,
@@ -169,7 +171,7 @@
   <h2>Data retention</h2>
   <ul>
     <li>With your own OpenAI key, prompt context is processed transiently to generate a suggestion and ParseOS retains nothing — we never receive it.</li>
-    <li>In token mode, the service keeps your account email, payment records, and technical usage metadata (token counts, timestamps, which model answered) — visible on your account page.</li>
+    <li>In token mode, the service keeps your account email, payment records, technical usage metadata (token counts, timestamps, which model answered) — visible on your account page — and a recent record of the requests it handled for your account, limited in number and pruned as newer ones arrive.</li>
     <li>Your key or token, settings, and recent prompt history stay in your browser until you remove the extension or clear them.</li>
   </ul>
 


### PR DESCRIPTION
# Merge Privacy Page Update into Staging

## Overview

The Nexpath service now keeps a recent, redacted record of the requests it
handles, so the privacy page — the page both store listings link to — says so.

## What's Included

* One clause added to each of the page's existing "what is stored" lists: the
  service keeps a recent record of the requests handled for an account, kept to
  operate and improve the service, with recognised credentials removed before
  anything is written and the record limited in number.
* No other change: no new section, no restructuring.

## Verification

The manifest and options guard suites pass, and the page still satisfies the
user-facing copy guards. No store declaration needs to change — Firefox already
declares `websiteContent` and Chrome already reports website content, so this
sits inside what both stores were already told.

Please review the changes and merge this PR into `staging` if everything looks good.