### PR TITLE
 Merge Staging into Main

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -57,163 +57,169 @@
 
   <header>
     <h1>Nexpath Browser Extension — Privacy Policy</h1>
-    <p class="meta">Last updated: 1 September 2026</p>
+    <p class="meta">Last updated: 3 September 2026</p>
   </header>
 
   <p class="lede">
-    Nexpath is a browser extension made by <strong>ParseOS</strong>. It is an AI coding assistant — a
-    behaviour-guidance layer that reviews a prompt as you send it to an AI coding agent and offers a
-    stronger version of it before it goes.
+    This Privacy Policy explains how <strong>ParseOS</strong> ("we", "us") handles information in
+    connection with the <strong>Nexpath</strong> browser extension and the Nexpath service at
+    parseos.tech. Nexpath is an AI coding assistant: it reviews a prompt as you send it to an AI
+    coding agent and offers a stronger version before it goes.
   </p>
 
   <p>
-    It runs only on the supported sites: <strong>Replit</strong>, <strong>Lovable</strong>,
-    and <strong>Bolt.new</strong>. Nexpath is an independent tool and is
-    not affiliated with, endorsed by, or sponsored by any of them.
+    The extension runs only on the supported sites: <strong>Replit</strong>, <strong>Lovable</strong>,
+    and <strong>Bolt.new</strong>. Nexpath is an independent tool and is not affiliated with,
+    endorsed by, or sponsored by any of them.
   </p>
 
   <div class="note">
-    <strong>The short version:</strong> your key or token and your settings stay in your browser.
-    With <strong>your own OpenAI API key</strong> (the default), prompt context is sent only to
-    <strong>OpenAI</strong>, under your own OpenAI account — ParseOS receives nothing. With an
-    optional <strong>Nexpath token</strong> from a Nexpath account, prompt context is sent to
-    <strong>Nexpath's own service</strong> instead, which forwards it to OpenAI to generate the
-    answer and meters your account credit. There is no tracking network and no remote code;
-    content-free usage signals leave your machine only if you answer the occasional rating prompt
-    (see "Usage signals and the rating prompt" below).
+    <strong>In short:</strong> your credential and your settings stay in your browser. With
+    <strong>your own OpenAI API key</strong>, prompt context is sent only to <strong>OpenAI</strong>
+    under your own account and ParseOS receives nothing. With an optional <strong>Nexpath token</strong>,
+    prompt context is sent to <strong>Nexpath's own service</strong>, which forwards it to OpenAI and
+    meters your account credit. There is no tracking network and no remote code.
   </div>
 
-  <h2>What Nexpath handles</h2>
+  <h2>1. Information We Collect</h2>
+
+  <p><strong>Information you provide directly.</strong></p>
   <ul>
-    <li>
-      <strong>Prompt text</strong> — the message you submit to the AI coding agent. Nexpath reads the
-      prompt you send; it does not read the rest of the page, your files, or your screen.
-    </li>
-    <li><strong>Your OpenAI API key or Nexpath token</strong> — whichever you enter yourself on the extension's options page.</li>
+    <li><strong>Prompt text</strong> — the message you submit to the AI coding agent. Nexpath reads
+      the prompt you send; it does not read the rest of the page, your files, or your screen.</li>
+    <li><strong>Your credential</strong> — the OpenAI API key or Nexpath token you enter yourself on
+      the extension's options page.</li>
     <li><strong>Your settings</strong> — such as suggestion frequency and your selected role.</li>
+    <li><strong>Account information</strong> — if you create a Nexpath account, the email address you
+      register with. Payments for Pro are processed by PayPal.</li>
   </ul>
 
-  <h2>How it is used</h2>
+  <p><strong>Information collected automatically.</strong></p>
   <ul>
