### PR TITLE
docs: link supported agents to their install surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Nexpath CLI is built for prompt capture across AI coding agents.
 
 | Agent | Status in v0.1.5 |
 |-------|-----------------|
-| **Claude Code** | Fully supported — end-to-end tested |
-| **Cursor** | Fully supported — end-to-end tested |
-| **Windsurf** | Fully supported — end-to-end tested |
-| **Replit** | Fully supported — end-to-end tested |
-| **Lovable** | Fully supported — end-to-end tested |
-| **Bolt.new** | Fully supported — end-to-end tested |
+| [**Claude Code**](#add-nexpath-to-your-development-workflow--installation) | Fully supported — end-to-end tested |
+| [**Cursor**](https://marketplace.visualstudio.com/items?itemName=nexpath.nexpath-vscode) | Fully supported — end-to-end tested |
+| [**Windsurf**](https://marketplace.visualstudio.com/items?itemName=nexpath.nexpath-vscode) | Fully supported — end-to-end tested |
+| [**Replit**](https://chromewebstore.google.com/search/nexpath) | Fully supported — end-to-end tested |
+| [**Lovable**](https://chromewebstore.google.com/search/nexpath) | Fully supported — end-to-end tested |
+| [**Bolt.new**](https://chromewebstore.google.com/search/nexpath) | Fully supported — end-to-end tested |
 
 ---
 


### PR DESCRIPTION
## Summary

Update the README supported-agents table to link each agent to its actual NexPath installation surface.

### Changes

* Link Claude Code to the installation section in the README.
* Link Cursor and Windsurf to the VS Code Marketplace listing.
* Link Replit, Lovable, and Bolt.new to the Chrome Web Store listing.

This makes it easier for users to go directly from the supported-agents list to the right place to install NexPath.
