### PR TITLE
 Merge VS Code Extension 0.1.36 into Staging

### DIFF
--- a/src/ext-vscode/CHANGELOG.md
+++ b/src/ext-vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.36 — 2026-09-02
+
+- The extension now records the same content-free interaction signals the CLI already
+  records for its own popups — which action was taken and when, never any text. They
+  are written locally through the CLI; nothing is sent anywhere unless you have turned
+  telemetry on yourself, which is off by default.
+- Internal comment and documentation cleanup. No change to how the extension behaves.
+
 ## 0.1.35 — 2026-08-26
 
 - Listing: the demo video is now linked at the top, next to what NexPath supports.

--- a/src/ext-vscode/package-lock.json
+++ b/src/ext-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexpath-vscode",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexpath-vscode",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12"

--- a/src/ext-vscode/package.json
+++ b/src/ext-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nexpath-vscode",
   "displayName": "Nexpath",
-  "description": "Strengthen your prompts and catch skipped checks before shipping. NexPath holds your prompt at submit, offers a sharper version with your intent preserved, and sends the one you choose — on Cursor and Windsurf (Devin).",
-  "version": "0.1.35",
+  "description": "Strengthen your prompts and catch skipped checks before shipping. Nexpath holds your prompt at submit, offers a sharper version with your intent preserved, and sends the one you choose — on Cursor and Windsurf (Devin).",
+  "version": "0.1.36",
   "publisher": "nexpath",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
# Merge VS Code Extension 0.1.36 into Staging

## Overview

The VS Code extension still carried version 0.1.35, which is already published on
both registries — a republish at that version is rejected. This bumps it to 0.1.36
so the next publish can go out, and records what has actually changed since the
last release.

## What's Included

* Version bumped to 0.1.36 in `src/ext-vscode/package.json` and in
  `package-lock.json` (both occurrences — the lockfile ships inside the VSIX and
  would otherwise disagree with the manifest).
* CHANGELOG entry for 0.1.36 covering the one real change since 0.1.35: the
  extension now records the same content-free interaction signals the CLI already
  records for its own popups — which action was taken and when, never any text,
  written locally through the CLI and sent nowhere unless the user has turned
  telemetry on, which is off by default. The rest is comment and documentation
  cleanup with no behaviour change.
* Marketplace description corrected: it still read "NexPath", and that string is
  displayed verbatim on both marketplace listings.

## Verification

Both registries were checked before choosing the number: Open VSX reports 0.1.35
as latest (0.1.35, 0.1.34, 0.1.33, 0.1.32, 0.1.31, 0.1.3) and the VS Code
Marketplace item page shows 0.1.35, last updated 18 August 2026 — so 0.1.36 is the
next free version on both. Typechecks are clean and the suite passes apart from
one `telemetry-send` action-kind assertion that fails identically on `staging`
without this change (the in-flight `pe_shown` signal-kind work, unrelated to this
PR).

Please review the changes and merge this PR into `staging` if everything looks good.