-    <li>
-      <strong>Most of the work happens locally.</strong> Nexpath classifies which phase of your
-      workflow a prompt belongs to <em>on your device</em>, inside the extension.
-    </li>
-    <li>
-      <strong>The LLM is called only when Nexpath evaluates whether to surface a suggestion</strong>
-      — not on every prompt, and never continuously. At that point recent prompt context is sent to
-      OpenAI using <strong>your own API key</strong>, or — in token mode — to
-      <strong>Nexpath's own service</strong>, which forwards it to OpenAI on your behalf and charges
-      the usage to your account credit.
-    </li>
-    <li>
-      <strong>Your API key or token and your settings are stored locally in your browser</strong>
-      (extension storage). Neither is ever bundled or logged. The credential leaves your browser only
-      on the requests it authorises — your key to OpenAI, or your token to Nexpath's service.
-    </li>
+    <li><strong>Service usage data</strong> — when a request is handled by the Nexpath service, we
+      record technical usage metadata such as token counts, timestamps, and which model answered,
+      together with a recent record of the requests handled for your account.</li>
+    <li><strong>Standard technical and connection data</strong> — like most online services, our
+      servers automatically receive and retain routine technical information associated with your
+      account when you sign in, of the kind every web server receives as part of delivering a
+      request. This is used to operate, secure and improve the service.</li>
+    <li><strong>Usage signals</strong> — the extension keeps a local, content-free record of which
+      popup buttons you press and when. See section 4.</li>
   </ul>
 
-  <h2>Who it is shared with</h2>
+  <h2>2. How We Use Information</h2>
+  <ul>
+    <li>To generate prompt suggestions — the core function of the product.</li>
+    <li>To operate your account, apply your plan credit, and process Pro payments.</li>
+    <li>To keep the service secure and reliable, including preventing abuse and automated signups.</li>
+    <li>To understand how the product is used in aggregate and improve it.</li>
+  </ul>
+  <p>
+    We do not use your information for advertising, and we do not sell it.
+  </p>
+
+  <h2>3. How Information Is Shared</h2>
   <ul>
     <li>
-      <strong>Only OpenAI</strong>, to generate the suggestion, under your own OpenAI account. Their
-      handling of that data is governed by
+      <strong>OpenAI</strong> — to generate the suggestion. With your own key this happens under your
+      own OpenAI account; in token mode our service forwards the request on your behalf. Their
+      handling is governed by
       <a href="https://openai.com/policies/privacy-policy" rel="noopener">OpenAI's privacy policy</a>.
     </li>
     <li>
-      <strong>In token mode: Nexpath's own service.</strong> Prompt context goes to the service to be
-      answered (it forwards the request to OpenAI). The service stores your account email, payment
-      records for Pro purchases, technical usage metadata — token counts, timestamps, and which
-      model answered — and a recent record of the requests handled for your account, kept to
-      operate and improve the service. Recognised credentials are removed before anything is
-      written. <strong>PayPal</strong> processes Pro payments and never sees your prompts.
+      <strong>PayPal</strong> — processes Pro payments. PayPal never receives your prompts.
     </li>
     <li>
-      <strong>With your own OpenAI key: no one else.</strong> ParseOS does not receive, store, sell,
+      <strong>With your own OpenAI key, no one else.</strong> ParseOS does not receive, store, sell,
       or share your prompts, your API key, or your settings.
     </li>
   </ul>
 
-  <h2>Usage signals and the rating prompt</h2>
+  <h2>4. Usage Signals and the Rating Prompt</h2>
   <ul>
     <li>
-      <strong>Usage signals stay on your machine until you choose to send them.</strong> Nexpath
-      keeps a local, content-free record of <em>which</em> popup buttons you press and <em>when</em>
-      — a fixed list of action names and timestamps. It never records prompt text, the text of an
-      option, which site you are on, or your project path.
+      <strong>Usage signals stay on your machine until you choose to send them.</strong> Nexpath keeps
+      a local, content-free record of <em>which</em> popup buttons you press and <em>when</em> — a
+      fixed list of action names and timestamps. It never records prompt text, the text of an option,
+      which site you are on, or your project path.
     </li>
     <li>
