### PR TITLE
Release CLI v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ The core interaction keeps your request and the added workflow guidance together
 
 Nexpath CLI is built for prompt capture across AI coding agents.
 
-| Agent | Status in v0.1.4 |
+| Agent | Status in v0.1.5 |
 |-------|-----------------|
 | **Claude Code** | Fully supported — end-to-end tested |
-| **Cursor** | Not yet supported — end-to-end testing planned for v0.1.5 |
-| **Windsurf** | Not yet supported — end-to-end testing planned for v0.1.5 |
-| **Replit** | Not yet supported — end-to-end testing planned for v0.1.5 |
-| **Lovable** | Not yet supported — end-to-end testing planned for v0.1.5 |
-| **Bolt.new** | Not yet supported — end-to-end testing planned for v0.1.5 |
+| **Cursor** | Fully supported — end-to-end tested |
+| **Windsurf** | Fully supported — end-to-end tested |
+| **Replit** | Fully supported — end-to-end tested |
+| **Lovable** | Fully supported — end-to-end tested |
+| **Bolt.new** | Fully supported — end-to-end tested |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexpath",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexpath",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.100.1",
         "@clack/prompts": "^0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexpath",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Behaviour guidance system for vibe coders using AI coding agents",
   "type": "module",
   "bin": {

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -12,8 +12,8 @@ async function run(...args: string[]) {
 }
 
 describe('nexpath CLI — metadata', () => {
-  it('version is 0.1.4', () => {
-    expect(createProgram().version()).toBe('0.1.4');
+  it('version is 0.1.5', () => {
+    expect(createProgram().version()).toBe('0.1.5');
   });
 
   it('name is nexpath', () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -50,7 +50,7 @@ export function createProgram(): Command {
   program
     .name('nexpath')
     .description('Behaviour guidance system for vibe coders using AI coding agents')
-    .version('0.1.4');
+    .version('0.1.5');
 
   // ── Lifecycle commands ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Release CLI v0.1.5

## Summary

This PR updates the CLI to version `0.1.5` and prepares the related documentation for the release.

## Changes

* Bumped the CLI version to `0.1.5`.
* Updated the lockfile and Commander version reference.
* Updated the related version test assertion.
* Updated the README supported-agents table for the `v0.1.5` release.
* Marked the currently listed agents as fully supported and end-to-end tested.

## Verification

The version references and related test assertion have been updated together to keep the release metadata consistent.

Please review the release changes and merge this PR into `main` if everything looks good.