-      <strong>The only thing that sends is the rating prompt, and only when you answer it.</strong>
-      Occasionally Nexpath asks how it is working out for you. Choosing a rating is what sends —
-      and it sends only a random installation ID (not tied to you or your machine), your 1–4
-      rating, and the timestamps above.
+      <strong>Only the rating prompt sends, and only when you answer it.</strong> Choosing a rating
+      sends a random installation ID (not tied to you or your machine), your 1–4 rating, and the
+      timestamps above.
     </li>
     <li>
-      <strong>If you dismiss the prompt, one line goes out saying just that</strong> — your
-      installation ID and the time, so we can tell "asked and declined" apart from "never asked".
-      The local usage signals above stay on your machine: only answering releases those.
+      <strong>If you dismiss the prompt, one line goes out saying just that</strong> — the
+      installation ID and the time, so we can tell "asked and declined" from "never asked". The local
+      signals stay on your machine; only answering releases them.
     </li>
-    <li>
-      <strong>Your prompt text is never part of any of this.</strong> Prompt text goes only over
-      the two routes described above — OpenAI with your key, or the Nexpath service with your token.
-    </li>
+    <li><strong>Your prompt text is never part of any of this.</strong></li>
   </ul>
 
-  <h2>What Nexpath does not do</h2>
+  <h2>5. What Nexpath Does Not Do</h2>
   <ul class="never">
     <li><strong>No tracking network, no ads, no remote code.</strong></li>
     <li>No advertising or third-party tracking scripts of any kind.</li>
     <li>No selling or transferring of your data to anyone.</li>
-    <li>No use of your data for anything unrelated to generating your suggestions or improving Nexpath.</li>
+    <li>No use of your data for anything unrelated to running and improving Nexpath.</li>
     <li>No running on websites other than the three supported AI coding sites.</li>
   </ul>
 
-  <h2>Data retention</h2>
+  <h2>6. Data Retention</h2>
   <ul>
-    <li>With your own OpenAI key, prompt context is processed transiently to generate a suggestion and ParseOS retains nothing — we never receive it.</li>
-    <li>In token mode, the service keeps your account email, payment records, technical usage metadata (token counts, timestamps, which model answered) — visible on your account page — and a recent record of the requests it handled for your account, limited in number and pruned as newer ones arrive.</li>
-    <li>Your key or token, settings, and recent prompt history stay in your browser until you remove the extension or clear them.</li>
+    <li>With your own OpenAI key, prompt context is processed transiently and ParseOS retains
+      nothing — we never receive it.</li>
+    <li>In token mode, the service retains your account information, payment records, usage metadata
+      visible on your account page, routine technical data associated with your account, and a recent
+      record of the requests it handled for you — limited in number and pruned as newer ones arrive.
+      Recognised credentials are removed before anything is written.</li>
+    <li>Your credential, settings, and recent prompt history stay in your browser until you remove
+      the extension or clear them.</li>
   </ul>
 
-  <h2>Your choices</h2>
+  <h2>7. Your Choices</h2>
   <ul>
     <li>View, change, or delete your API key or Nexpath token and settings at any time on the options page.</li>
     <li>Turn Nexpath off for an individual project directly from the popup.</li>
     <li>Adjust how often suggestions appear, or switch them off entirely.</li>
     <li>Uninstalling the extension removes the data Nexpath stored locally.</li>
+    <li>To access or delete your account information, contact us at the address in section 11.</li>
   </ul>
 
-  <h2>Permissions and why they are needed</h2>
+  <h2>8. Permissions and Why They Are Needed</h2>
   <ul>
     <li><strong>storage</strong> — save your API key or Nexpath token and preferences locally.</li>
     <li><strong>tabs</strong> — show the suggestion panel on the correct agent tab, and reload an
       already-open agent tab on install or update so the extension activates without a manual refresh.</li>
-    <li>
-      <strong>Site access</strong> (Replit, Lovable, Bolt.new) — Nexpath only works on
-      these AI coding sites and runs nowhere else.
-    </li>
-    <li>
-      <strong>Service access</strong> (parseos.tech) — contacted only in token mode, to generate
-      your suggestion through Nexpath's own service. Never contacted when you use your own OpenAI key.
-    </li>
+    <li><strong>Site access</strong> (Replit, Lovable, Bolt.new) — Nexpath only works on these AI
+      coding sites and runs nowhere else.</li>
+    <li><strong>Service access</strong> (parseos.tech) — contacted only in token mode, to generate
+      your suggestion through Nexpath's own service. Never contacted when you use your own OpenAI key.</li>
   </ul>
 
-  <h2>Children's privacy</h2>
-  <p>Nexpath is a developer tool and is not directed at children under 13.</p>
-
-  <h2>Changes to this policy</h2>
+  <h2>9. Security</h2>
   <p>
-    If this policy changes, the updated version will be published at this same address with a new
-    "last updated" date.
+    Traffic to the Nexpath service is encrypted in transit. Account tokens are stored only as hashes,
+    so a copy of our database cannot be used to act as you, and passwords are stored using a
+    purpose-built password hash. No method of transmission or storage is completely secure, but we
+    take reasonable measures appropriate to the data involved.
   </p>
 
-  <h2>Contact</h2>
-  <p>Questions about this policy: <a href="mailto:pyemptyops@gmail.com">pyemptyops@gmail.com</a></p>
+  <h2>10. Children's Privacy</h2>
+  <p>Nexpath is a developer tool and is not directed at children under 13.</p>
+
+  <h2>11. Changes to This Policy and Contact</h2>
+  <p>
+    If this policy changes, the updated version will be published at this same address with a new
+    "last updated" date. Questions about this policy:
+    <a href="mailto:pyemptyops@gmail.com">pyemptyops@gmail.com</a>
+  </p>
 
   <div class="scope">
     <strong>Scope.</strong> This policy covers the <strong>Nexpath browser extension</strong> for
-    Chrome and Firefox only. The Nexpath CLI and the Nexpath VS Code extension are separate products
-    with their own data practices and their own documentation.
+    Chrome and Firefox, and the Nexpath service at parseos.tech that supports it. The Nexpath CLI and
+    the Nexpath VS Code extension are separate products with their own data practices and their own
+    documentation.
   </div>
 
   <footer>

--- a/src/ext-browser/CHANGELOG.md
+++ b/src/ext-browser/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the browser extension. Versions track the `version` field in
 `manifest.chrome.json` / `manifest.firefox.json`.
 
+## 0.1.54
+
+Housekeeping. Nothing changes in what the extension does or what it sends.
+
+### Changed
+- **The privacy policy has been rewritten** into a clearer, conventionally
+  structured document covering both credential modes, the rating prompt, and what
+  the Nexpath service records for your account. The policy is published at the
+  same address and is linked from both store listings.
+
+### Fixed
+- An internal signal-kind mismatch between the extension and the Nexpath CLI made
+  the type check fail. The extension records the same fixed set of content-free
+  action names as before — the list is unchanged, and one kind the CLI emits from
+  a hook this extension does not have is now filtered out explicitly rather than
+  by accident.
+
 ## 0.1.53
 
 Nexpath token support — run without an OpenAI API key.

--- a/src/ext-browser/PUBLISH.md
+++ b/src/ext-browser/PUBLISH.md
@@ -78,27 +78,41 @@ The committed source at the tagged release reproduces the uploaded package exact
 rebuild from these steps and byte-diff the result against the upload — use `npm ci` (exact lockfile),
 not `npm install`, and match the Node version above.
 
-The Firefox manifest sets `strict_min_version` **112** and declares
-`browser_specific_settings.gecko.data_collection_permissions.required = ["authenticationInfo",
-"websiteContent", "technicalAndInteraction"]` (Mozilla's built-in data-consent) — keep these in sync
-with the store data disclosures (the API key + prompt text, and the rating telemetry).
+The Firefox manifest sets `strict_min_version` **112** and declares Mozilla's built-in
+data-consent keys as:
 
-`technicalAndInteraction` covers the rating send (installation ID, rating, timestamps). It is
-declared **required**, not `optional`, and the reason is a mechanism mismatch — not an absence of
-user control. The extension DOES have a kill switch (Settings → Feedback), but that is an extension
-setting; Mozilla's `optional` is a permission the BROWSER toggles in about:addons and the extension
-is expected to honour through `browser.permissions`. Declaring `optional` while ignoring that API
-would advertise a control the extension does not read.
+```json
+"data_collection_permissions": {
+  "required": ["websiteContent"],
+  "optional": ["technicalAndInteraction"]
+}
+```
 
-Honouring it properly is blocked by our own support range: `strict_min_version` is **112**, and
-data-collection permissions are a much later Firefox feature (140+). Across most of the range we
-ship to, the key is ignored entirely and the `browser.permissions` data-collection API is not there
-to check — so an `optional` declaration would have to fail open on those versions, which is the
-opposite of what declaring it optional promises.
+Keep these in sync with the store data disclosures and with `docs/privacy.html` — a store
+declaration narrower than what the code does is the class of mistake that gets an extension
+removed. Four tests in `manifest.test.ts` pin this shape.
 
-`required` is therefore the honest declaration: when this extension collects, it does so under its
-own setting, with no browser-level toggle involved. Revisit if `strict_min_version` ever rises past
-the versions that support the API.
+**`websiteContent` is required** because the prompt the user submits is sent to the LLM route to
+generate the suggestion. That is the extension's whole purpose, so it is not optional.
+
+**`technicalAndInteraction` is optional, not required** — it covers the rating send (installation
+ID, 1–4 rating, timestamps). Mozilla does not permit this key in the `required` list, so declaring
+it there is a submission risk rather than a stylistic choice. As an optional data permission
+Firefox shows it at install as a checkbox that is **ticked by default**, so the rating feature
+keeps working with no code change.
+
+**`authenticationInfo` is deliberately NOT declared.** No credential is collected from the user or
+transmitted to a party that did not issue it: a user-supplied OpenAI API key is stored in extension
+storage and sent only to `api.openai.com` as that request's own `Authorization` header, and a
+Nexpath token is issued by our own service and sent only back to that service to authenticate the
+user's own request. Neither is stored or transmitted anywhere else. The same wording goes in the
+reviewer-note field on both stores.
+
+> Note on the older `required`-only declaration: earlier releases declared all three keys as
+> required, on the reasoning that the extension's own Settings toggle — not a browser-level one —
+> governs the rating send, and that `strict_min_version` 112 predates the Firefox versions (140+)
+> that implement the `browser.permissions` data-collection API. That reasoning is superseded: the
+> key is not permitted in `required` at all, which settles it regardless of the support range.
 
 ⚠️ Verify the spelling against AMO at submission — an unrecognised category value is rejected there,
 not at build time.

--- a/src/ext-browser/README.md
+++ b/src/ext-browser/README.md
@@ -100,7 +100,11 @@ workflow without slowing it down.
   above.
 - **If you dismiss the prompt, one line goes out saying just that** — your installation ID and the
   time, so we can tell "asked and declined" apart from "never asked". No rating, because you did not
-  give one, and the local usage signals above stay on your machine: only answering releases those.- **Your prompt text is never sold or shared.** The only places prompt text goes are the two
+  give one, and the local usage signals above stay on your machine: only answering releases those.
+- **In token mode the service keeps the usual service-side records** — your account details,
+  payment records for Pro, usage metadata shown on your account page, and routine technical
+  information associated with your account, kept to operate, secure and improve the service.
+- **Your prompt text is never sold or shared.** The only places prompt text goes are the two
   routes above — OpenAI with your key, or the Nexpath service with your token. Full policy:
   [privacy policy](https://hi0001234d.github.io/nexpath/privacy.html).
 

--- a/src/ext-browser/adapters/telemetry-send.test.ts
+++ b/src/ext-browser/adapters/telemetry-send.test.ts
@@ -423,9 +423,36 @@ describe('contract: which kinds the CLI actually records', () => {
     expect(callers).not.toMatch(/recordOptionSelected\(/);
   });
 
-  it('the action-kind enum is the CLI\'s, in the CLI\'s order', () => {
-    const flat = signals.replace(/\s+/g, ' ');
-    expect(flat).toContain(ACTION_SIGNAL_KINDS.map((k) => `'${k}'`).join(', '));
+  it('the action-kind enum is a SUBSET of the CLI\'s, in the CLI\'s order', () => {
+    // Was a contiguous-substring match, which only held while the two lists were
+    // identical. The CLI then inserted `pe_shown` mid-list — it and the VS Code
+    // extension emit it from a popup-shown hook the browser does not have — and a
+    // contiguous match cannot express "same names, same order, fewer of them".
+    //
+    // Subset-in-order is the contract that was always meant: every kind the
+    // browser records must exist in the CLI under the same name, and their
+    // relative order must match, so the two never drift into disagreeing about
+    // what a name means. It still fails loudly if the browser invents a kind the
+    // CLI does not have, or reorders one.
+    const cliOrder = [...signals.matchAll(/'(pe_[a-z_]+|mps_[a-z_]+)'/g)].map((m) => m[1]);
+    const cliIndex = new Map(cliOrder.map((k, i) => [k, i] as const));
+
+    const missing = ACTION_SIGNAL_KINDS.filter((k) => !cliIndex.has(k));
+    expect(missing, 'browser records kinds the CLI has never heard of').toEqual([]);
+
+    const positions = ACTION_SIGNAL_KINDS.map((k) => cliIndex.get(k)!);
+    const sorted = [...positions].sort((a, b) => a - b);
+    expect(positions, 'browser kinds are out of order versus the CLI').toEqual(sorted);
+  });
+
+  it('⭐ the browser deliberately does NOT record the CLI\'s pe_shown', () => {
+    // Not an oversight. The browser has no popup-shown hook, and adding the kind
+    // without one would put a seventeenth event into a store disclosure that
+    // promises sixteen. `pe-popup-host.ts` narrows it away at the boundary.
+    // Delete this test only in the change that adds the hook AND updates the
+    // Chrome/Firefox data disclosures together.
+    expect(signals).toContain("'pe_shown'");
+    expect(ACTION_SIGNAL_KINDS as readonly string[]).not.toContain('pe_shown');
   });
 
   it('the CLI still posts an action event under the kind as the event name', () => {

--- a/src/ext-browser/background/pe-popup-host.ts
+++ b/src/ext-browser/background/pe-popup-host.ts
@@ -44,7 +44,7 @@ import {
   type PromptEnhancementMpsFirstPopupModelV1,
 } from './pe-engine.js';
 import { recordPeFeedbackEvent, type PeFeedbackKeyStore } from '../adapters/pe-feedback-store.js';
-import { recordSignal } from '../adapters/lifecycle-signals.js';
+import { isActionKind, recordSignal } from '../adapters/lifecycle-signals.js';
 import {
   PE_PANEL_SCHEMA_VERSION,
   isPePanelCommandV1,
@@ -483,7 +483,16 @@ export async function runBrowserPePopup(
         // CLI parity: `prompt-enhancement-popup-host.ts:222` records this same
         // MPS kind rather than only logging it. Buffered locally; nothing is
         // sent until the user consents by rating (§4.2).
-        if (deps.feedbackStore) void recordSignal(deps.feedbackStore, signalKind, Date.now());
+        // `isActionKind` narrows to the kinds THIS extension records. The shared
+        // producer's return type also admits `pe_shown`, which the CLI and the VS
+        // Code extension emit from a popup-shown hook the browser does not have —
+        // so it can never occur here, and recording it would add a seventeenth
+        // event to a store disclosure that promises sixteen. Drop it at the
+        // boundary rather than widen the enum: revisit when the browser gains
+        // that hook AND the disclosure is updated in the same change.
+        if (deps.feedbackStore && isActionKind(signalKind)) {
+          void recordSignal(deps.feedbackStore, signalKind, Date.now());
+        }
       }
       if (offerOutcome === 'send') {
         return {
@@ -599,7 +608,10 @@ export async function runBrowserPePopup(
       // kind is a fixed UI-action enum — no prompt or option text.
       actionSignalSink: (kind, occurredAt) => {
         log.debug('pe_action_signal', { kind, occurredAt });
-        if (deps.feedbackStore) void recordSignal(deps.feedbackStore, kind, occurredAt);
+        // Same narrowing as above — see the comment at the MPS outcome sink.
+        if (deps.feedbackStore && isActionKind(kind)) {
+          void recordSignal(deps.feedbackStore, kind, occurredAt);
+        }
       },
     });
     if (suppressedUneditable) {

--- a/src/ext-browser/manifest.chrome.json
+++ b/src/ext-browser/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nexpath",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "AI coding assistant for Replit, Lovable, and Bolt — reviews your prompt before you send it.",
   "permissions": [
     "storage",

--- a/src/ext-browser/manifest.firefox.json
+++ b/src/ext-browser/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Nexpath",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "AI coding assistant for Replit, Lovable, and Bolt — reviews your prompt before you send it.",
   "permissions": [
     "storage",

--- a/src/ext-browser/manifest.test.ts
+++ b/src/ext-browser/manifest.test.ts
@@ -201,7 +201,7 @@ describe('ext-browser manifests — permission surface', () => {
   it('never ships a version below one already submitted to a store', () => {
     // Append at release time. A version that shipped can never be re-used or gone below,
     // so this list only grows.
-    const RELEASED = ['0.1.5', '0.1.51', '0.1.52'];
+    const RELEASED = ['0.1.5', '0.1.51', '0.1.52', '0.1.53'];
     const parse = (v: string) => v.split('.').map(Number);
     const isBelow = (a: number[], b: number[]) => {
       for (let i = 0; i < Math.max(a.length, b.length); i++) {


### PR DESCRIPTION
# Merge Staging into Main

## Overview

Promotes the post-0.1.53 housekeeping into `main`: the rewritten privacy policy,
two documentation corrections, the signal-kind fix that restores a clean type
check, and the 0.1.54 version bump.

Merging this publishes the updated privacy policy, which is served from `main` by
GitHub Pages at the address both store listings link to. No store submission is
required for that.

## What's Included

* **Privacy policy rewritten** into conventional numbered sections, now stating
  what the Nexpath service records for an account.
* **README** — a broken list item (two bullets merged onto one line) fixed, and
  the privacy section brought into step with the policy.
* **PUBLISH.md** — the Firefox data declaration paragraph corrected; it described
  the pre-0.1.53 shape and contradicted the shipped manifest inside the source
  archive AMO reviewers read.
* **Signal-kind fix** — `pe_shown` is narrowed away at the browser boundary
  instead of widening the recorded-kind enum, keeping the sixteen-event store
  disclosure accurate. Shipped behaviour unchanged.
* **0.1.54**, with `0.1.53` recorded as released on both stores.

## Verification

Type checks clean, full suite **452 files / 12,723 tests with no failures**, VS
Code extension 60 files / 1,198 tests, both 0.1.54 packages building with all
manifest and packaging checks passing and `pe_shown` absent from the shipped
service worker.

Please review the changes and merge this PR into `main` if everything looks good.